### PR TITLE
fix: add null checking for missing model key in Claude settings template

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -28,8 +28,8 @@
 {{- $settingsFile := joinPath .chezmoi.homeDir ".claude" "settings.json" }}
 {{- if stat $settingsFile }}
 {{- $existing := $settingsFile | include | fromJson }}
-  "model": {{ $existing.model | toJson }},
-  "feedbackSurveyState": {{ $existing.feedbackSurveyState | toJson }},
+  "model": {{ if hasKey $existing "model" }}{{ $existing.model | toJson }}{{ else }}"sonnet"{{ end }},
+  "feedbackSurveyState": {{ if hasKey $existing "feedbackSurveyState" }}{{ $existing.feedbackSurveyState | toJson }}{{ else }}{ "lastShownTime": 1754075292901 }{{ end }},
 {{- else }}
   "model": "sonnet",
   "feedbackSurveyState": {


### PR DESCRIPTION
Fixes template error when Claude Code removes model key after setting to default.

Added hasKey checks for both model and feedbackSurveyState keys to prevent template execution errors.

Fixes #43

Generated with [Claude Code](https://claude.ai/code)