### PR TITLE
Evaluate and Replace Current Markup

### DIFF
--- a/private_dot_config/nvim/lua/exact_plugins/opencode.lua
+++ b/private_dot_config/nvim/lua/exact_plugins/opencode.lua
@@ -4,14 +4,7 @@ return {
     opts = {},
     dependencies = {
       "nvim-lua/plenary.nvim",
-      {
-        "MeanderingProgrammer/render-markdown.nvim",
-        opts = {
-          anti_conceal = { enabled = false },
-          file_types = { "markdown", "opencode_output" },
-        },
-        ft = { "markdown", "Avante", "copilot-chat", "opencode_output" },
-      },
+      "MeanderingProgrammer/render-markdown.nvim", -- Configured in render-markdown.lua
       -- Optional, for file mentions and commands completion, pick only one
       "saghen/blink.cmp",
       -- Optional, for file mentions picker, pick only one

--- a/private_dot_config/nvim/lua/exact_plugins/render-markdown.lua
+++ b/private_dot_config/nvim/lua/exact_plugins/render-markdown.lua
@@ -1,0 +1,25 @@
+return {
+  {
+    "MeanderingProgrammer/render-markdown.nvim",
+    ft = { "markdown", "Avante", "copilot-chat", "opencode_output" },
+    dependencies = {
+      "nvim-treesitter/nvim-treesitter",
+    },
+    opts = {
+      preset = "obsidian", -- Optimized for obsidian.nvim integration
+      render_modes = { "n", "c" }, -- Render in normal and command modes
+      anti_conceal = {
+        enabled = true, -- Hide virtual text on cursor line for better editing
+      },
+      heading = {
+        width = "block",
+        border = true,
+      },
+      code = {
+        width = "block",
+        border = "thin",
+      },
+      file_types = { "markdown", "opencode_output" },
+    },
+  },
+}


### PR DESCRIPTION
Extract render-markdown.nvim from opencode.nvim dependencies into its own plugin configuration file for better visibility and maintainability.

Changes:
- Create standalone render-markdown.lua with enhanced configuration
- Enable 'obsidian' preset for optimal obsidian.nvim integration
- Enable anti_conceal for better editing experience (hides virtual text on cursor line)
- Add visual enhancements: block-width headings/code, borders
- Update opencode.lua to reference standalone plugin

Benefits:
- Clearer plugin organization and configuration
- Optimized for existing obsidian.nvim workflow
- Enhanced markdown viewing with proper editability
- Better performance with render_modes configuration