### PR TITLE
feat: add atuin installation script for non-brew environments

### DIFF
--- a/run_once_01-install-atuin.sh.tmpl
+++ b/run_once_01-install-atuin.sh.tmpl
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Install atuin shell history manager if not already installed
+# This script runs once and checks if atuin is available
+
+set -euo pipefail
+
+echo "Checking for atuin installation..."
+
+# Check if atuin is already installed
+if command -v atuin &> /dev/null; then
+    echo "✓ atuin is already installed (version: $(atuin --version))"
+    exit 0
+fi
+
+echo "atuin not found. Installing..."
+
+# Try to install via brew first (if available)
+{{- if eq .chezmoi.os "darwin" }}
+if command -v brew &> /dev/null; then
+    echo "Installing atuin via Homebrew..."
+    brew install atuin && echo "✓ atuin installed via Homebrew" && exit 0
+fi
+{{- else if eq .chezmoi.os "linux" }}
+if command -v /home/linuxbrew/.linuxbrew/bin/brew &> /dev/null; then
+    echo "Installing atuin via Homebrew..."
+    /home/linuxbrew/.linuxbrew/bin/brew install atuin && echo "✓ atuin installed via Homebrew" && exit 0
+fi
+{{- end }}
+
+# Fall back to the official installation script
+echo "Installing atuin via official installation script..."
+curl --proto '=https' --tlsv1.2 -LsSf https://setup.atuin.sh | sh
+
+# Verify installation
+if command -v atuin &> /dev/null; then
+    echo "✓ atuin successfully installed (version: $(atuin --version))"
+    
+    # Note about shell configuration
+    echo ""
+    echo "Note: Shell integration is already configured in:"
+    echo "  - Fish: ~/.config/fish/config.fish"
+    echo "  - Zsh: ~/.zshrc"
+    echo ""
+    echo "You may need to restart your shell or run 'source' on your shell config."
+else
+    echo "✗ Failed to install atuin"
+    exit 1
+fi


### PR DESCRIPTION
Closes #73

## Summary

Add a dedicated installation script for atuin shell history manager that handles installation on systems where Homebrew might not be available or might fail.

## Changes

- Created `run_once_01-install-atuin.sh.tmpl` to handle atuin installation
- Script checks if atuin is already installed before attempting installation
- Attempts installation via Homebrew first, falls back to official installation script
- Provides clear feedback about installation status
- Supports both macOS and Linux through chezmoi templating

## Testing

The script has been designed to:
1. Skip installation if atuin is already present
2. Try brew first on systems where it's available
3. Fall back to the official installer as specified in the issue
4. Verify successful installation

---

Generated with [Claude Code](https://claude.ai/code)