### PR TITLE
Simplify LSP configuration using Neovim 0.11 native APIs

### DIFF
--- a/private_dot_config/nvim/CLAUDE.md
+++ b/private_dot_config/nvim/CLAUDE.md
@@ -29,7 +29,10 @@ Modules in `lua/core/` are loaded explicitly in this order (from init.lua):
 
 Key plugin categories:
 - **Completion**: blink.cmp with LSP integration
-- **LSP/Formatting**: Mason for LSP management, conform.nvim for formatting, nvim-lint for linting
+- **LSP/Formatting**: Mason for LSP server installation, conform.nvim for formatting, nvim-lint for linting
+  - Uses native Neovim 0.11 LSP APIs (no nvim-lspconfig needed)
+  - navic/navbuddy for code navigation and breadcrumbs
+  - schemastore for JSON schema validation
 - **Navigation**: fzf-lua, oil.nvim, aerial.nvim
 - **Git**: gitsigns, git fugitive integration
 - **UI**: tokyonight theme, lualine statusline, noice.nvim
@@ -75,12 +78,19 @@ Key plugin categories:
 
 ### LSP Configuration
 
-The LSP setup uses Neovim's built-in `vim.lsp.config()` with capabilities automatically extended for blink.cmp completion. Language servers are installed via Mason and configured in `lua/core/lsp.lua`.
+The LSP setup uses Neovim 0.11's native `vim.lsp.config()` and `vim.lsp.enable()` APIs with capabilities automatically extended for blink.cmp completion. Language servers are installed via Mason and configured in `lua/core/lsp.lua`.
+
+**Important**: This configuration does NOT use nvim-lspconfig or mason-lspconfig plugins. It uses Neovim's built-in LSP configuration system introduced in 0.11.
+
+To add a new LSP server:
+1. Install it via Mason (`:Mason`)
+2. Add configuration in `lua/core/lsp.lua` using `vim.lsp.config("server_name", { ... })`
+3. Enable it with `vim.lsp.enable("server_name")`
 
 Configured LSPs include:
 - terraformls - Terraform with experimental features
 - jsonls - JSON with SchemaStore integration
-- Multiple others via Mason integration
+- Additional servers can be added following the pattern above
 
 ### Formatting & Linting
 

--- a/private_dot_config/nvim/lua/core/lsp.lua
+++ b/private_dot_config/nvim/lua/core/lsp.lua
@@ -23,11 +23,7 @@ vim.lsp.config("*", {
 -- Enable LSP on-type formatting
 vim.lsp.on_type_formatting.enable()
 
--- require("mason").setup()
--- require("mason-lspconfig").setup({
---   -- ensure_installed = { "rust_analyzer", "lua_ls", "jsonls" }
--- })
-
+-- Server-specific configurations
 vim.lsp.config("terraformls", {
   settings = {
     ["terraform"] = {
@@ -44,5 +40,10 @@ vim.lsp.config("jsonls", {
     },
   },
 })
+
+-- Enable configured LSP servers
+-- Note: Servers must be installed via Mason (:Mason) before they can be enabled
+vim.lsp.enable("terraformls")
+vim.lsp.enable("jsonls")
 
 vim.keymap.set({ "n", "x" }, "<leader>a", '<cmd>lua require("fastaction").code_action()<CR>', { buffer = bufnr })

--- a/private_dot_config/nvim/lua/plugins/mason.lua
+++ b/private_dot_config/nvim/lua/plugins/mason.lua
@@ -25,23 +25,16 @@ return {
     event = "VeryLazy",
   },
   {
-    "williamboman/mason-lspconfig.nvim",
-    opts = {},
+    "SmiteshP/nvim-navbuddy",
+    dependencies = {
+      "SmiteshP/nvim-navic",
+      "MunifTanjim/nui.nvim",
+    },
+    opts = { lsp = { auto_attach = true } },
     event = "VeryLazy",
   },
   {
-    "neovim/nvim-lspconfig",
-    dependencies = {
-      {
-        "SmiteshP/nvim-navbuddy",
-        dependencies = {
-          "SmiteshP/nvim-navic",
-          "MunifTanjim/nui.nvim",
-        },
-        opts = { lsp = { auto_attach = true } },
-      },
-      "b0o/schemastore.nvim",
-    },
-    -- your lsp config or other stuff
+    "b0o/schemastore.nvim",
+    event = "VeryLazy",
   },
 }


### PR DESCRIPTION
Simplifies the LSP configuration by removing unnecessary plugins and using Neovim 0.11's built-in LSP APIs.

### Changes
- Remove nvim-lspconfig plugin (replaced by native vim.lsp.config)
- Remove mason-lspconfig.nvim (no longer needed)
- Add vim.lsp.enable() calls to complete migration
- Move navbuddy and schemastore to top-level plugins
- Clean up commented Mason setup code
- Update documentation to reflect new architecture

This leverages Neovim 0.11's built-in LSP configuration system, making the setup cleaner and removing unnecessary plugin dependencies.

Fixes #26

---

Generated with [Claude Code](https://claude.ai/code)