### PR TITLE
Add Google Chat Formatting Style Guide

### DIFF
--- a/docs/google-chat-formatting.md
+++ b/docs/google-chat-formatting.md
@@ -1,0 +1,100 @@
+# Google Chat Formatting Style Guide
+
+A comprehensive guide for formatting messages in Google Chat with proper syntax and best practices.
+
+## Basic Formatting
+
+### Bold Text
+Use single asterisks to create bold text:
+```
+*This text will be bold*
+```
+
+**Important:** Google Chat uses single asterisks (`*`) for bold, not double asterisks (`**`) like Markdown.
+
+### Code and Monospace Text
+Use backticks for inline code or monospace text:
+```
+`code` or `monospace text`
+```
+
+For code blocks, use triple backticks:
+```
+```
+code block
+```
+```
+
+## Lists and Structure
+
+### Bullet Points
+Use the bullet symbol (`•`) for lists, not hyphens or asterisks:
+```
+• First item
+• Second item
+• Third item
+```
+
+### Structure Guidelines
+- Use *bold* for headings and subheadings (since `#` headers are not supported)
+- Separate sections with blank lines for better readability
+- Keep paragraphs concise for mobile-friendly viewing
+- Use colons after bold labels: `*Label:* description`
+
+## Best Practices
+
+### Formatting Consistency
+- Always use single asterisks for bold text
+- Consistently use `•` for bullet points
+- Apply proper spacing around formatted elements
+- Avoid mixing formatting styles within the same message
+
+### Readability Guidelines
+- Break long messages into shorter paragraphs
+- Use bullet points for lists instead of numbered lists when order doesn't matter
+- Apply bold formatting sparingly for emphasis
+- Use code formatting for technical terms, commands, and file names
+
+### Common Patterns
+```
+*Subject:* Brief description of the topic
+
+*Key Points:*
+• Important point one
+• Important point two
+• Important point three
+
+*Next Steps:*
+• Action item one
+• Action item two
+
+*Code Example:*
+`command --option value`
+```
+
+## Limitations
+
+### Unsupported Markdown Features
+Google Chat does not support:
+- Headers using `#` syntax
+- Double asterisk bold (`**text**`)
+- Italics using underscores or single asterisks in Markdown style
+- Tables
+- Links with Markdown syntax `[text](url)`
+- Strikethrough text
+
+### Compatibility Notes
+- Always test formatting in a Google Chat environment
+- Some formatting may appear differently on mobile vs. desktop
+- Complex formatting may not render consistently across all Google Chat clients
+
+## Quick Reference
+
+| Element | Syntax | Example |
+|---------|--------|---------|
+| Bold | `*text*` | *Bold text* |
+| Code | `` `text` `` | `code` |
+| Bullet | `•` | • Item |
+| Label | `*Label:*` | *Note:* description |
+
+Use this guide to ensure consistent, readable formatting across all Google Chat communications.

--- a/dot_claude/commands/google-chat-format.md
+++ b/dot_claude/commands/google-chat-format.md
@@ -1,0 +1,106 @@
+# Google Chat Format Command
+
+Convert text to Google Chat compatible formatting automatically.
+
+## Usage
+```bash
+claude chat --file ~/.claude/commands/google-chat-format.md [TEXT|FILE]
+```
+
+## Arguments
+- `TEXT` (optional): Text to convert inline
+- `FILE` (optional): File path containing text to convert
+- If no arguments provided, processes text from clipboard or stdin
+
+## Workflow
+
+1. **Text Input**
+   - Accept text from command arguments, file, clipboard, or stdin
+   - Preserve existing structure and intent
+
+2. **Format Conversion**
+   - Convert Markdown headers (`#`, `##`, etc.) to bold text (`*Header*`)
+   - Convert double asterisks (`**bold**`) to single asterisks (`*bold*`)
+   - Replace hyphens and asterisks in lists with bullet symbols (`•`)
+   - Preserve existing backticks for code formatting
+   - Add proper spacing around formatted elements
+
+3. **Structure Enhancement**
+   - Ensure blank lines between sections
+   - Format labels with colons: `*Label:* description`
+   - Maintain readability for mobile viewing
+
+## Conversion Rules
+
+### Headers
+- `# Header` → `*Header*`
+- `## Subheader` → `*Subheader*`
+- `### Section` → `*Section*`
+
+### Text Formatting
+- `**bold**` → `*bold*`
+- `__bold__` → `*bold*`
+- Preserve existing `*bold*` formatting
+- Preserve `` `code` `` formatting
+
+### Lists
+- `- item` → `• item`
+- `* item` → `• item`
+- `+ item` → `• item`
+- Preserve numbered lists as-is
+
+### Special Patterns
+- `**Label:**` → `*Label:*`
+- Multiple blank lines → Single blank line
+- Trailing whitespace → Cleaned
+
+## Examples
+
+### Input:
+```markdown
+# Meeting Notes
+
+## Key Decisions
+- Approved budget increase
+- **Priority:** High urgency items first
+- Next meeting: `2024-01-15`
+
+### Action Items
+* Review proposal
+* Update documentation
+```
+
+### Output:
+```
+*Meeting Notes*
+
+*Key Decisions*
+• Approved budget increase
+• *Priority:* High urgency items first
+• Next meeting: `2024-01-15`
+
+*Action Items*
+• Review proposal
+• Update documentation
+```
+
+## Features
+
+- **Batch Processing**: Convert multiple files at once
+- **Clipboard Integration**: Automatically process clipboard content
+- **Preservation**: Maintain code blocks and existing Google Chat formatting
+- **Validation**: Check output for Google Chat compatibility
+- **Preview**: Show before/after comparison
+
+## Integration
+
+- Works with any text editor or IDE
+- Can be piped with other text processing commands
+- Compatible with markdown files, documentation, and plain text
+- Integrates with Claude workflows for content creation
+
+## Success Criteria
+- All Markdown formatting converted to Google Chat equivalents
+- Text structure and readability maintained
+- Code blocks and technical content preserved
+- Output ready for direct paste into Google Chat

--- a/dot_local/bin/executable_google-chat-format
+++ b/dot_local/bin/executable_google-chat-format
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+
+# Google Chat Format Converter
+# Converts Markdown text to Google Chat compatible formatting
+
+set -euo pipefail
+
+# Colors for output
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly YELLOW='\033[1;33m'
+readonly NC='\033[0m' # No Color
+
+# Help text
+show_help() {
+    cat << EOF
+Google Chat Format Converter
+
+Convert Markdown text to Google Chat compatible formatting.
+
+USAGE:
+    google-chat-format [OPTIONS] [FILE|TEXT]
+
+OPTIONS:
+    -h, --help      Show this help message
+    -c, --clipboard Process clipboard content (macOS/Linux)
+    -f, --file FILE Process specific file
+    -i, --in-place  Edit file in-place (with -f)
+    -p, --preview   Show preview without applying changes
+
+EXAMPLES:
+    # Convert text from argument
+    google-chat-format "# Header\n**bold text**"
+    
+    # Convert from file
+    google-chat-format -f document.md
+    
+    # Convert clipboard content
+    google-chat-format -c
+    
+    # Preview changes
+    google-chat-format -p -f document.md
+    
+    # Edit file in-place
+    google-chat-format -f document.md -i
+
+If no arguments provided, reads from stdin.
+EOF
+}
+
+# Convert text to Google Chat format
+convert_text() {
+    local text="$1"
+    
+    # Convert headers to bold
+    text=$(echo "$text" | sed -E 's/^### (.*)/\*\1\*/g')
+    text=$(echo "$text" | sed -E 's/^## (.*)/\*\1\*/g')
+    text=$(echo "$text" | sed -E 's/^# (.*)/\*\1\*/g')
+    
+    # Convert double asterisk bold to single asterisk
+    text=$(echo "$text" | sed -E 's/\*\*([^*]+)\*\*/\*\1\*/g')
+    
+    # Convert underscore bold to asterisk
+    text=$(echo "$text" | sed -E 's/__([^_]+)__/\*\1\*/g')
+    
+    # Convert list markers to bullet points
+    text=$(echo "$text" | sed -E 's/^[[:space:]]*[-*+][[:space:]]/• /g')
+    
+    # Fix label formatting (convert **Label:** to *Label:*)
+    text=$(echo "$text" | sed -E 's/\*\*([^:]+):\*\*/\*\1:\*/g')
+    
+    # Remove excessive blank lines (more than 2 consecutive)
+    text=$(echo "$text" | sed -E '/^[[:space:]]*$/N;/\n[[:space:]]*$/N;/\n[[:space:]]*\n[[:space:]]*$/d')
+    
+    # Ensure single blank line between sections (after bold headers)
+    text=$(echo "$text" | sed -E '/^\*.*\*$/{N;/\n[^[:space:]]/s/\n/\n\n/;}')
+    
+    echo "$text"
+}
+
+# Get clipboard content (cross-platform)
+get_clipboard() {
+    if command -v pbpaste >/dev/null 2>&1; then
+        # macOS
+        pbpaste
+    elif command -v xclip >/dev/null 2>&1; then
+        # Linux with xclip
+        xclip -selection clipboard -o
+    elif command -v xsel >/dev/null 2>&1; then
+        # Linux with xsel
+        xsel --clipboard --output
+    else
+        echo "Error: No clipboard tool found (pbpaste, xclip, or xsel)" >&2
+        exit 1
+    fi
+}
+
+# Set clipboard content (cross-platform)
+set_clipboard() {
+    local content="$1"
+    if command -v pbcopy >/dev/null 2>&1; then
+        # macOS
+        echo "$content" | pbcopy
+    elif command -v xclip >/dev/null 2>&1; then
+        # Linux with xclip
+        echo "$content" | xclip -selection clipboard
+    elif command -v xsel >/dev/null 2>&1; then
+        # Linux with xsel
+        echo "$content" | xsel --clipboard --input
+    else
+        echo "Error: No clipboard tool found (pbcopy, xclip, or xsel)" >&2
+        exit 1
+    fi
+}
+
+# Main function
+main() {
+    local file=""
+    local use_clipboard=false
+    local in_place=false
+    local preview=false
+    local input_text=""
+    
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -h|--help)
+                show_help
+                exit 0
+                ;;
+            -c|--clipboard)
+                use_clipboard=true
+                shift
+                ;;
+            -f|--file)
+                file="$2"
+                shift 2
+                ;;
+            -i|--in-place)
+                in_place=true
+                shift
+                ;;
+            -p|--preview)
+                preview=true
+                shift
+                ;;
+            *)
+                # Treat as input text
+                input_text="$1"
+                shift
+                ;;
+        esac
+    done
+    
+    # Get input text
+    if [[ "$use_clipboard" == true ]]; then
+        input_text=$(get_clipboard)
+        echo -e "${YELLOW}Processing clipboard content...${NC}" >&2
+    elif [[ -n "$file" ]]; then
+        if [[ ! -f "$file" ]]; then
+            echo -e "${RED}Error: File '$file' not found${NC}" >&2
+            exit 1
+        fi
+        input_text=$(cat "$file")
+        echo -e "${YELLOW}Processing file: $file${NC}" >&2
+    elif [[ -z "$input_text" ]]; then
+        # Read from stdin
+        input_text=$(cat)
+        echo -e "${YELLOW}Processing stdin...${NC}" >&2
+    fi
+    
+    # Convert the text
+    converted_text=$(convert_text "$input_text")
+    
+    # Handle output
+    if [[ "$preview" == true ]]; then
+        echo -e "${GREEN}=== ORIGINAL ===${NC}"
+        echo "$input_text"
+        echo -e "${GREEN}=== CONVERTED ===${NC}"
+        echo "$converted_text"
+    elif [[ "$in_place" == true && -n "$file" ]]; then
+        echo "$converted_text" > "$file"
+        echo -e "${GREEN}File updated: $file${NC}" >&2
+    elif [[ "$use_clipboard" == true ]]; then
+        set_clipboard "$converted_text"
+        echo -e "${GREEN}Converted text copied to clipboard${NC}" >&2
+    else
+        echo "$converted_text"
+    fi
+}
+
+# Run main function with all arguments
+main "$@"


### PR DESCRIPTION
Add Google Chat formatting style guide and converter command as requested in issue #40.

## Changes
- Added comprehensive style guide in `docs/google-chat-formatting.md`
- Created Claude command for text conversion in `dot_claude/commands/google-chat-format.md`
- Implemented executable script for automated Markdown to Google Chat format conversion
- Supports clipboard integration, file processing, and preview modes

## Addresses
Closes #40

Generated with [Claude Code](https://claude.ai/code)