### PR TITLE
feat: add zsh completions for bun/bunx

### DIFF
--- a/.chezmoidata.toml
+++ b/.chezmoidata.toml
@@ -59,6 +59,7 @@
       skaffold = "skaffold completion zsh"
       kitty = "kitty +complete setup zsh"
       vectorcode = "vectorcode -s zsh"
+      bun = "bun completions"
 
 [packages.brew]
   # Taps for both macOS and Linux


### PR DESCRIPTION
Add bun to the automated zsh completion generation in .chezmoidata.toml.
This ensures bun completions are generated when the completion script runs.

Closes #83

Generated with [Claude Code](https://claude.ai/code)