### PR TITLE
feat: enable LSP on-type formatting with blink.cmp support

### DIFF
--- a/private_dot_config/nvim/lua/core/lsp.lua
+++ b/private_dot_config/nvim/lua/core/lsp.lua
@@ -1,13 +1,27 @@
 -- Add the same capabilities to ALL server configurations.
 -- Refer to :h vim.lsp.config() for more information.
+local capabilities = vim.lsp.protocol.make_client_capabilities()
+
+-- Check if blink.cmp is available and merge capabilities
+local ok, blink = pcall(require, 'blink.cmp')
+if ok then
+  capabilities = vim.tbl_deep_extend('force', capabilities, blink.get_lsp_capabilities())
+end
+
+-- Add onTypeFormatting capability for blink.cmp compatibility
+capabilities.textDocument.onTypeFormatting = { dynamicRegistration = false }
+
 vim.lsp.config("*", {
-  capabilities = vim.lsp.protocol.make_client_capabilities(),
+  capabilities = capabilities,
   on_attach = function(client, bufnr)
     if client.server_capabilities.documentSymbolProvider then
       require("nvim-navic").attach(client, bufnr)
     end
   end,
 })
+
+-- Enable LSP on-type formatting
+vim.lsp.on_type_formatting.enable()
 
 -- require("mason").setup()
 -- require("mason-lspconfig").setup({


### PR DESCRIPTION
Enables LSP on-type formatting for real-time formatting assistance as you type.

- Add `vim.lsp.on_type_formatting.enable()` to enable on-type formatting globally
- Configure textDocument.onTypeFormatting capability for blink.cmp compatibility
- Merge blink.cmp capabilities with base LSP capabilities
- Supports real-time formatting for tools like basedpyright, lua_ls, rust-analyzer

Closes #68

Generated with [Claude Code](https://claude.ai/code)