### PR TITLE
feat(nvim): add filetype-specific iskeyword settings

### DIFF
--- a/private_dot_config/nvim/after/ftplugin/css.lua
+++ b/private_dot_config/nvim/after/ftplugin/css.lua
@@ -1,0 +1,3 @@
+-- CSS-specific settings
+-- Include hyphens in word motions (for kebab-case class names)
+vim.opt_local.iskeyword:append("-")

--- a/private_dot_config/nvim/after/ftplugin/go.lua
+++ b/private_dot_config/nvim/after/ftplugin/go.lua
@@ -1,0 +1,4 @@
+-- Go-specific settings
+-- Include underscores and exclude colons (for easier navigation)
+vim.opt_local.iskeyword:append("_")
+vim.opt_local.iskeyword:remove(":")

--- a/private_dot_config/nvim/after/ftplugin/javascript.lua
+++ b/private_dot_config/nvim/after/ftplugin/javascript.lua
@@ -1,0 +1,3 @@
+-- JavaScript-specific settings
+-- Exclude dots from word motions for easier property navigation
+vim.opt_local.iskeyword:remove(".")

--- a/private_dot_config/nvim/after/ftplugin/json.lua
+++ b/private_dot_config/nvim/after/ftplugin/json.lua
@@ -1,0 +1,3 @@
+-- JSON-specific settings
+-- Exclude dots from word motions for easier property navigation
+vim.opt_local.iskeyword:remove(".")

--- a/private_dot_config/nvim/after/ftplugin/lua.lua
+++ b/private_dot_config/nvim/after/ftplugin/lua.lua
@@ -1,0 +1,4 @@
+-- Lua-specific settings
+-- Include underscores and dots (for module navigation like require("module.submodule"))
+vim.opt_local.iskeyword:append("_")
+vim.opt_local.iskeyword:append(".")

--- a/private_dot_config/nvim/after/ftplugin/python.lua
+++ b/private_dot_config/nvim/after/ftplugin/python.lua
@@ -1,0 +1,3 @@
+-- Python-specific settings
+-- Include underscores in word motions (for snake_case identifiers)
+vim.opt_local.iskeyword:append("_")

--- a/private_dot_config/nvim/after/ftplugin/rust.lua
+++ b/private_dot_config/nvim/after/ftplugin/rust.lua
@@ -1,0 +1,4 @@
+-- Rust-specific settings
+-- Include underscores (for snake_case) and exclude colons (for easier path navigation)
+vim.opt_local.iskeyword:append("_")
+vim.opt_local.iskeyword:remove(":")

--- a/private_dot_config/nvim/after/ftplugin/scss.lua
+++ b/private_dot_config/nvim/after/ftplugin/scss.lua
@@ -1,0 +1,3 @@
+-- SCSS-specific settings
+-- Include hyphens in word motions (for kebab-case class names)
+vim.opt_local.iskeyword:append("-")

--- a/private_dot_config/nvim/after/ftplugin/sh.lua
+++ b/private_dot_config/nvim/after/ftplugin/sh.lua
@@ -1,0 +1,4 @@
+-- Shell script-specific settings
+-- Include underscores and hyphens (common in shell variable and command names)
+vim.opt_local.iskeyword:append("_")
+vim.opt_local.iskeyword:append("-")

--- a/private_dot_config/nvim/after/ftplugin/typescript.lua
+++ b/private_dot_config/nvim/after/ftplugin/typescript.lua
@@ -1,0 +1,3 @@
+-- TypeScript-specific settings
+-- Exclude dots from word motions for easier property navigation
+vim.opt_local.iskeyword:remove(".")

--- a/private_dot_config/nvim/after/ftplugin/yaml.lua
+++ b/private_dot_config/nvim/after/ftplugin/yaml.lua
@@ -1,0 +1,4 @@
+-- YAML-specific settings
+-- Include hyphens and underscores (common in YAML keys)
+vim.opt_local.iskeyword:append("-")
+vim.opt_local.iskeyword:append("_")


### PR DESCRIPTION
Configure sensible word delimiters for different programming languages to improve navigation with w/b/e motions and WORD operations.

Closes #84

🤖 Generated with [Claude Code](https://claude.ai/code)