### PR TITLE
feat: implement opts overriding for trouble.nvim and lualine integration

### DIFF
--- a/private_dot_config/nvim/lua/plugins/lualine.lua
+++ b/private_dot_config/nvim/lua/plugins/lualine.lua
@@ -22,6 +22,23 @@ return {
         },
         lualine_x = {
           {
+            function()
+              return require("trouble").statusline({
+                mode = "lsp_document_symbols",
+                groups = {},
+                title = false,
+                filter = { range = true },
+                format = "{kind_icon}{symbol.name:Normal}",
+                -- The following line need to be set only if the `trouble` setup function 
+                -- is not yet called, so that statusline works properly before trouble is opened
+                hl_group = "lualine_c_normal",
+              })
+            end,
+            cond = function()
+              return package.loaded["trouble"] and require("trouble").is_open()
+            end,
+          },
+          {
             require("lazy.status").updates,
             cond = require("lazy.status").has_updates,
             color = { fg = "#ff9e64" },

--- a/private_dot_config/nvim/lua/plugins/trouble.lua
+++ b/private_dot_config/nvim/lua/plugins/trouble.lua
@@ -1,7 +1,17 @@
 return {
   {
     "folke/trouble.nvim",
-    opts = {}, -- for default options, refer to the configuration section for custom setup.
+    opts = {
+      -- Example of opts overriding - these options merge with defaults
+      modes = {
+        lsp_document_symbols = {
+          mode = "lsp_document_symbols",
+          focus = false,
+          win = { position = "right", size = { width = 0.3 } },
+          filter = { range = true },
+        },
+      },
+    },
     cmd = "Trouble",
     keys = {
       {


### PR DESCRIPTION
Implements proper opts overriding for plugin configs as requested in issue #27.

## Changes
- Add trouble.nvim statusline component to lualine configuration
- Demonstrate proper opts overriding in trouble.nvim config
- Configure lsp_document_symbols mode with custom settings
- Integrate statusline component with conditional visibility

Resolves #27

🤖 Generated with [Claude Code](https://claude.ai/code)