### PR TITLE
Prevent main branch reset in Claude git agent

### DIFF
--- a/exact_dot_claude/skills/git-branch-pr-workflow/SKILL.md
+++ b/exact_dot_claude/skills/git-branch-pr-workflow/SKILL.md
@@ -301,12 +301,25 @@ git reset --hard origin/feat/branch-name
 
 ### Accidentally Committed to Main
 
+Use the safe, non-destructive approach that preserves all commits:
+
 ```bash
-# Move commit to new branch
-git branch feat/accidental-commit
-git reset --hard HEAD~1
-git switch feat/accidental-commit
+# Create branch from current state (includes the commits)
+git switch -c feat/accidental-commit
+
+# Push the branch
+git push -u origin feat/accidental-commit
+
+# When the PR is merged to main on GitHub, sync local main:
+git switch main
+git pull  # Fast-forward merge handles this cleanly
 ```
+
+**Why this approach works:**
+- Preserves all commits without risky resets
+- When GitHub merges the PR to main, your local main becomes behind by the same commits
+- `git pull` recognizes the commits and fast-forwards cleanly
+- No history rewriting, no data loss, no merge conflicts
 
 ### Rebase Conflicts Are Too Complex
 


### PR DESCRIPTION
Replace the "Accidentally Committed to Main" guidance that used git reset --hard with a non-destructive approach:
- Create branch from current state with git switch -c
- Push the branch for PR
- When merged, git pull handles fast-forward cleanly

This prevents data loss and avoids unnecessary history rewriting. The commits are preserved and GitHub merge + local pull work together without conflicts.