### PR TITLE
Convert neovim config to Lua

### DIFF
--- a/meta/configs/neovim.yaml
+++ b/meta/configs/neovim.yaml
@@ -1,0 +1,16 @@
+- clean: ['~/.config/nvim']
+
+- create:
+    - ~/.local/share/nvim/site/pack/packer/start
+
+- link:
+    ~/.config/nvim:
+      create: true
+      path: neovim
+
+- shell:
+    -
+      command: setup/neovim.sh
+      description: Checking nvim
+      stdout: true
+      stderr: true

--- a/neovim/init.lua
+++ b/neovim/init.lua
@@ -1,0 +1,30 @@
+--[[
+
+Neovim init file
+Version: 0.50.0 - 2022/03/07
+Maintainer: brainf+ck
+Website: https://github.com/brainfucksec/neovim-lua
+
+--]]
+
+-- Bootstrap packer
+local fn = vim.fn
+local install_path = fn.stdpath('data')..'/site/pack/packer/start/packer.nvim'
+if fn.empty(fn.glob(install_path)) > 0 then
+  packer_bootstrap = fn.system({'git', 'clone', '--depth', '1', 'https://github.com/wbthomason/packer.nvim', install_path})
+end
+
+-- Import Lua modules
+require('core/settings')
+require('core/keymaps')
+require('packer_init')
+require('plugins/nvim-tree')
+require('plugins/indent-blankline')
+require('plugins/feline')
+require('plugins/vista')
+require('plugins/nvim-cmp')
+require('plugins/nvim-lspconfig')
+require('plugins/nvim-treesitter')
+require('plugins/nvim-telescope')
+require('plugins/alpha-nvim')
+require('plugins/nvim-gps')

--- a/neovim/lua/core/colors.lua
+++ b/neovim/lua/core/colors.lua
@@ -1,0 +1,63 @@
+-----------------------------------------------------------
+-- Color schemes configuration file
+-----------------------------------------------------------
+
+-- Load nvim color scheme
+--require('monokai').setup {}
+
+-- OneDark styles: dark, darker, cool, deep, warm, warmer, light
+require('onedark').setup {
+  style = 'darker',
+}
+require('onedark').load()
+
+-- Import color scheme with:
+--- require('colors').colorscheme_name
+
+local M = {}
+
+-- Theme: OneDark
+--- See: https://github.com/navarasu/onedark.nvim/blob/master/lua/onedark/colors.lua
+M.onedark = {
+  bg = '#282c34',
+  fg = '#abb2bf',
+  pink = '#c678dd',
+  green = '#98c379',
+  cyan = '#56b6c2',
+  yellow = '#e5c07b',
+  orange = '#d19a66',
+  purple = '#8a3fa0',
+  red = '#e86671',
+}
+
+-- Theme: Monokai (classic)
+--- See: https://github.com/tanvirtin/monokai.nvim/blob/master/lua/monokai.lua
+M.monokai = {
+  bg = '#202328', --default: #272a30
+  fg = '#f8f8f0',
+  pink = '#f92672',
+  green = '#a6e22e',
+  cyan = '#66d9ef',
+  yellow = '#e6db74',
+  orange = '#fd971f',
+  purple = '#ae81ff',
+  red = '#e95678',
+}
+
+-- Theme: Rosé Pine (main)
+--- See: https://github.com/rose-pine/neovim/blob/main/lua/rose-pine/palette.lua
+--- color names are adapted to the format above
+M.rose_pine = {
+  bg = '#111019', --default: #191724
+  fg = '#e0def4',
+  gray = '#908caa',
+  pink = '#eb6f92',
+  green = '#9ccfd8',
+  cyan = '#31748f',
+  yellow = '#f6c177',
+  orange = '#2a2837',
+  purple = '#c4a7e7',
+  red = '#ebbcba',
+}
+
+return M

--- a/neovim/lua/core/keymaps.lua
+++ b/neovim/lua/core/keymaps.lua
@@ -1,0 +1,66 @@
+-----------------------------------------------------------
+-- Define keymaps of Neovim and installed plugins.
+-----------------------------------------------------------
+
+local function map(mode, lhs, rhs, opts)
+  local options = { noremap = true, silent = true }
+  if opts then
+    options = vim.tbl_extend('force', options, opts)
+  end
+  vim.api.nvim_set_keymap(mode, lhs, rhs, options)
+end
+
+-- Change leader to a comma
+vim.g.mapleader = ' '
+
+-----------------------------------------------------------
+-- Neovim shortcuts
+-----------------------------------------------------------
+
+-- Clear search highlighting with <leader> and c
+map('n', '<leader>c', ':nohl<CR>')
+
+-- Map Esc to jj
+map('i', 'jj', '<Esc>')
+
+-- Don't use arrow keys
+map('', '<up>', '<nop>')
+map('', '<down>', '<nop>')
+map('', '<left>', '<nop>')
+map('', '<right>', '<nop>')
+
+-- Fast saving with <leader> and s
+-- map('n', '<leader>s', ':w<CR>')
+-- map('i', '<leader>s', '<C-c>:w<CR>')
+
+-- Move around splits using Ctrl + {h,j,k,l}
+map('n', '<C-h>', '<C-w>h')
+map('n', '<C-j>', '<C-w>j')
+map('n', '<C-k>', '<C-w>k')
+map('n', '<C-l>', '<C-w>l')
+
+-- Close all windows and exit from Neovim with <leader> and q
+-- map('n', '<leader>q', ':qa!<CR>')
+
+-----------------------------------------------------------
+-- Applications and Plugins shortcuts
+-----------------------------------------------------------
+
+-- Terminal mappings
+map('n', '<C-t>', ':Term<CR>', { noremap = true })  -- open
+map('t', '<Esc>', '<C-\\><C-n>')                    -- exit
+
+-- NvimTree
+map('n', '<C-n>', ':NvimTreeToggle<CR>')            -- open/close
+map('n', '<leader>r', ':NvimTreeRefresh<CR>')       -- refresh
+map('n', '<leader>n', ':NvimTreeFindFile<CR>')      -- search file
+
+-- Vista tag-viewer
+map('n', '<C-m>', ':Vista!!<CR>') -- open/close
+
+-- Telescope
+map('n', '<leader>ff', '<cmd>lua require("telescope.builtin").find_files()<cr>')
+map('n', '<leader>fg', '<cmd>lua require("telescope.builtin").live_grep()<cr>')
+map('n', '<leader>fb', '<cmd>lua require("telescope.builtin").buffers()<cr>')
+map('n', '<leader>fh', '<cmd>lua require("telescope.builtin").help_tags()<cr>')
+map('n', '<leader>fm', '<cmd>lua require("telescope.builtin").keymaps()<cr>')

--- a/neovim/lua/core/settings.lua
+++ b/neovim/lua/core/settings.lua
@@ -1,0 +1,141 @@
+-----------------------------------------------------------
+-- General Neovim settings and configuration
+-----------------------------------------------------------
+
+-- Default options are not included
+--- See: https://neovim.io/doc/user/vim_diff.html
+--- [2] Defaults - *nvim-defaults*
+
+-----------------------------------------------------------
+-- Neovim API aliases
+-----------------------------------------------------------
+local cmd = vim.cmd     				      -- Execute Vim commands
+local exec = vim.api.nvim_exec 	      -- Execute Vimscript
+local g = vim.g         				      -- Global variables
+local opt = vim.opt         		      -- Set options (global/buffer/windows-scoped)
+--local fn = vim.fn       				    -- Call Vim functions
+
+-----------------------------------------------------------
+-- General
+-----------------------------------------------------------
+opt.mouse = 'a'                       -- Enable mouse support
+-- opt.clipboard = 'unnamedplus'         -- Copy/paste to system clipboard
+opt.swapfile = false                  -- Don't use swapfile
+opt.completeopt = 'menuone,noselect,noinsert'  -- Autocomplete options
+opt.timeoutlen = 500 -- mapping timeout 500ms  (adjust for preference)
+opt.ttimeoutlen = 20 -- keycode timeout 20ms
+opt.undofile = true -- Enable persistent undo
+
+-----------------------------------------------------------
+-- Neovim UI
+-----------------------------------------------------------
+opt.number = true                     -- Show line number
+opt.showmatch = true                  -- Highlight matching parenthesis
+opt.matchtime = 2                     -- How many tenths of a second to blink when matching brackets
+opt.foldmethod = 'marker'             -- Enable folding (default 'foldmarker')
+opt.colorcolumn = '80'                -- Line lenght marker at 80 columns
+opt.splitright = true                 -- Vertical split to the right
+opt.splitbelow = true                 -- Orizontal split to the bottom
+opt.ignorecase = true                 -- Ignore case letters when search
+opt.smartcase = true                  -- Ignore lowercase for the whole pattern
+opt.linebreak = true                  -- Wrap on word boundary
+opt.termguicolors = true              -- Enable 24-bit RGB colors
+opt.scrolloff=12                      -- Start scrolling before reaching the edge when moving with j/k
+opt.inccommand='nosplit'              -- Live preview of substitution results
+opt.diffopt:append 'vertical,iwhite,algorithm:patience,hiddenoff'
+opt.pumblend = 10                     -- Transparency for completions menu
+opt.cmdheight=2                       -- Better display for messages
+opt.updatetime=300                    -- You will have bad experience for diagnostic messages when it's default 4000.
+opt.listchars='eol:↲,tab:» ,extends:›,precedes:‹,nbsp:☠,trail:·'
+
+-----------------------------------------------------------
+-- Tabs, indent
+-----------------------------------------------------------
+opt.expandtab = true                  -- Use spaces instead of tabs
+opt.shiftwidth = 4                    -- Shift 4 spaces when tab
+opt.tabstop = 4                       -- 1 tab == 4 spaces
+opt.smartindent = true                -- Autoindent new lines
+
+-----------------------------------------------------------
+-- Memory, CPU
+-----------------------------------------------------------
+opt.hidden = true                     -- Enable background buffers
+opt.history = 100                     -- Remember N lines in history
+opt.lazyredraw = true                 -- Faster scrolling
+opt.synmaxcol = 240                   -- Max column for syntax highlight
+
+-----------------------------------------------------------
+-- Autocommands
+-----------------------------------------------------------
+
+-- Remove whitespace on save
+cmd [[au BufWritePre * :%s/\s\+$//e]]
+
+-- Highlight on yank
+exec([[
+  augroup YankHighlight
+    autocmd!
+    autocmd TextYankPost * silent! lua vim.highlight.on_yank{higroup="IncSearch", timeout=800}
+  augroup end
+]], false)
+
+-- Don't auto commenting new lines
+cmd [[au BufEnter * set fo-=c fo-=r fo-=o]]
+
+-- Remove line lenght marker for selected filetypes
+cmd [[autocmd FileType text,markdown,html,xhtml,javascript setlocal cc=0]]
+
+-- 2 spaces for selected filetypes
+cmd [[
+  autocmd FileType xml,html,xhtml,css,scss,javascript,lua,yaml,terraform,sh setlocal shiftwidth=2 tabstop=2
+]]
+
+-----------------------------------------------------------
+-- Terminal
+-----------------------------------------------------------
+
+-- Open a terminal pane on the right using :Term
+cmd [[command Term :botright vsplit term://$SHELL]]
+
+-- Terminal visual tweaks:
+--- enter insert mode when switching to terminal
+--- close terminal buffer on process exit
+cmd [[
+    autocmd TermOpen * setlocal listchars= nonumber norelativenumber nocursorline
+    autocmd TermOpen * startinsert
+    autocmd BufLeave term://* stopinsert
+]]
+
+-----------------------------------------------------------
+-- Startup
+-----------------------------------------------------------
+
+-- Disable nvim intro
+opt.shortmess:append "sI"
+
+-- Disable builtins plugins
+local disabled_built_ins = {
+    "netrw",
+    "netrwPlugin",
+    "netrwSettings",
+    "netrwFileHandlers",
+    "gzip",
+    "zip",
+    "zipPlugin",
+    "tar",
+    "tarPlugin",
+    "getscript",
+    "getscriptPlugin",
+    "vimball",
+    "vimballPlugin",
+    "2html_plugin",
+    "logipat",
+    "rrhelper",
+    "spellfile_plugin",
+    "matchit"
+}
+
+for _, plugin in pairs(disabled_built_ins) do
+    g["loaded_" .. plugin] = 1
+end
+

--- a/neovim/lua/packer_init.lua
+++ b/neovim/lua/packer_init.lua
@@ -1,0 +1,110 @@
+-----------------------------------------------------------
+-- Plugin manager configuration file
+-----------------------------------------------------------
+
+-- Plugin manager: packer.nvim
+-- url: https://github.com/wbthomason/packer.nvim
+
+-- For information about installed plugins see the README
+--- neovim-lua/README.md
+--- https://github.com/brainfucksec/neovim-lua#readme
+
+
+local cmd = vim.cmd
+cmd [[packadd packer.nvim]]
+
+local packer = require 'packer'
+
+-- Add packages
+return packer.startup(function()
+  use 'wbthomason/packer.nvim' -- packer can manage itself
+
+  -- File explorer
+  use 'kyazdani42/nvim-tree.lua'
+
+  -- Indent line
+  use 'lukas-reineke/indent-blankline.nvim'
+
+  -- Autopair
+  use {
+    'windwp/nvim-autopairs',
+    config = function()
+      require('nvim-autopairs').setup()
+    end
+  }
+
+  -- Icons
+  use 'kyazdani42/nvim-web-devicons'
+
+  -- Tag viewer
+  use 'liuchengxu/vista.vim'
+
+  -- Treesitter interface
+  use 'nvim-treesitter/nvim-treesitter'
+
+  -- Color schemes
+  use 'navarasu/onedark.nvim'
+
+  use 'tanvirtin/monokai.nvim'
+
+  use { 'rose-pine/neovim', as = 'rose-pine' }
+
+  -- LSP
+  use 'neovim/nvim-lspconfig'
+
+  -- Autocomplete
+  use {
+    'hrsh7th/nvim-cmp',
+    requires = {
+      'L3MON4D3/LuaSnip',
+      'hrsh7th/cmp-nvim-lsp',
+      'hrsh7th/cmp-nvim-lua',
+      'hrsh7th/cmp-path',
+      'hrsh7th/cmp-buffer',
+      'saadparwaiz1/cmp_luasnip',
+    },
+  }
+
+  -- Statusline
+  use {
+    'famiu/feline.nvim',
+    requires = { 'kyazdani42/nvim-web-devicons' },
+  }
+
+  -- git labels
+  use {
+    'lewis6991/gitsigns.nvim',
+    requires = { 'nvim-lua/plenary.nvim' },
+    config = function()
+      require('gitsigns').setup()
+    end
+  }
+
+  -- Dashboard (start screen)
+  use {
+    'goolord/alpha-nvim',
+    requires = { 'kyazdani42/nvim-web-devicons' },
+  }
+
+  -- Helpers
+  use 'tpope/vim-eunuch'
+  use 'tpope/vim-repeat'
+  use 'tpope/vim-commentary'
+  use 'tpope/vim-fugitive'
+  use 'tpope/vim-surround'
+
+  use {
+    "SmiteshP/nvim-gps",
+    requires = "nvim-treesitter/nvim-treesitter"
+  } use 'SmiteshP/nvim-gps'
+
+  -- Telescope
+  use {'nvim-telescope/telescope-fzf-native.nvim', run = 'make' }
+  use {
+    'nvim-telescope/telescope.nvim',
+    requires = { {'nvim-lua/plenary.nvim'} }
+  }
+
+  -- Undotree
+  use 'mbbill/undotree'
+end)

--- a/neovim/lua/plugins/alpha-nvim.lua
+++ b/neovim/lua/plugins/alpha-nvim.lua
@@ -1,0 +1,48 @@
+-----------------------------------------------------------
+-- Dashboard configuration file
+-----------------------------------------------------------
+
+-- Plugin: alpha-nvim
+-- url: https://github.com/goolord/alpha-nvim
+
+-- For configuration examples see: https://github.com/goolord/alpha-nvim/discussions/16
+
+
+local alpha = require 'alpha'
+local dashboard = require 'alpha.themes.dashboard'
+
+-- Footer
+local function footer()
+  local version = vim.version()
+  local print_version = "v" .. version.major .. '.' .. version.minor .. '.' .. version.patch
+  local datetime = os.date('%Y/%m/%d %H:%M:%S')
+
+  return print_version .. ' ' .. datetime
+end
+
+-- Banner
+local banner = {
+  "                                                    ",
+  " ███╗   ██╗███████╗ ██████╗ ██╗   ██╗██╗███╗   ███╗ ",
+  " ████╗  ██║██╔════╝██╔═══██╗██║   ██║██║████╗ ████║ ",
+  " ██╔██╗ ██║█████╗  ██║   ██║██║   ██║██║██╔████╔██║ ",
+  " ██║╚██╗██║██╔══╝  ██║   ██║╚██╗ ██╔╝██║██║╚██╔╝██║ ",
+  " ██║ ╚████║███████╗╚██████╔╝ ╚████╔╝ ██║██║ ╚═╝ ██║ ",
+  " ╚═╝  ╚═══╝╚══════╝ ╚═════╝   ╚═══╝  ╚═╝╚═╝     ╚═╝ ",
+  "                                                    ",
+}
+
+dashboard.section.header.val = banner
+
+-- Menu
+dashboard.section.buttons.val = {
+  dashboard.button('e', ' New file', ':ene <BAR> startinsert<CR>'),
+  dashboard.button('f', ' Find file', ':NvimTreeOpen<CR>'),
+  dashboard.button('s', ' Settings', ':e $MYVIMRC<CR>'),
+  dashboard.button('u', ' Update plugins', ':PackerUpdate<CR>'),
+  dashboard.button('q', ' Quit', ':qa<CR>'),
+}
+
+dashboard.section.footer.val = footer()
+
+alpha.setup(dashboard.config)

--- a/neovim/lua/plugins/feline.lua
+++ b/neovim/lua/plugins/feline.lua
@@ -1,0 +1,271 @@
+----------------------------------------------------------
+-- Statusline configuration file
+-----------------------------------------------------------
+
+-- Plugin: feline.nvim
+-- url: https://github.com/famiu/feline.nvim
+
+--- For the configuration see the Usage section:
+--- https://github.com/famiu/feline.nvim/blob/master/USAGE.md
+
+--- Thanks to ibhagwan for the example to follow:
+--- https://github.com/ibhagwan/nvim-lua
+
+
+-- Set colorscheme (from core/colors.lua/colorscheme_name)
+local colors = require('core/colors').onedark
+
+local vi_mode_colors = {
+  NORMAL = colors.cyan,
+  INSERT = colors.green,
+  VISUAL = colors.yellow,
+  OP = colors.cyan,
+  BLOCK = colors.cyan,
+  REPLACE = colors.red,
+  ['V-REPLACE'] = colors.red,
+  ENTER = colors.orange,
+  MORE = colors.orange,
+  SELECT = colors.yellow,
+  COMMAND = colors.pink,
+  SHELL = colors.pink,
+  TERM = colors.pink,
+  NONE = colors.purple
+}
+
+-- Providers (LSP, vi_mode)
+local lsp = require 'feline.providers.lsp'
+local vi_mode_utils = require 'feline.providers.vi_mode'
+local gps = require("nvim-gps")
+
+-- LSP diagnostic
+local lsp_get_diag = function(str)
+  local count = vim.lsp,diagnostic.get_count(0, str)
+  return (count > 0) and ' '..count..' ' or ''
+end
+
+-- My components
+local comps = {
+  -- vi_mode -> NORMAL, INSERT..
+  vi_mode = {
+    left = {
+      provider = function()
+        local label = ' '..vi_mode_utils.get_vim_mode()..' '
+        return label
+      end,
+      hl = function()
+        local set_color = {
+          name = vi_mode_utils.get_mode_highlight_name(),
+          fg = colors.bg,
+          bg = vi_mode_utils.get_mode_color(),
+          style = 'bold',
+        }
+        return set_color
+      end,
+      left_sep = ' ',
+      right_sep = ' ',
+    }
+  },
+  -- Parse file information:
+  file = {
+    -- File name
+    info = {
+      provider = {
+        name = 'file_info',
+        opts = {
+          type = 'relative',
+          file_modified_icon = '',
+        }
+      },
+      hl = { fg = colors.cyan },
+      icon = '',
+    },
+    -- File type
+    type = {
+      provider = function()
+        local type = vim.bo.filetype:lower()
+        local extension = vim.fn.expand '%:e'
+        local icon = require('nvim-web-devicons').get_icon(extension)
+        if icon == nil then
+          icon = ' '
+        end
+        return ' ' .. icon .. ' ' .. type
+      end,
+      hl = { fg = colors.fg },
+      left_sep = ' ',
+      righ_sep = ' ',
+    },
+    -- Operating system
+    os = {
+      provider = function()
+        local os = vim.bo.fileformat:lower()
+        local icon
+        if os == 'unix' then
+          icon = '  '
+        elseif os == 'mac' then
+          icon = '  '
+        else
+          icon = '  '
+        end
+        return icon .. os
+      end,
+      hl = { fg = colors.fg },
+      --left_sep = ' ',
+      right_sep = ' ',
+    },
+    -- Line-column
+    position = {
+      provider = { name = 'position' },
+      hl = {
+        fg = colors.fg,
+        style = 'bold',
+      },
+      left_sep = ' ',
+      right_sep = ' ',
+    },
+    -- Cursor position in %
+    line_percentage = {
+      provider = { name = 'line_percentage' },
+      hl = {
+        fg = colors.cyan,
+        style = 'bold',
+      },
+      left_sep = ' ',
+      right_sep = ' ',
+    },
+    -- Simple scrollbar
+    scroll_bar = {
+      provider = { name = 'scroll_bar' },
+      hl = { fg = colors.fg },
+      left_sep = ' ',
+      right_sep = ' ',
+    },
+    gps = {
+      provider = function()
+        return gps.get_location()
+      end,
+      enabled = function()
+        return gps.is_available()
+      end,
+      left_sep = ' ',
+      right_sep = ' ',
+    },
+  },
+  -- LSP info
+  diagnos = {
+    err = {
+      provider = 'diagnostic_errors',
+      icon = '⚠ ',
+      hl = { fg = colors.red },
+      left_sep = '  ',
+    },
+    warn = {
+      provider = 'diagnostic_warnings',
+      icon = ' ',
+      hl = { fg = colors.yellow },
+      left_sep = ' ',
+    },
+    info = {
+      provider = 'diagnostic_info',
+      icon = ' ',
+      hl = { fg = colors.green },
+      left_sep = ' ',
+    },
+    hint = {
+      provider = 'diagnostic_hints',
+      icon = ' ',
+      hl = { fg = colors.cyan },
+      left_sep = ' ',
+    },
+  },
+  lsp = {
+    name = {
+      provider = 'lsp_client_names',
+      icon = '  ',
+      hl = { fg = colors.pink },
+      left_sep = '  ',
+      right_sep = ' ',
+    }
+  },
+  -- git info
+  git = {
+    branch = {
+      provider = 'git_branch',
+      icon = ' ',
+      hl = { fg = colors.pink },
+      left_sep = '  ',
+    },
+    add = {
+      provider = 'git_diff_added',
+      icon = '  ',
+      hl = { fg = colors.green },
+      left_sep = ' ',
+    },
+    change = {
+      provider = 'git_diff_changed',
+      icon = '  ',
+      hl = { fg = colors.orange },
+      left_sep = ' ',
+    },
+    remove = {
+      provider = 'git_diff_removed',
+      icon = '  ',
+      hl = { fg = colors.red },
+      left_sep = ' ',
+    }
+  },
+}
+
+-- Get active/inactive components
+--- see: https://github.com/famiu/feline.nvim/blob/master/USAGE.md#components
+local components = {
+  active = {},
+  inactive = {},
+}
+
+table.insert(components.active, {})
+table.insert(components.active, {})
+table.insert(components.inactive, {})
+table.insert(components.inactive, {})
+
+-- Right section
+table.insert(components.active[1], comps.vi_mode.left)
+table.insert(components.active[1], comps.file.info)
+table.insert(components.active[1], comps.git.branch)
+table.insert(components.active[1], comps.git.add)
+table.insert(components.active[1], comps.git.change)
+table.insert(components.active[1], comps.git.remove)
+table.insert(components.active[1], comps.file.gps)
+table.insert(components.inactive[1], comps.file.info)
+
+-- Left Section
+table.insert(components.active[2], comps.diagnos.err)
+table.insert(components.active[2], comps.diagnos.warn)
+table.insert(components.active[2], comps.diagnos.hint)
+table.insert(components.active[2], comps.diagnos.info)
+table.insert(components.active[2], comps.lsp.name)
+table.insert(components.active[2], comps.file.type)
+table.insert(components.active[2], comps.file.os)
+table.insert(components.active[2], comps.file.position)
+table.insert(components.active[2], comps.file.line_percentage)
+
+-- Call feline
+require('feline').setup {
+  theme = {
+    bg = colors.bg,
+    fg = colors.fg,
+  },
+  components = components,
+  vi_mode_colors = vi_mode_colors,
+  force_inactive = {
+    filetypes = {
+      '^NvimTree$',
+      '^packer$',
+      '^vista$',
+      '^help$',
+    },
+    buftypes = {
+      '^terminal$'
+    },
+    bufnames = {},
+  },
+}

--- a/neovim/lua/plugins/indent-blankline.lua
+++ b/neovim/lua/plugins/indent-blankline.lua
@@ -1,0 +1,25 @@
+-----------------------------------------------------------
+-- Indent line configuration file
+-----------------------------------------------------------
+
+-- Plugin: indent-blankline
+-- url: https://github.com/lukas-reineke/indent-blankline.nvim
+
+
+require('indent_blankline').setup {
+  char = "▏",
+  show_first_indent_level = false,
+  filetype_exclude = {
+    'help',
+    'git',
+    'markdown',
+    'text',
+    'terminal',
+    'lspinfo',
+    'packer',
+  },
+  buftype_exclude = {
+    'terminal',
+    'nofile',
+  },
+}

--- a/neovim/lua/plugins/nvim-cmp.lua
+++ b/neovim/lua/plugins/nvim-cmp.lua
@@ -1,0 +1,69 @@
+-----------------------------------------------------------
+-- Autocomplete configuration file
+-----------------------------------------------------------
+
+-- Plugin: nvim-cmp
+-- url: https://github.com/hrsh7th/nvim-cmp
+
+
+local cmp = require 'cmp'
+local luasnip = require 'luasnip'
+
+cmp.setup {
+  -- Load snippet support
+  snippet = {
+    expand = function(args)
+      luasnip.lsp_expand(args.body)
+    end,
+  },
+
+-- Completion settings
+  completion = {
+    --completeopt = 'menu,menuone,noselect'
+    keyword_length = 2
+  },
+
+  -- Key mapping
+  mapping = {
+    ['<C-n>'] = cmp.mapping.select_next_item(),
+    ['<C-p>'] = cmp.mapping.select_prev_item(),
+    ['<C-d>'] = cmp.mapping.scroll_docs(-4),
+    ['<C-f>'] = cmp.mapping.scroll_docs(4),
+    ['<C-Space>'] = cmp.mapping.complete(),
+    ['<C-e>'] = cmp.mapping.close(),
+    ['<CR>'] = cmp.mapping.confirm {
+      behavior = cmp.ConfirmBehavior.Replace,
+      select = true,
+    },
+
+    -- Tab mapping
+    ['<Tab>'] = function(fallback)
+      if cmp.visible() then
+        cmp.select_next_item()
+      elseif luasnip.expand_or_jumpable() then
+        luasnip.expand_or_jump()
+      else
+        fallback()
+      end
+    end,
+    ['<S-Tab>'] = function(fallback)
+      if cmp.visible() then
+        cmp.select_prev_item()
+      elseif luasnip.jumpable(-1) then
+        luasnip.jump(-1)
+      else
+        fallback()
+      end
+    end
+  },
+
+  -- Load sources, see: https://github.com/topics/nvim-cmp
+  sources = {
+    { name = 'nvim_lua' },
+    { name = 'nvim_lsp' },
+    { name = 'luasnip' },
+    { name = 'path' },
+    { name = 'buffer' },
+  },
+}
+

--- a/neovim/lua/plugins/nvim-gps.lua
+++ b/neovim/lua/plugins/nvim-gps.lua
@@ -1,0 +1,9 @@
+-----------------------------------------------------------
+-- gps configuration file
+----------------------------------------------------------
+
+-- Plugin: nvim-gps
+-- url: https://github.com/SmiteshP/nvim-gps
+
+-- nvim-gps
+require("nvim-gps").setup()

--- a/neovim/lua/plugins/nvim-lspconfig.lua
+++ b/neovim/lua/plugins/nvim-lspconfig.lua
@@ -1,0 +1,106 @@
+-----------------------------------------------------------
+-- Neovim LSP configuration file
+-----------------------------------------------------------
+
+-- Plugin: nvim-lspconfig
+-- url: https://github.com/neovim/nvim-lspconfig
+
+local nvim_lsp = require 'lspconfig'
+
+-- Add additional capabilities supported by nvim-cmp
+local capabilities = vim.lsp.protocol.make_client_capabilities()
+capabilities.textDocument.completion.completionItem.documentationFormat = { 'markdown', 'plaintext' }
+capabilities.textDocument.completion.completionItem.snippetSupport = true
+capabilities.textDocument.completion.completionItem.preselectSupport = true
+capabilities.textDocument.completion.completionItem.insertReplaceSupport = true
+capabilities.textDocument.completion.completionItem.labelDetailsSupport = true
+capabilities.textDocument.completion.completionItem.deprecatedSupport = true
+capabilities.textDocument.completion.completionItem.commitCharactersSupport = true
+capabilities.textDocument.completion.completionItem.tagSupport = { valueSet = { 1 } }
+capabilities.textDocument.completion.completionItem.resolveSupport = {
+  properties = {
+    'documentation',
+    'detail',
+    'additionalTextEdits',
+  },
+}
+
+-- Use an on_attach function to only map the following keys
+-- after the language server attaches to the current buffer
+local on_attach = function(client, bufnr)
+  local function buf_set_keymap(...) vim.api.nvim_buf_set_keymap(bufnr, ...) end
+  local function buf_set_option(...) vim.api.nvim_buf_set_option(bufnr, ...) end
+
+  -- Enable completion triggered by <c-x><c-o>
+  buf_set_option('omnifunc', 'v:lua.vim.lsp.omnifunc')
+
+  -- Mappings.
+  local opts = { noremap=true, silent=true }
+
+  -- See `:help vim.lsp.*` for documentation on any of the below functions
+  buf_set_keymap('n', 'gD', '<cmd>lua vim.lsp.buf.declaration()<CR>', opts)
+  buf_set_keymap('n', 'gd', '<cmd>lua vim.lsp.buf.definition()<CR>', opts)
+  buf_set_keymap('n', 'K', '<cmd>lua vim.lsp.buf.hover()<CR>', opts)
+  buf_set_keymap('n', 'gi', '<cmd>lua vim.lsp.buf.implementation()<CR>', opts)
+  buf_set_keymap('n', '<C-k>', '<cmd>lua vim.lsp.buf.signature_help()<CR>', opts)
+  buf_set_keymap('n', '<space>wa', '<cmd>lua vim.lsp.buf.add_workspace_folder()<CR>', opts)
+  buf_set_keymap('n', '<space>wr', '<cmd>lua vim.lsp.buf.remove_workspace_folder()<CR>', opts)
+  buf_set_keymap('n', '<space>wl', '<cmd>lua print(vim.inspect(vim.lsp.buf.list_workspace_folders()))<CR>', opts)
+  buf_set_keymap('n', '<space>D', '<cmd>lua vim.lsp.buf.type_definition()<CR>', opts)
+  buf_set_keymap('n', '<space>rn', '<cmd>lua vim.lsp.buf.rename()<CR>', opts)
+  buf_set_keymap('n', '<space>ca', '<cmd>lua vim.lsp.buf.code_action()<CR>', opts)
+  buf_set_keymap('n', 'gr', '<cmd>lua vim.lsp.buf.references()<CR>', opts)
+  buf_set_keymap('n', '<space>e', '<cmd>lua vim.lsp.diagnostic.show_line_diagnostics()<CR>', opts)
+  buf_set_keymap('n', '[d', '<cmd>lua vim.lsp.diagnostic.goto_prev()<CR>', opts)
+  buf_set_keymap('n', ']d', '<cmd>lua vim.lsp.diagnostic.goto_next()<CR>', opts)
+  buf_set_keymap('n', '<space>q', '<cmd>lua vim.lsp.diagnostic.set_loclist()<CR>', opts)
+  buf_set_keymap('n', '<space>f', '<cmd>lua vim.lsp.buf.formatting()<CR>', opts)
+
+end
+
+--[[
+
+Language servers setup:
+
+For language servers list see:
+https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md
+
+Bash --> bashls
+https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#bashls
+
+Python --> pyright
+https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#pyright
+
+C-C++ -->  clangd
+https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#clangd
+
+HTML/CSS/JSON --> vscode-html-languageserver
+https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#html
+
+JavaScript/TypeScript --> tsserver
+https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#tsserver
+
+--]]
+
+-- Use a loop to conveniently call 'setup' on multiple servers and
+-- map buffer local keybindings when the language server attaches.
+-- Add your language server below:
+local servers = { 'bashls', 'pyright', 'tsserver', 'clangd', 'html', 'diagnosticls', 'dockerls', 'yamlls', 'jsonls', 'terraformls' }
+
+-- tsserver settings
+local ts_settings = function(client)
+  client.resolved_capabilities.document_formatting = false
+  ts_settings(client)
+end
+
+-- Call setup
+for _, lsp in ipairs(servers) do
+  nvim_lsp[lsp].setup {
+    on_attach = on_attach,
+    capabilities = capabilities,
+    ts_settings = ts_settings,
+    flags = {
+      debounce_text_changes = 150,
+    }
+  }
+end

--- a/neovim/lua/plugins/nvim-telescope.lua
+++ b/neovim/lua/plugins/nvim-telescope.lua
@@ -1,0 +1,23 @@
+-----------------------------------------------------------
+-- Telescope configuration file
+----------------------------------------------------------
+
+-- Plugin: nvim-telescope
+-- url: https://github.com/nvim-telescope/telescope.nvim
+
+-- You dont need to set any of these options. These are the default ones. Only
+-- the loading is important
+require('telescope').setup {
+  extensions = {
+    fzf = {
+      fuzzy = true,                    -- false will only do exact matching
+      override_generic_sorter = true,  -- override the generic sorter
+      override_file_sorter = true,     -- override the file sorter
+      case_mode = "smart_case",        -- or "ignore_case" or "respect_case"
+                                       -- the default case_mode is "smart_case"
+    }
+  }
+}
+-- To get fzf loaded and working with telescope, you need to call
+-- load_extension, somewhere after setup function:
+require('telescope').load_extension('fzf')

--- a/neovim/lua/plugins/nvim-tree.lua
+++ b/neovim/lua/plugins/nvim-tree.lua
@@ -1,0 +1,52 @@
+-----------------------------------------------------------
+-- File manager configuration file
+-----------------------------------------------------------
+
+-- Plugin: nvim-tree
+-- url: https://github.com/kyazdani42/nvim-tree.lua
+
+--- Keybindings are defined in `core/keymapping.lua`:
+--- https://github.com/kyazdani42/nvim-tree.lua#keybindings
+
+--- Note: options under the g: command should be set BEFORE running the
+--- setup function: https://github.com/kyazdani42/nvim-tree.lua#setup
+--- Default options are not included.
+--- See: `help NvimTree`
+local g = vim.g
+
+g.nvim_tree_indent_markers = 1
+g.nvim_tree_git_hl = 1
+g.nvim_tree_highlight_opened_files = 1
+g.nvim_tree_respect_buf_cwd = 1
+g.nvim_tree_width_allow_resize  = 1
+g.nvim_tree_show_icons = {
+  git = 1,
+  folders = 1,
+  files = 1,
+}
+
+g.nvim_tree_icons = {
+	default = "‣ "
+}
+
+require('nvim-tree').setup {
+  open_on_setup = true,
+  auto_close = false,
+  update_cwd = true,
+  actions = {
+    open_file = {
+      resize_window = false,
+      quit_on_open = false,
+      window_picker = { enable = false },
+    },
+  },
+  system_open = {
+    cmd  = nil,
+    args = {}
+  },
+  filters = {
+    dotfiles = true,
+    custom = { '.git', 'node_modules', '.cache', '.bin' },
+  },
+  view = { width = 32 },
+}

--- a/neovim/lua/plugins/nvim-treesitter.lua
+++ b/neovim/lua/plugins/nvim-treesitter.lua
@@ -1,0 +1,16 @@
+-----------------------------------------------------------
+-- Treesitter configuration file
+----------------------------------------------------------
+
+-- Plugin: nvim-treesitter
+-- url: https://github.com/nvim-treesitter/nvim-treesitter
+
+
+require('nvim-treesitter.configs').setup {
+  highlight = {
+    enable = true,
+  },
+  indent = {
+    enable = true
+  },
+}

--- a/neovim/lua/plugins/vista.lua
+++ b/neovim/lua/plugins/vista.lua
@@ -1,0 +1,37 @@
+----------------------------------------------------------
+-- Vista (tagbar) configuration file
+-----------------------------------------------------------
+
+-- Plugin: vista.vim
+-- url: https://github.com/liuchengxu/vista.vim
+
+
+local g = vim.g
+local cmd = vim.cmd
+
+-- How each level is indented and what to prepend.
+--- This could make the display more compact or more spacious.
+--- e.g., more compact: ["▸ ", ""]
+--- Note: this option only works for the kind renderer, not the tree renderer
+g.vista_icon_indent = '["╰─▸ ", "├─▸ "]'
+
+-- Executive used when opening vista sidebar without specifying it.
+--- See all the avaliable executives via `:echo g:vista#executives`.
+g.vista_default_executive = 'ctags'
+
+-- Ensure you have installed some decent font to show these pretty symbols,
+--- then you can enable icon for the kind.
+cmd [[let g:vista#renderer#enable_icon = 1]]
+
+
+-- Change some default icons
+--- see: https://github.com/slavfox/Cozette/blob/master/img/charmap.txt
+cmd [[
+  let g:vista#renderer#icons = {
+  \   "function": "\u0192",
+  \   "variable": "\uf00d",
+  \   "prototype": "\uf013",
+  \   "macro": "\uf00b",
+  \ }
+]]
+

--- a/setup/neovim.sh
+++ b/setup/neovim.sh
@@ -1,0 +1,11 @@
+#!/bin/zsh -e
+
+# Always run install_nvim so it's at the latest version.
+# Too many things break otherwise.
+# Defined in ~/.zshenv
+install_nvim
+if npm --version > /dev/null 2>&1; then
+    npm install -g neovim
+fi
+
+nvim --headless -c 'autocmd User PackerComplete quitall' -c 'PackerSync'


### PR DESCRIPTION
Since LSP configuration was already in Lua I decided to "convert" the
rest of my neovim configuration as well. I stumbled upon the
https://github.com/brainfucksec/neovim-lua repository which I took as a
base and have applied most of my previous plugins and configs that were
not present out of the box. I've left some out for now intentionally and
might add them back in if I miss them.

I had also thought about switching from vim-plug to packer.nvim to
manage plugins so that was achieved here as well. The statusline plugin
changed from lualine to feline which I had also considered testing.

I still left my old configs in place so either can be installed. I'll
get rid of the old stuff when I feel comfortable in doing so. In general
the new configs seem less convoluted than the old.