### PR TITLE
Set up dotfiles container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,20 +1,30 @@
-# Ignore all submodules so my local files don't interfere with docker tests and vice-versa
-#
-# The following commands can be used to sync the list of submodules to
-# dockerignore and deduplicate them
-# git submodule | awk '{ print "/"$2 }' >> .dockerignore
-# awk '!seen[$0]++' .dockerignore > temp && mv temp .dockerignore
-/i3/i3blocks-contrib
-/meta/dotbot
-/node/node-build
-/node/nodenv
-/node/nodenv-default-packages
-/python/pyenv
-/ruby/rbenv
-/ruby/ruby-build
-/tmux/tmux-themepack
-/vim/vim-plug
-/zsh/fzf-tab
-/zsh/oh-my-zsh
-/zsh/zsh-autosuggestions
-/zsh/zsh-syntax-highlighting
+# Exclude files that shouldn't be in the Docker build context
+# for testing chezmoi dotfiles
+
+# Git and version control
+.git/
+.gitignore
+.gitattributes
+
+# Claude Code runtime directories (these are preserved via .chezmoiignore)
+.claude/projects/
+.claude/session-env/
+.claude/shell-snapshots/
+
+# CI/CD
+.github/
+
+# Secret and local files
+.env
+.api_tokens
+*.key
+*.pem
+
+# Editor and IDE
+.vscode/
+.idea/
+
+# Test and build artifacts
+*.log
+*.tmp
+.DS_Store

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,148 @@
+# Docker Testing Environment
+
+This directory contains a Docker-based testing environment for validating chezmoi dotfiles installation in a clean Alpine Linux container.
+
+## Quick Start
+
+```bash
+# Build and run interactive shell
+./docker-test.sh run
+
+# Quick verification test
+./docker-test.sh test
+
+# Clean up everything
+./docker-test.sh clean
+```
+
+## Manual Docker Commands
+
+```bash
+# Build the container
+docker compose build
+
+# Run interactive shell
+docker compose run --rm dotfiles
+
+# Run specific command
+docker compose run --rm dotfiles fish -c "chezmoi verify"
+
+# Clean up
+docker compose down --rmi all
+```
+
+## Container Details
+
+- **Base Image**: Alpine Linux 3
+- **Shell**: Fish (with bash also available)
+- **User**: `tester` (non-root)
+- **Chezmoi**: Latest version from get.chezmoi.io
+- **Working Directory**: `/home/tester`
+
+## What Gets Tested
+
+The Dockerfile performs these steps:
+
+1. Installs fish, git, curl, and age
+2. Installs latest chezmoi
+3. Creates a test user with fish as default shell
+4. Initializes chezmoi from the dotfiles source
+5. Applies all dotfiles with `chezmoi apply -v`
+6. Verifies installation with `chezmoi verify`
+
+## Troubleshooting
+
+### Build fails during chezmoi apply
+
+Check the verbose output to see which file is causing issues. Common problems:
+
+- **Templates requiring data**: Ensure `.chezmoidata.toml` has all required values
+- **Platform-specific files**: Check `.chezmoiignore` excludes unsupported files
+- **External dependencies**: Some configs may require tools not installed in Alpine
+
+### Shell doesn't start
+
+The container defaults to fish shell. If fish installation fails, you can temporarily change `CMD ["/bin/fish"]` to `CMD ["/bin/bash"]` in the Dockerfile.
+
+### Missing tools
+
+The container includes minimal tools. Add additional packages to the `apk add` line in the Dockerfile:
+
+```dockerfile
+RUN apk add --no-cache \
+    bash \
+    fish \
+    git \
+    curl \
+    shadow \
+    age \
+    # Add more tools here
+    neovim \
+    tmux
+```
+
+## CI Integration
+
+This Docker setup can be integrated into CI/CD pipelines:
+
+```yaml
+# .github/workflows/test-dotfiles.yml
+name: Test Dotfiles
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and test dotfiles
+        run: docker compose run --rm dotfiles fish -c "chezmoi verify"
+```
+
+## Advanced Usage
+
+### Persistent Testing
+
+Uncomment the volume section in `docker-compose.yml` to persist the home directory between runs:
+
+```yaml
+volumes:
+  - dotfiles-test-home:/home/tester
+```
+
+### Multi-Platform Testing
+
+Test on different architectures:
+
+```bash
+# Build for ARM64 (e.g., Apple Silicon)
+docker buildx build --platform linux/arm64 -t dotfiles-arm64 .
+
+# Build for AMD64
+docker buildx build --platform linux/amd64 -t dotfiles-amd64 .
+```
+
+### Interactive Development
+
+Start a container and keep it running for iterative testing:
+
+```bash
+docker compose up -d
+docker compose exec dotfiles fish
+# Make changes, test, repeat
+docker compose down
+```
+
+## Limitations
+
+- **Alpine-specific**: Uses Alpine Linux, which may behave differently than Ubuntu/macOS
+- **Minimal tools**: Only essential tools installed by default
+- **No systemd**: Services that require systemd won't work
+- **Templates**: Platform-specific templates may not render correctly on Alpine
+
+## See Also
+
+- [Chezmoi Documentation](https://www.chezmoi.io/)
+- [Alpine Linux Package Search](https://pkgs.alpinelinux.org/)
+- Main dotfiles README: `README.md`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,21 @@
-version: "3.7"
+version: "3.8"
 
 services:
   dotfiles:
     image: laurigates/dotfiles
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: dotfiles-test
+    # Interactive shell for manual testing
+    stdin_open: true
+    tty: true
+    # Optional: Mount a volume for persistent testing
+    # volumes:
+    #   - dotfiles-test-home:/home/tester
+    environment:
+      - TERM=xterm-256color
+
+# Optional: Persistent volume for testing iterations
+# volumes:
+#   dotfiles-test-home:

--- a/docker-test.sh
+++ b/docker-test.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Docker testing helper for chezmoi dotfiles
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+usage() {
+    cat <<EOF
+Usage: $0 <command>
+
+Commands:
+    build       Build the dotfiles container
+    run         Build and run interactive shell
+    test        Build and run chezmoi verify
+    clean       Remove container and image
+    shell       Run shell in existing container
+    logs        Show build logs
+
+Examples:
+    $0 build              # Build the container
+    $0 run                # Build and start interactive fish shell
+    $0 test               # Quick verification test
+    $0 clean              # Clean up everything
+
+EOF
+}
+
+build() {
+    echo "🔨 Building dotfiles container..."
+    docker compose build
+}
+
+run_interactive() {
+    echo "🚀 Starting interactive dotfiles container..."
+    build
+    docker compose run --rm dotfiles
+}
+
+test_dotfiles() {
+    echo "🧪 Testing dotfiles installation..."
+    build
+    docker compose run --rm dotfiles fish -c "
+        echo '=== Chezmoi Status ==='
+        chezmoi verify
+        echo ''
+        echo '=== Fish Shell ==='
+        fish --version
+        echo ''
+        echo '=== Git Config ==='
+        git config --global --list | head -5 || echo 'No git config found'
+    "
+}
+
+clean() {
+    echo "🧹 Cleaning up containers and images..."
+    docker compose down --rmi all --volumes --remove-orphans
+}
+
+shell() {
+    echo "🐚 Opening shell in dotfiles container..."
+    docker compose exec dotfiles fish
+}
+
+logs() {
+    echo "📋 Showing container logs..."
+    docker compose logs --tail=50 dotfiles
+}
+
+case "${1:-}" in
+    build)
+        build
+        ;;
+    run)
+        run_interactive
+        ;;
+    test)
+        test_dotfiles
+        ;;
+    clean)
+        clean
+        ;;
+    shell)
+        shell
+        ;;
+    logs)
+        logs
+        ;;
+    -h|--help|help)
+        usage
+        ;;
+    *)
+        echo "Error: Unknown command '${1:-}'"
+        echo ""
+        usage
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
The Docker setup was broken after migrating from dotbot to chezmoi. Updated all Docker files to use chezmoi workflow and added helper tools for easier testing.

Changes:
- Dockerfile: Replace dotbot with chezmoi init/apply workflow
- Dockerfile: Switch from zsh to fish shell (aligns with dotfiles)
- Dockerfile: Add age encryption support
- .dockerignore: Remove obsolete dotbot submodule references
- .dockerignore: Add chezmoi-relevant exclusions (.claude/, .github/)
- docker-compose.yml: Add TTY, stdin, and TERM for interactive use
- docker-test.sh: New helper script with build/run/test/clean commands
- DOCKER.md: Complete documentation with troubleshooting and CI examples

Testing:
./docker-test.sh test  # Validates chezmoi apply and verify
./docker-test.sh run   # Interactive fish shell for exploration