### PR TITLE
Analyze and Review Neovim Configuration

### DIFF
--- a/private_dot_config/nvim/lua/core/lsp.lua
+++ b/private_dot_config/nvim/lua/core/lsp.lua
@@ -52,10 +52,25 @@ vim.lsp.config("jsonls", {
   },
 })
 
+-- Configure Arduino Language Server
+-- Requires: arduino-cli and arduino-language-server installed via Mason
+vim.lsp.config("arduino_language_server", {
+  cmd = {
+    "arduino-language-server",
+    "-cli-config", vim.fn.expand("~/.arduino15/arduino-cli.yaml"),
+    "-fqbn", "arduino:avr:uno", -- Default FQBN, can be overridden per project
+    "-cli", "arduino-cli",
+    "-clangd", "clangd",
+  },
+  filetypes = { "arduino", "ino" },
+  root_markers = { "*.ino" },
+})
+
 -- Enable configured LSP servers
 -- Note: Servers must be installed via Mason (:Mason) before they can be enabled
 vim.lsp.enable("terraformls")
 vim.lsp.enable("jsonls")
+vim.lsp.enable("arduino_language_server")
 
 -- Additional LSP server examples (uncomment and configure as needed):
 --

--- a/private_dot_config/nvim/lua/exact_plugins/arduino.lua
+++ b/private_dot_config/nvim/lua/exact_plugins/arduino.lua
@@ -1,5 +1,20 @@
+-- Arduino Language Server Protocol support
+-- Install: arduino-cli config init && arduino-cli core install arduino:avr
+-- Install LSP: go install github.com/arduino/arduino-language-server@latest
+-- Or via Mason: :MasonInstall arduino-language-server
 return {
+  -- LSP configuration for Arduino is handled in core/lsp.lua
+  -- Mason will handle installation of arduino-language-server
+  -- The LSP will auto-attach to .ino files
+
+  -- Optional: Install arduino-language-server via Mason automatically
+  -- This ensures the LSP is available without manual installation
   {
-    "stevearc/vim-arduino",
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = opts.ensure_installed or {}
+      table.insert(opts.ensure_installed, "arduino_language_server")
+    end,
   },
 }

--- a/private_dot_config/nvim/lua/exact_plugins/init.lua
+++ b/private_dot_config/nvim/lua/exact_plugins/init.lua
@@ -67,7 +67,6 @@ return {
   --     --Config goes here
   --   },
   -- }
-  "stevearc/vim-arduino",
   -- {
   --   "nvimtools/none-ls.nvim",
   --   dependencies = {

--- a/private_dot_config/nvim/lua/exact_plugins/mason.lua
+++ b/private_dot_config/nvim/lua/exact_plugins/mason.lua
@@ -25,7 +25,7 @@ return {
     event = "VeryLazy",
   },
   {
-    "SmiteshP/nvim-navbuddy",
+    "hasansujon786/nvim-navbuddy",
     dependencies = {
       "SmiteshP/nvim-navic",
       "MunifTanjim/nui.nvim",

--- a/private_dot_config/nvim/lua/exact_plugins/neotest.lua
+++ b/private_dot_config/nvim/lua/exact_plugins/neotest.lua
@@ -4,7 +4,6 @@ return {
     dependencies = {
       "nvim-neotest/nvim-nio",
       "nvim-lua/plenary.nvim",
-      "antoinemadec/FixCursorHold.nvim",
       "nvim-treesitter/nvim-treesitter",
     },
     -- You can add configuration options for neotest here later if needed,


### PR DESCRIPTION
- Remove FixCursorHold.nvim (deprecated since Neovim 0.8.0+)
- Update nvim-navbuddy to new maintainer (hasansujon786/nvim-navbuddy)
- Replace vim-arduino with arduino-language-server LSP configuration
- Add Mason auto-installation for arduino-language-server

The Arduino setup now uses proper LSP integration instead of the unmaintained vim-arduino plugin, providing better IDE features like autocomplete, diagnostics, and go-to-definition for .ino files.