### PR TITLE
feat: add detect-secrets pre-commit hook for credential protection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,12 @@ repos:
     rev: v1.7.7
     hooks:
       - id: actionlint
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ['--baseline', '.secrets.baseline']
+        exclude: package.lock.json
   - repo: local
     hooks:
       - id: trufflehog

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,112 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {},
+  "generated_at": "2025-08-29T10:44:00Z"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,14 @@ shellcheck **/*.sh                    # Shell scripts
 luacheck private_dot_config/nvim/lua  # Neovim config
 actionlint                            # GitHub Actions
 brew bundle check --file=Brewfile     # Brewfile integrity
+pre-commit run --all-files            # Run all pre-commit hooks
+```
+
+### Secret Scanning
+```bash
+detect-secrets scan --baseline .secrets.baseline  # Scan for new secrets
+detect-secrets audit .secrets.baseline            # Review flagged secrets
+pre-commit run detect-secrets --all-files         # Run via pre-commit
 ```
 
 ## Key Files & Directories
@@ -54,3 +62,6 @@ Multi-platform testing (Ubuntu/macOS) with linting → build stages in `.github/
 - API tokens in `~/.api_tokens` (not in repo)
 - Private files use `private_` prefix
 - No secrets committed
+- **detect-secrets** pre-commit hook prevents accidental secret commits
+- **TruffleHog** scans for leaked credentials in git history
+- Both tools run automatically on commit via pre-commit hooks


### PR DESCRIPTION
Add detect-secrets pre-commit check to prevent accidental credential commits.

## Changes
- Add detect-secrets v1.5.0 to pre-commit configuration
- Create baseline file for false positives management
- Update CLAUDE.md with secret scanning documentation
- Complements existing TruffleHog secret detection

Closes #45

Generated with [Claude Code](https://claude.ai/code)