### PR TITLE
ci: simplify smoke test workflow

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -7,53 +7,36 @@ on:
     branches: [ main ] # Or your default branch name
 
 jobs:
-  lint-ubuntu:
-    name: Linters (Ubuntu)
+  lint:
+    name: Linters
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
 
       - name: Setup Homebrew (Linux)
         uses: Homebrew/actions/setup-homebrew@v1
 
       - name: Install Dependencies
         run: |
-          brew install chezmoi shellcheck actionlint
-          sudo apt-get update && sudo apt-get install -y luacheck
+          brew install chezmoi
+          pip install pre-commit
 
-      - name: Run actionlint
-        run: actionlint -color
-
-      - name: Run shellcheck
-        # Find all .sh and .zsh files, excluding .git directory, and run shellcheck
-        run: |
-          find . -type f \( -name "*.sh" -o -name "*.zsh" \) -not -path "./.git/*" -print0 | xargs -0 shellcheck -x
-
-      - name: Run luacheck
-        # Assuming neovim config is under private_dot_config/nvim/lua
-        run: luacheck private_dot_config/nvim/lua
+      - name: Run pre-commit
+        run: pre-commit run --all-files
 
       - name: Run chezmoi verify
         run: chezmoi verify .
 
-  lint-macos:
-    name: Linters (macOS)
-    runs-on: macos-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Homebrew # Ensure brew is available and in PATH
-        uses: Homebrew/actions/setup-homebrew@v1
-
-      - name: Check Brewfile
-        run: brew bundle check --file=Brewfile
-
-  build-linux:
+  build:
     name: Build (Ubuntu)
     runs-on: ubuntu-latest
-    needs: [lint-ubuntu] # Run after linters pass
+    needs: [lint] # Run after linters pass
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -70,9 +53,9 @@ jobs:
             ${{ runner.os }}-brew-
 
       - name: Install Dependencies
-        # Install chezmoi, mise, and any deps needed *before* chezmoi apply (e.g., neovim for tasks)
+        # Install chezmoi, mise, fish, and any deps needed *before* chezmoi apply
         run: |
-          brew install chezmoi neovim
+          brew install chezmoi neovim fish
 
       - name: Setup mise
         uses: nick-fields/setup-mise@v0
@@ -81,78 +64,23 @@ jobs:
         # Use -v for verbose output, useful for debugging CI failures
         run: chezmoi apply -v
 
-      - name: Test zsh autosuggestions initialization
+      - name: Test fish shell initialization
         run: |
-          # Test that zsh-autosuggestions loads immediately in fresh shell
-          timeout 10s zsh -c '
-            source ~/.zshrc
-            # Check if plugin loaded by testing for ZSH_AUTOSUGGEST_STRATEGY variable
-            if [[ -n "$ZSH_AUTOSUGGEST_STRATEGY" ]]; then
-              echo "✅ zsh-autosuggestions loaded successfully"
+          # Test that fish shell loads and configuration works
+          timeout 10s fish -c '
+            # Check if fish configuration loaded
+            if test -n "$fish_greeting"
+              echo "✅ Fish configuration loaded successfully"
             else
-              echo "❌ zsh-autosuggestions failed to load"
+              echo "❌ Fish configuration failed to load"
               exit 1
-            fi
+            end
 
-            # Test that autosuggestion functions are available
-            if typeset -f _zsh_autosuggest_start > /dev/null; then
-              echo "✅ zsh-autosuggestions functions available"
+            # Test that fish functions are available
+            if functions -q fish_prompt
+              echo "✅ Fish prompt function available"
             else
-              echo "❌ zsh-autosuggestions functions not found"
+              echo "❌ Fish prompt function not found"
               exit 1
-            fi
-          '
-
-  build-macos:
-    name: Build (macOS)
-    runs-on: macos-latest
-    needs: [lint-macos] # Run after macOS linters pass
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Homebrew # Ensure brew is available and in PATH
-        uses: Homebrew/actions/setup-homebrew@v1
-
-      - name: Cache Homebrew
-        uses: actions/cache@v4
-        with:
-          path: ~/Library/Caches/Homebrew
-          key: ${{ runner.os }}-brew-${{ hashFiles('**/Brewfile') }}
-          restore-keys: |
-            ${{ runner.os }}-brew-
-
-      - name: Install Dependencies
-        # Install chezmoi, mise, and any deps needed *before* chezmoi apply
-        # (neovim, groff, autoconf for tasks)
-        run: |
-          brew install chezmoi neovim groff autoconf
-
-      - name: Setup mise
-        uses: nick-fields/setup-mise@v0
-
-      - name: Run chezmoi apply
-        # Use -v for verbose output
-        run: chezmoi apply -v
-
-      - name: Test zsh autosuggestions initialization
-        run: |
-          # Test that zsh-autosuggestions loads immediately in fresh shell
-          timeout 10s zsh -c '
-            source ~/.zshrc
-            # Check if plugin loaded by testing for ZSH_AUTOSUGGEST_STRATEGY variable
-            if [[ -n "$ZSH_AUTOSUGGEST_STRATEGY" ]]; then
-              echo "✅ zsh-autosuggestions loaded successfully"
-            else
-              echo "❌ zsh-autosuggestions failed to load"
-              exit 1
-            fi
-
-            # Test that autosuggestion functions are available
-            if typeset -f _zsh_autosuggest_start > /dev/null; then
-              echo "✅ zsh-autosuggestions functions available"
-            else
-              echo "❌ zsh-autosuggestions functions not found"
-              exit 1
-            fi
+            end
           '


### PR DESCRIPTION
## Summary
- Removes macOS jobs to reduce CI complexity and runtime  
- Replaces individual linters with unified pre-commit hooks
- Switches shell testing from zsh to fish (primary shell)

## Context
This implements the changes recommended by Claude in GitHub Actions run [#17341193324](https://github.com/laurigates/dotfiles/actions/runs/17341193324) to streamline CI while maintaining comprehensive testing coverage through pre-commit hooks.

## Test plan
- [x] Verify pre-commit runs all necessary linters
- [x] Confirm fish shell tests work correctly
- [ ] CI passes on Ubuntu

🤖 Generated with [Claude Code](https://claude.ai/code)