### PR TITLE
Create CLAUDE.md documentation files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ alias ca-claude='chezmoi apply -v ~/.claude'
 ```
 
 ### Claude Code Skills & Plugins
-This repository includes **Skills** (33 total) - automatically discovered capabilities that Claude uses based on context:
+This repository includes **Skills** (63 total) - automatically discovered capabilities that Claude uses based on context:
 
 **Core Development Tools:**
 - **Chezmoi Expert** - Comprehensive chezmoi guidance (file management, templates, cross-platform configs)
@@ -194,6 +194,30 @@ pre-commit run detect-secrets --all-files         # Run via pre-commit
 - `Brewfile` - Homebrew package definitions (bootstrap and system tools)
 - `dot_default-*-packages` - Legacy tool package lists (cargo, npm)
 - `.chezmoidata.toml` - Data for chezmoi templates (includes uv_tools during migration)
+
+## Detailed Documentation
+
+For detailed information about specific subdirectories, see the following CLAUDE.md files:
+
+### Claude Code Infrastructure
+- **`.claude/CLAUDE.md`** - High-level design principles, delegation strategy, and operational mandates for Claude Code
+- **`.claude/commands/CLAUDE.md`** - Comprehensive guide to slash commands, namespaces, and command creation
+- **`.claude/skills/CLAUDE.md`** - Skills system documentation, all 63 skills categorized by domain
+
+### Configuration & Scripts
+- **`private_dot_config/CLAUDE.md`** - Application configuration management with chezmoi naming conventions and cross-platform templating
+- **`scripts/CLAUDE.md`** - Maintenance scripts for Claude CLI completions, command migrations, and automation
+
+### Quick Reference
+
+| Topic | Documentation | Key Information |
+|-------|---------------|-----------------|
+| **Overall guidance** | `CLAUDE.md` (this file) | Repository overview, tools, security |
+| **Claude Code design** | `.claude/CLAUDE.md` | Delegation strategy, development principles |
+| **Slash commands** | `.claude/commands/CLAUDE.md` | 13 namespaces, command creation guide |
+| **Skills catalog** | `.claude/skills/CLAUDE.md` | 63 skills across 9 categories |
+| **Configuration files** | `private_dot_config/CLAUDE.md` | Chezmoi naming, templates, cross-platform |
+| **Maintenance scripts** | `scripts/CLAUDE.md` | CLI completions, command migration |
 
 ## Cross-Platform Support
 

--- a/exact_dot_claude/commands/CLAUDE.md
+++ b/exact_dot_claude/commands/CLAUDE.md
@@ -1,0 +1,475 @@
+# CLAUDE.md - Slash Commands
+
+User-defined slash commands that extend Claude Code with custom workflows and automation.
+
+## What are Slash Commands?
+
+Slash commands are markdown files that expand into prompts when invoked with the `/` prefix. They provide:
+
+- **Reusable workflows** - Complex multi-step procedures in a single command
+- **Standardized processes** - Consistent approach to common tasks
+- **Context-aware automation** - Commands can reference project state and structure
+- **Composable operations** - Combine multiple tools and actions
+
+## Directory Structure
+
+Commands are organized by namespace for clarity and discoverability:
+
+```
+.claude/commands/
+├── blueprint-*.md           # Blueprint Development methodology (root-level)
+├── project-*.md             # Project-wide operations (root-level)
+├── refactor.md              # Legacy refactor command (root-level)
+├── code/                    # Code quality and review
+├── config/                  # Configuration management
+├── deploy/                  # Deployment operations
+├── deps/                    # Dependency management
+├── docs/                    # Documentation generation
+├── git/                     # Git and GitHub operations
+├── lint/                    # Linting and code quality checks
+├── project/                 # Project setup and maintenance
+├── sync/                    # Synchronization tasks
+├── test/                    # Testing infrastructure
+├── tools/                   # Tool initialization
+└── workflow/                # Development workflows
+```
+
+## Namespace Reference
+
+### Root-Level Commands (Uncategorized)
+
+| Command | Purpose | Usage |
+|---------|---------|-------|
+| `/blueprint-init` | Initialize Blueprint Development structure | Setting up new Blueprint project |
+| `/blueprint-generate-commands` | Generate commands from PRDs | Creating workflow commands from requirements |
+| `/blueprint-generate-skills` | Generate skills from PRDs | Creating project-specific skills |
+| `/blueprint-work-order` | Create minimal work-order for subagent | Isolated task execution |
+| `/project-continue` | Analyze project state and continue development | Resuming work after interruption |
+| `/project-test-loop` | Run test → fix → refactor TDD loop | Test-driven development workflow |
+| `/refactor` | Refactor code selection for quality | Legacy refactor command |
+
+### `code:` - Code Quality and Review
+
+| Command | Purpose | Usage |
+|---------|---------|-------|
+| `/code:review` | Comprehensive code review with fixes | Quality analysis, security, performance |
+| `/code:refactor` | Refactor following SOLID principles | Improving code quality and design |
+
+### `config:` - Configuration Management
+
+| Command | Purpose | Usage |
+|---------|---------|-------|
+| `/config:assimilate` | Analyze and assimilate project configs | Understanding unfamiliar project setups |
+| `/config:audit` | Audit subagent configurations | Validating completeness and security |
+
+### `deploy:` - Deployment Operations
+
+| Command | Purpose | Usage |
+|---------|---------|-------|
+| `/deploy:release` | Create and publish a release | Semantic versioning, changelog, tagging |
+| `/deploy:handoff` | Generate deployment handoff docs | Production deployment documentation |
+
+### `deps:` - Dependency Management
+
+| Command | Purpose | Usage |
+|---------|---------|-------|
+| `/deps:install` | Universal dependency installer | Auto-detects package manager (npm, pip, cargo, etc.) |
+
+### `docs:` - Documentation Generation
+
+| Command | Purpose | Usage |
+|---------|---------|-------|
+| `/docs:generate` | Update docs from code annotations | API references, README, changelog |
+| `/docs:build` | Set up documentation build system | Sphinx, MkDocs, Docusaurus, GitHub Pages |
+| `/docs:decommission` | Generate service decommission docs | Service shutdown documentation |
+| `/docs:knowledge-graph` | Build knowledge graph from Obsidian vault | Comprehensive documentation analysis |
+
+### `git:` - Git and GitHub Operations
+
+| Command | Purpose | Usage |
+|---------|---------|-------|
+| `/git:commit` | Complete workflow from changes to PR | Analyze, commit, push, create PR |
+| `/git:maintain` | Repository maintenance and cleanup | Prune, GC, verify, branch cleanup |
+| `/git:issues` | Process multiple GitHub issues | Bulk issue processing |
+| `/git:issue` | Process single GitHub issue with TDD | Fix issue with test-driven workflow |
+| `/git:fix-pr` | Analyze and fix failing PR checks | CI/CD failure resolution |
+
+### `lint:` - Linting and Code Quality
+
+| Command | Purpose | Usage |
+|---------|---------|-------|
+| `/lint:check` | Universal linter auto-detection | Run appropriate linting tools |
+
+### `project:` - Project Setup and Maintenance
+
+| Command | Purpose | Usage |
+|---------|---------|-------|
+| `/project:new` | Initialize new project with dev environment | Python, Node, Go, generic setup |
+| `/project:init` | Base project initialization | Foundation for language-specific setup |
+| `/project:modernize` | Modernize to current standards | Security, 12-factor, best practices |
+| `/project:modernize-exp` | Experimental modernization | Latest tooling (Python, Node) |
+
+### `sync:` - Synchronization Tasks
+
+| Command | Purpose | Usage |
+|---------|---------|-------|
+| `/sync:github-podio` | Bidirectional GitHub-Podio sync | Project management integration |
+| `/sync:daily` | Daily catch-up aggregation | ADHD-friendly Obsidian summary |
+
+### `test:` - Testing Infrastructure
+
+| Command | Purpose | Usage |
+|---------|---------|-------|
+| `/test:run` | Universal test runner auto-detection | Run appropriate testing framework |
+| `/test:setup` | Configure comprehensive testing infrastructure | Coverage, CI/CD integration |
+
+### `tools:` - Tool Initialization
+
+| Command | Purpose | Usage |
+|---------|---------|-------|
+| `/tools:vectorcode` | Initialize VectorCode with auto-config | Semantic code search setup |
+
+### `workflow:` - Development Workflows
+
+| Command | Purpose | Usage |
+|---------|---------|-------|
+| `/workflow:dev` | Automated development loop with TDD | Issue creation, test-driven development |
+| `/workflow:dev-zen` | AI-powered development with Zen MCP | Enhanced development loop |
+
+## Command Anatomy
+
+### Basic Structure
+
+```markdown
+---
+description: Brief description shown in command list
+---
+
+# Command Title
+
+Detailed instructions for Claude Code to follow when executing this command.
+
+## Context
+
+Describe when and why to use this command.
+
+## Steps
+
+1. First action to take
+2. Second action to take
+3. ...
+
+## Expected Outcome
+
+What should result from running this command.
+```
+
+### Frontmatter
+
+Commands support YAML frontmatter for metadata:
+
+```yaml
+---
+description: Short description (required)
+tags: [optional, categorization, tags]
+requires: [tools, dependencies, prerequisites]
+---
+```
+
+### Parameter Placeholders
+
+Commands can accept parameters:
+
+```markdown
+# /code:review [PATH]
+
+Review code at the specified PATH.
+If PATH is omitted, review current directory.
+```
+
+Parameters are referenced with:
+- `[PARAM]` - Optional parameter
+- `<PARAM>` - Required parameter
+- `[--flag]` - Optional flag
+
+### Command Composition
+
+Commands can invoke other commands or tools:
+
+```markdown
+## Steps
+
+1. Run `/git:commit --no-push` to commit changes
+2. Use the `code-review` agent to analyze changes
+3. Run `/test:run --coverage` to verify tests pass
+4. Create PR with `/git:commit --pr`
+```
+
+## Creating New Commands
+
+### Step 1: Choose Namespace
+
+Determine the appropriate namespace:
+- **code** - Code quality, review, refactoring
+- **config** - Configuration management, settings
+- **deploy** - Deployment, releases, handoff
+- **docs** - Documentation generation
+- **git** - Git operations, GitHub integration
+- **project** - Project setup, maintenance
+- **test** - Testing infrastructure
+- **workflow** - Development automation
+
+If no namespace fits, create as root-level command.
+
+### Step 2: Create Command File
+
+```bash
+# For namespaced command
+cd ~/.local/share/chezmoi/.claude/commands/namespace
+vim new-command.md
+
+# For root-level command
+cd ~/.local/share/chezmoi/.claude/commands
+vim new-command.md
+```
+
+### Step 3: Write Command Content
+
+Use this template:
+
+```markdown
+---
+description: Clear, concise description (50 chars max)
+---
+
+# /namespace:new-command [ARGS]
+
+Detailed explanation of what this command does and when to use it.
+
+## Usage
+
+\`\`\`bash
+/namespace:new-command [optional-arg] <required-arg>
+\`\`\`
+
+## Parameters
+
+- `[optional-arg]` - Description of optional parameter
+- `<required-arg>` - Description of required parameter
+
+## Context
+
+When should Claude use this command? What problem does it solve?
+
+## Prerequisites
+
+- Required tools or dependencies
+- Expected project state
+- Necessary permissions
+
+## Steps
+
+1. **Step 1** - First action to take
+   - Sub-action detail
+   - Expected outcome
+
+2. **Step 2** - Second action to take
+   - Sub-action detail
+   - Expected outcome
+
+3. **Step 3** - Final action
+   - Verification steps
+   - Success criteria
+
+## Output
+
+Describe what Claude should produce or report back to the user.
+
+## Example
+
+\`\`\`bash
+# Example invocation
+/namespace:new-command example-arg
+
+# Expected output or behavior
+...
+\`\`\`
+
+## Error Handling
+
+- **Error condition 1** - How to handle or recover
+- **Error condition 2** - Alternative approach
+
+## See Also
+
+- Related commands: `/related:command1`, `/related:command2`
+- Relevant skills: `skill-name`
+- Documentation: `docs/reference.md`
+```
+
+### Step 4: Test Command
+
+Since `.claude/` is symlinked, commands are immediately available:
+
+```bash
+# In Claude Code session
+/namespace:new-command test-arg
+```
+
+No `chezmoi apply` needed for `.claude/` changes!
+
+### Step 5: Document and Commit
+
+Update this CLAUDE.md with the new command, then commit:
+
+```bash
+git add .claude/commands/namespace/new-command.md
+git add .claude/commands/CLAUDE.md
+git commit -m "feat(commands): add /namespace:new-command"
+```
+
+## Modifying Existing Commands
+
+### Edit in Source
+
+```bash
+cd ~/.local/share/chezmoi/.claude/commands
+vim namespace/command.md
+```
+
+### Test Changes
+
+Since `.claude/` is symlinked, changes are immediately active. Test in Claude Code.
+
+### Commit Changes
+
+```bash
+git add .claude/commands/namespace/command.md
+git commit -m "fix(commands): improve /namespace:command error handling"
+```
+
+## Command Naming Conventions
+
+### Naming Rules
+
+1. **Use kebab-case:** `multi-word-command.md` (not `MultiWordCommand.md`)
+2. **Be descriptive:** `fix-pr.md` better than `fix.md`
+3. **Avoid redundant namespace:** `git/commit.md` not `git/git-commit.md`
+4. **Use verbs:** `review.md`, `deploy.md`, `generate.md`
+
+### Invocation Format
+
+Commands are invoked with namespace prefix:
+
+```bash
+# Namespaced command
+/namespace:command
+
+# Root-level command
+/command
+
+# With parameters
+/namespace:command arg1 --flag arg2
+```
+
+### Legacy Commands
+
+Some commands remain at root level for backward compatibility:
+- `/blueprint-*` - Blueprint Development methodology
+- `/project-continue` - Project state analysis
+- `/project-test-loop` - TDD loop
+- `/refactor` - Legacy refactor (prefer `/code:refactor`)
+
+## Best Practices
+
+### Command Design
+
+1. **Single Responsibility** - Each command does one thing well
+2. **Composable** - Commands can invoke other commands
+3. **Idempotent** - Safe to run multiple times
+4. **Fail Fast** - Validate prerequisites early
+5. **Clear Output** - Describe what was done and next steps
+
+### Documentation
+
+1. **Clear description** - User sees this in command list
+2. **Usage examples** - Show common invocations
+3. **Prerequisites** - State dependencies upfront
+4. **Error handling** - Guide recovery from failures
+5. **Cross-references** - Link to related commands/skills
+
+### Testing
+
+1. **Test in isolation** - Run command standalone
+2. **Test with parameters** - Verify argument handling
+3. **Test error cases** - Ensure graceful failure
+4. **Test composition** - Verify command chaining works
+
+## Maintenance Scripts
+
+Located in `scripts/`:
+
+- **`migrate-command-namespaces.sh`** - Reorganize commands into namespaces
+- **`update-command-references.sh`** - Update documentation references after migration
+
+See `scripts/CLAUDE.md` for detailed usage.
+
+## Integration with Skills
+
+Commands often work with skills:
+
+| Command | Invokes Skill | Purpose |
+|---------|---------------|---------|
+| `/git:commit` | `git-commit-workflow` | Conventional commits, staging |
+| `/git:fix-pr` | `github-actions-inspection` | Analyze workflow failures |
+| `/code:review` | `code-review` | Quality analysis |
+| `/code:refactor` | `code-refactoring` | SOLID principles |
+| `/test:run` | Language-specific testing skills | Framework detection |
+
+Skills are auto-discovered and invoked based on context. Commands explicitly request skill usage.
+
+## Troubleshooting
+
+### Command Not Found
+
+**Symptom:** `/namespace:command` shows "command not found"
+
+**Solutions:**
+1. Verify file exists: `ls ~/.claude/commands/namespace/command.md`
+2. Check symlink: `ls -la ~/.claude` should point to chezmoi source
+3. Restart Claude Code session
+
+### Command Not Executing Correctly
+
+**Symptom:** Command runs but doesn't follow instructions
+
+**Solutions:**
+1. Review command markdown for clarity
+2. Ensure steps are unambiguous and actionable
+3. Add more context or prerequisites
+4. Test with simpler example first
+
+### Parameters Not Recognized
+
+**Symptom:** Command ignores provided arguments
+
+**Solutions:**
+1. Check parameter syntax in command markdown
+2. Verify placeholder format: `[optional]` or `<required>`
+3. Document parameter usage in command description
+
+### Namespace Migration Issues
+
+**Symptom:** Old command references still work but new namespace doesn't
+
+**Solutions:**
+1. Run `/scripts/update-command-references.sh` to update docs
+2. Check for duplicate command files at old and new locations
+3. Remove old command files after migration
+
+## See Also
+
+- **Root CLAUDE.md** - Overall repository guidance
+- **`.claude/CLAUDE.md`** - High-level design and delegation strategy
+- **`.claude/skills/CLAUDE.md`** - Skills system documentation
+- **`scripts/CLAUDE.md`** - Maintenance scripts for command management

--- a/exact_dot_claude/skills/CLAUDE.md
+++ b/exact_dot_claude/skills/CLAUDE.md
@@ -13,9 +13,9 @@ Skills are **model-invoked** capabilities. Claude autonomously decides when to u
 
 ## Skills in This Repository
 
-This repository contains **33 specialized skills** organized by domain:
+This repository contains **63 specialized skills** organized by domain:
 
-### Core Development Tools (8 skills)
+### Core Development Tools (9 skills)
 - **chezmoi-expert** - Comprehensive chezmoi guidance (templates, cross-platform configs, file naming)
 - **shell-expert** - Shell scripting, CLI tools, automation, cross-platform scripting
 - **fd-file-finding** - Fast file search with smart defaults and gitignore awareness
@@ -24,12 +24,14 @@ This repository contains **33 specialized skills** organized by domain:
 - **yq-yaml-processing** - YAML querying, filtering, and transformation with yq (v4+) command-line tool
 - **ast-grep-search** - AST-based code search for structural pattern matching
 - **vectorcode-search** - Semantic code search using embeddings for concept-based discovery
+- **vectorcode-init** - Initialize VectorCode with automatic configuration generation
 
-### Version Control & Release (5 skills)
+### Version Control & Release (6 skills)
 - **git-branch-pr-workflow** - Branch management, pull request workflows, and GitHub integration
 - **git-commit-workflow** - Commit message conventions, staging, and commit best practices
 - **git-security-checks** - Pre-commit security validation and secret detection
 - **git-repo-detection** - Extract GitHub repository owner/name from git remotes
+- **github-issue-search** - Search and filter GitHub issues efficiently
 - **release-please-protection** - Prevents manual edits to automated release files
 
 ### GitHub Actions Integration (4 skills)
@@ -38,28 +40,66 @@ This repository contains **33 specialized skills** organized by domain:
 - **github-actions-auth-security** - Authentication methods, secrets management, security best practices
 - **github-actions-inspection** - Inspect workflow runs, analyze logs, debug CI/CD failures
 
-### Programming Languages (4 skills)
-- **python-development** - Modern Python with uv, ruff, pytest, type hints
-- **rust-development** - Memory-safe systems programming with cargo and modern tooling
+### Python Development (9 skills)
+- **python-development** - Core Python concepts, idioms, and best practices
+- **python-testing** - pytest, fixtures, parametrization, test organization
+- **python-code-quality** - Linting, formatting, type checking, code analysis
+- **python-packaging** - Package creation, distribution, publishing to PyPI
+- **uv-project-management** - Modern Python project management with uv
+- **uv-python-versions** - Python version management with uv
+- **uv-tool-management** - CLI tool installation and management with uv
+- **uv-workspaces** - Monorepo and workspace management with uv
+- **uv-advanced-dependencies** - Advanced dependency resolution with uv
+
+### TypeScript/JavaScript Development (3 skills)
 - **nodejs-development** - JavaScript/TypeScript with Bun, Vite, Vue 3, Pinia
+- **vitest-testing** - Modern TypeScript/JavaScript testing with Vitest
+- **bun-lockfile-update** - Manage Bun lockfile updates and version pinning
+
+### Other Languages (3 skills)
+- **rust-development** - Memory-safe systems programming with cargo and modern tooling
 - **cpp-development** - Modern C++20/23 with CMake, Conan, Clang tools
+- **embedded-systems** - ESP32/ESP-IDF, STM32, FreeRTOS, real-time systems
 
 ### Editor & Configuration (1 skill)
 - **neovim-configuration** - Lua configuration, plugin management, LSP setup, AI integration
 
-### Infrastructure & DevOps (4 skills)
+### Infrastructure & DevOps (10 skills)
 - **container-development** - Docker, multi-stage builds, 12-factor apps, Skaffold
 - **kubernetes-operations** - K8s cluster management, debugging, kubectl mastery
 - **infrastructure-terraform** - Infrastructure as Code with HCL and state management
-- **embedded-systems** - ESP32/ESP-IDF, STM32, FreeRTOS, real-time systems
+- **helm-chart-development** - Helm chart creation, templating, best practices
+- **helm-debugging** - Debug Helm deployments and template rendering
+- **helm-release-management** - Manage Helm releases and upgrades
+- **helm-release-recovery** - Recover from failed Helm releases
+- **helm-values-management** - Manage Helm values files and overrides
+- **argocd-login** - ArgoCD authentication and CLI login workflows
 
-### Meta Skills (3 skills)
-- **agent-context-management** - Managing context and delegation in multi-agent workflows
+### Testing & Quality (4 skills)
+- **api-testing** - HTTP API testing for TypeScript and Python (Supertest, httpx)
+- **playwright-testing** - End-to-end testing with Playwright (cross-browser, visual regression)
+- **mutation-testing** - Validate test effectiveness with Stryker and mutmut
+- **property-based-testing** - Property-based testing with fast-check and Hypothesis
+- **test-quality-analysis** - Detect test smells, overmocking, flaky tests
+
+### Code Quality & Formatting (3 skills)
+- **ruff-linting** - Python code quality with ruff linter
+- **ruff-formatting** - Python code formatting with ruff format
+- **ruff-integration** - Integrate ruff with editors, pre-commit, and CI/CD
+
+### Meta & Coordination (6 skills)
+- **agent-coordination-patterns** - Patterns for multi-agent task coordination
+- **agent-file-coordination** - File-based coordination between agents
 - **multi-agent-workflows** - Coordinating complex tasks across specialized agents
-- **knowledge-graph-patterns** - Structuring and querying knowledge graphs effectively
+- **blueprint-development** - PRD-first development methodology and skill generation
+- **project-discovery** - Systematic project orientation for unfamiliar codebases
+- **graphiti-episode-storage** - Episode-based memory storage with Graphiti
+- **graphiti-learning-workflows** - Learning workflows using Graphiti memory
+- **graphiti-memory-retrieval** - Retrieve and query episodic memory with Graphiti
 
-### Communication & Formatting (1 skill)
+### Communication & Formatting (2 skills)
 - **google-chat-formatting** - Convert Markdown to Google Chat formatting syntax
+- **imagemagick-conversion** - Image conversion and manipulation with ImageMagick
 
 ## Skill Structure
 
@@ -252,6 +292,6 @@ Skills in `.claude/skills/` are automatically distributed to all team members wh
 
 ---
 
-**Last updated**: 2025-11-11
-**Total skills**: 33
+**Last updated**: 2025-11-15
+**Total skills**: 63
 **Skill version format**: YAML frontmatter in SKILL.md

--- a/private_dot_config/CLAUDE.md
+++ b/private_dot_config/CLAUDE.md
@@ -1,0 +1,228 @@
+# CLAUDE.md - Configuration Directory
+
+Application configuration files managed by chezmoi with cross-platform support.
+
+## Chezmoi Naming Conventions
+
+This directory uses chezmoi's attribute-based naming system to control file handling:
+
+### Prefix System
+
+| Prefix | Effect | Example | Target |
+|--------|--------|---------|--------|
+| `dot_` | Add `.` prefix | `dot_gitconfig` | `~/.config/.gitconfig` |
+| `private_` | Skip git tracking (local only) | `private_api_keys` | Not committed to repo |
+| `executable_` | Make file executable | `executable_startup.sh` | Executable script |
+| `symlink_` | Create symlink | `symlink_dot_claude.tmpl` | Symlink to source |
+| `readonly_` | Make file read-only | `readonly_config` | Read-only file |
+
+### Combined Prefixes
+
+Multiple prefixes combine their effects:
+- `private_dot_config` → `~/.config/` (private, hidden directory)
+- `private_executable_script.sh` → Private executable script
+- `symlink_dot_claude.tmpl` → Symlink to `~/.claude`
+
+### Template Suffix
+
+Files ending in `.tmpl` are processed as templates:
+- Access variables from `chezmoi.toml.tmpl` data section
+- Platform-specific logic using Go templates
+- Conditional configuration based on OS, architecture, hostname
+
+## Directory Structure
+
+### Editor & Shell
+
+| Directory | Purpose | Key Files |
+|-----------|---------|-----------|
+| **`nvim/`** | Neovim editor configuration | `init.lua`, `lazy-lock.json`, `lua/plugins/` |
+| **`fish/`** | Fish shell configuration | `config.fish`, `functions/`, `completions/` |
+| **`private_fish/`** | Private fish shell configs | Sensitive environment variables |
+
+### Version Control & Tools
+
+| Directory | Purpose | Key Files |
+|-----------|---------|-----------|
+| **`git/`** | Git configuration | `config`, `ignore`, `attributes` |
+| **`chezmoi/`** | Chezmoi-specific config | `chezmoi.toml` (merge behavior, template settings) |
+| **`mise/`** | Tool version manager | `config.toml` (language runtimes, tools) |
+
+### Terminal & UI
+
+| Directory | Purpose | Key Files |
+|-----------|---------|-----------|
+| **`private_kitty/`** | Kitty terminal emulator | `kitty.conf`, themes, keybindings |
+| **`zellij/`** | Terminal multiplexer | `config.kdl`, layouts |
+| **`private_atuin/`** | Shell history manager | `config.toml` (history search, sync) |
+| **`ranger/`** | File manager | `rc.conf`, plugins |
+| **`rofi/`** | Application launcher | Theme, keybindings |
+| **`sketchybar/`** | macOS status bar | Configuration, plugins |
+
+### System & Utilities
+
+| Directory | Purpose | Key Files |
+|-----------|---------|-----------|
+| **`private_dunst/`** | Notification daemon | `dunstrc` (notification rules) |
+| **`private_i3/`** | i3 window manager | `config`, `i3blocks.conf` |
+| **`fd/`** | fd file search config | `ignore` patterns |
+| **`pet/`** | Snippet manager | Snippet storage |
+
+## Making Changes
+
+### Adding New Configuration
+
+1. **Create file in chezmoi source directory:**
+   ```bash
+   cd ~/.local/share/chezmoi/private_dot_config
+   # For public config:
+   mkdir -p newtool
+   vim newtool/config.yml
+
+   # For private config (not committed):
+   mkdir -p private_newtool
+   vim private_newtool/config.yml
+   ```
+
+2. **Preview changes:**
+   ```bash
+   chezmoi diff
+   ```
+
+3. **Apply to target:**
+   ```bash
+   chezmoi apply --dry-run  # Preview
+   chezmoi apply            # Actually apply
+   ```
+
+### Modifying Existing Configuration
+
+1. **Edit in source directory:**
+   ```bash
+   cd ~/.local/share/chezmoi/private_dot_config
+   vim nvim/init.lua
+   ```
+
+2. **Or use chezmoi edit:**
+   ```bash
+   chezmoi edit ~/.config/nvim/init.lua
+   ```
+
+3. **Apply changes:**
+   ```bash
+   chezmoi apply
+   ```
+
+### Using Templates for Cross-Platform Config
+
+Example template for platform-specific paths:
+
+```go-template
+# fish/config.fish.tmpl
+{{ if eq .chezmoi.os "darwin" -}}
+set -gx HOMEBREW_PREFIX /opt/homebrew
+{{ else if eq .chezmoi.os "linux" -}}
+set -gx HOMEBREW_PREFIX /home/linuxbrew/.linuxbrew
+{{ end -}}
+```
+
+Template variables available:
+- `.chezmoi.os` - Operating system (darwin, linux, windows)
+- `.chezmoi.arch` - CPU architecture (amd64, arm64)
+- `.chezmoi.hostname` - Machine hostname
+- Custom variables from `chezmoi.toml.tmpl` data section
+
+## Testing Configuration Changes
+
+### Local Testing
+
+```bash
+# Preview what would change
+chezmoi diff
+
+# Dry-run application
+chezmoi apply --dry-run --verbose
+
+# Apply to specific file
+chezmoi apply ~/.config/nvim/init.lua
+```
+
+### Container Testing
+
+```bash
+# Test configuration in Docker container
+docker-compose run --rm dotfiles-test
+
+# Test specific platform
+docker build --platform linux/amd64 -t dotfiles-test .
+docker run -it dotfiles-test fish
+```
+
+## Tool-Specific Documentation
+
+### Neovim (`nvim/`)
+
+- **Plugin manager:** lazy.nvim
+- **LSP setup:** Mason for language servers
+- **Key structure:** `init.lua` → `lua/plugins/` → individual plugin configs
+- **Modification:** Add new plugins to `lua/plugins/*.lua`, lock with `lazy-lock.json`
+
+### Fish Shell (`fish/`)
+
+- **Functions:** `functions/*.fish` - Auto-loaded on first use
+- **Completions:** `completions/*.fish` - Command completions
+- **Config:** `config.fish` - Main shell configuration
+- **Private config:** `~/.config/private_fish/config.fish` - API keys, tokens
+
+### Git (`git/`)
+
+- **Config:** User settings, aliases, core behavior
+- **Ignore:** Global gitignore patterns
+- **Attributes:** File handling rules (line endings, diffs)
+
+### mise (`mise/`)
+
+- **Purpose:** Manages language runtimes (Node.js, Python, Ruby, Go) and tools
+- **Config:** `config.toml` defines versions per-tool
+- **Activation:** Auto-loads correct versions when entering directories
+
+## Troubleshooting
+
+### Configuration not applying
+
+```bash
+# Check what chezmoi sees
+chezmoi status
+
+# Verify source vs target diff
+chezmoi diff
+
+# Re-apply forcefully
+chezmoi apply --force
+```
+
+### Template errors
+
+```bash
+# Execute templates and show output
+chezmoi execute-template < private_dot_config/fish/config.fish.tmpl
+
+# Check template data
+chezmoi data
+```
+
+### Private files appearing in git
+
+Ensure `private_` prefix is used:
+```bash
+# Rename file to mark as private
+mv ~/.local/share/chezmoi/private_dot_config/tool/config \
+   ~/.local/share/chezmoi/private_dot_config/private_tool/config
+```
+
+## See Also
+
+- **Root CLAUDE.md** - Overall repository guidance
+- **Chezmoi Expert Skill** - Automatic guidance for chezmoi operations
+- **docs/components.md** - Tool overview and integration points
+- **docs/platform_specific.md** - Cross-platform compatibility notes

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -1,0 +1,382 @@
+# CLAUDE.md - Maintenance Scripts
+
+Utility scripts for maintaining and automating Claude Code infrastructure in this dotfiles repository.
+
+## Scripts Overview
+
+| Script | Purpose | When to Use |
+|--------|---------|-------------|
+| **`generate-claude-completion.sh`** | Generate zsh completions for Claude CLI | After Claude CLI updates or when completions are outdated |
+| **`generate-claude-completion-simple.sh`** | Simplified version of completion generator | Fallback if main generator fails; faster but less dynamic |
+| **`migrate-command-namespaces.sh`** | Migrate commands to new namespace structure | During command reorganization or namespace refactoring |
+| **`update-command-references.sh`** | Update documentation references after migration | After running `migrate-command-namespaces.sh` |
+
+## Script Details
+
+### generate-claude-completion.sh
+
+**Purpose:** Automatically generates zsh completion functions for the Claude CLI by parsing `claude --help` output.
+
+**Features:**
+- Parses main commands, subcommands, and options dynamically
+- Generates context-aware completions for `config`, `mcp`, and `install` subcommands
+- Extracts model names, config keys, and MCP server names
+- Validates generated completion syntax
+- Auto-tracks completion file in git if not already tracked
+
+**Output:** `dot_zfunc/_claude` (zsh completion file)
+
+**Usage:**
+```bash
+# Generate completions
+./scripts/generate-claude-completion.sh
+
+# Apply to chezmoi target
+chezmoi apply ~/.zfunc/_claude
+
+# Test completions
+exec zsh
+claude <TAB>
+```
+
+**How it works:**
+1. Checks for Claude CLI availability
+2. Captures help output from `claude --help`, `claude config --help`, etc.
+3. Parses commands and options using AWK
+4. Dynamically discovers models, config keys, and MCP servers
+5. Generates zsh completion functions with proper syntax
+6. Validates with `zsh -n`
+7. Writes to `dot_zfunc/_claude`
+
+**Troubleshooting:**
+- **Error: "Claude CLI not found"** - Ensure `claude` is in your PATH
+- **Syntax errors** - Completion validation failed; check AWK parsing logic
+- **Completions not working** - Run `exec zsh` or `source ~/.zfunc/_claude`
+
+---
+
+### generate-claude-completion-simple.sh
+
+**Purpose:** Simplified, more robust completion generator using straightforward parsing.
+
+**Differences from full generator:**
+- Uses simpler sed/awk parsing (less prone to edge cases)
+- Hardcoded model and config key lists (fallback approach)
+- Faster execution
+- More compatible with older bash versions
+
+**When to use:**
+- Main generator encounters parsing errors
+- Need faster generation during development
+- Working with beta/unstable Claude CLI versions
+
+**Usage:**
+```bash
+./scripts/generate-claude-completion-simple.sh
+```
+
+---
+
+### migrate-command-namespaces.sh
+
+**Purpose:** Refactor Claude Code commands from flat structure to organized namespace hierarchy.
+
+**Features:**
+- Migrates commands to namespace directories (`git/`, `code/`, `project/`, etc.)
+- Renames commands to follow namespace:command pattern
+- Handles associated files (PRD files, related docs)
+- Dry-run mode for safe previewing
+- Tracks migration statistics
+
+**Usage:**
+```bash
+# Preview changes without modifying files
+./scripts/migrate-command-namespaces.sh --dry-run
+
+# Execute migration
+./scripts/migrate-command-namespaces.sh
+
+# Apply changes via chezmoi
+chezmoi diff
+chezmoi apply
+```
+
+**Namespace Structure:**
+| Namespace | Purpose | Example Commands |
+|-----------|---------|------------------|
+| `git:` | Git and GitHub operations | `git:commit`, `git:issues`, `git:fix-pr` |
+| `code:` | Code quality and review | `code:review`, `code:refactor` |
+| `config:` | Configuration management | `config:audit`, `config:assimilate` |
+| `project:` | Project setup and maintenance | `project:new`, `project:modernize` |
+| `test:` | Testing infrastructure | `test:run`, `test:setup` |
+| `docs:` | Documentation generation | `docs:generate`, `docs:build` |
+| `workflow:` | Development workflows | `workflow:dev`, `workflow:dev-zen` |
+| `sync:` | Synchronization tasks | `sync:daily`, `sync:github-podio` |
+| `deploy:` | Deployment operations | `deploy:release`, `deploy:handoff` |
+| `tools:` | Tool initialization | `tools:vectorcode` |
+
+**Migration Process:**
+1. Creates namespace directories if needed
+2. Moves command files to new locations
+3. Renames files to match new namespace pattern
+4. Migrates associated files (PRDs, etc.)
+5. Provides summary statistics
+
+**Example Migration:**
+```
+OLD: .claude/commands/smartcommit.md
+NEW: .claude/commands/git/commit.md
+
+Command reference changes:
+/smartcommit → /git:commit
+```
+
+---
+
+### update-command-references.sh
+
+**Purpose:** Update all markdown documentation to reflect new command namespace references after migration.
+
+**Features:**
+- Scans all markdown files in repository
+- Updates slash command references (`/old-name` → `/namespace:new-name`)
+- Updates file path references (`.claude/commands/old.md` → `.claude/commands/namespace/new.md`)
+- Dry-run mode for previewing changes
+- Shows statistics (files modified, total replacements)
+
+**Usage:**
+```bash
+# Preview changes
+./scripts/update-command-references.sh --dry-run
+
+# Apply updates
+./scripts/update-command-references.sh
+
+# Review and commit
+git diff
+git add .
+git commit -m "refactor: update command namespace references"
+```
+
+**What it updates:**
+- **Slash command references:** `/smartcommit` → `/git:commit`
+- **File path references:** `.claude/commands/smartcommit.md` → `.claude/commands/git/commit.md`
+- **Cross-references in documentation**
+
+**Example output:**
+```
+📄 Finding markdown files...
+  Found 127 markdown files
+
+🔄 Processing files...
+  ✓ CLAUDE.md (4 changes)
+  ✓ .claude/skills/git-commit-workflow/SKILL.md (2 changes)
+  ✓ README.md (1 changes)
+
+═══════════════════════════════════════════════════════════
+  Update Summary
+═══════════════════════════════════════════════════════════
+  Total files scanned:     127
+  Files modified:          23
+  Total replacements:      47
+```
+
+**Compatibility:**
+- Compatible with bash 3.2+ (macOS default)
+- Uses BSD sed syntax (`sed -i ''`)
+- Portable across Linux and macOS
+
+---
+
+## Workflow: Command Migration
+
+When reorganizing Claude Code commands, follow this sequence:
+
+```bash
+# 1. Preview migration
+./scripts/migrate-command-namespaces.sh --dry-run
+
+# 2. Execute migration
+./scripts/migrate-command-namespaces.sh
+
+# 3. Apply to target via chezmoi
+chezmoi apply
+
+# 4. Preview documentation updates
+./scripts/update-command-references.sh --dry-run
+
+# 5. Apply documentation updates
+./scripts/update-command-references.sh
+
+# 6. Review all changes
+git status
+git diff
+
+# 7. Stage and commit
+git add .
+git commit -m "refactor: reorganize commands with namespace structure"
+```
+
+## Workflow: Updating Completions
+
+After Claude CLI updates:
+
+```bash
+# 1. Generate new completions
+./scripts/generate-claude-completion.sh
+
+# 2. Review changes
+chezmoi diff
+
+# 3. Apply to target
+chezmoi apply ~/.zfunc/_claude
+
+# 4. Test in new shell
+exec zsh
+claude <TAB>
+
+# 5. Commit if satisfied
+git add dot_zfunc/_claude
+git commit -m "chore: update Claude CLI completions"
+```
+
+## Best Practices
+
+### Script Modifications
+
+When modifying these scripts:
+
+1. **Always test with dry-run first**
+   ```bash
+   ./scripts/script-name.sh --dry-run
+   ```
+
+2. **Validate bash syntax**
+   ```bash
+   shellcheck scripts/*.sh
+   ```
+
+3. **Test on sample data before production**
+   - Create test directory with sample commands
+   - Run script on test data
+   - Verify expected behavior
+
+### Chezmoi Integration
+
+These scripts modify files in the chezmoi source directory:
+- **Source:** `~/.local/share/chezmoi/`
+- **Target:** `~/` (after `chezmoi apply`)
+
+Always run `chezmoi apply` after script execution to sync changes to target locations.
+
+### Git Workflow
+
+1. **Before running scripts:**
+   ```bash
+   git status  # Ensure clean working directory
+   git diff    # Verify no uncommitted changes
+   ```
+
+2. **After running scripts:**
+   ```bash
+   git status  # Review what changed
+   git diff    # Inspect specific changes
+   git add .   # Stage changes
+   git commit  # Commit with descriptive message
+   ```
+
+## Extending the Scripts
+
+### Adding New Command Namespaces
+
+Edit `migrate-command-namespaces.sh`:
+
+1. Add namespace to `NAMESPACES` array:
+   ```bash
+   declare -a NAMESPACES=(
+       ...
+       "new-namespace"
+   )
+   ```
+
+2. Add migration mappings to `MIGRATIONS` array:
+   ```bash
+   "old-path.md|new-namespace|new-name.md"
+   ```
+
+3. Update `update-command-references.sh` `MAPPINGS` array:
+   ```bash
+   "/old-command|/new-namespace:new-command"
+   ```
+
+### Adding Custom Completions
+
+Edit `generate-claude-completion.sh` or `generate-claude-completion-simple.sh`:
+
+1. Add new helper function:
+   ```bash
+   _claude_custom_completion() {
+       local -a items
+       items=(
+           'item1:Description 1'
+           'item2:Description 2'
+       )
+       _describe -t items 'custom items' items
+   }
+   ```
+
+2. Reference in argument specification:
+   ```bash
+   _arguments \
+       '1:item:_claude_custom_completion'
+   ```
+
+## Troubleshooting
+
+### Script Errors
+
+**"Command not found" errors:**
+- Ensure scripts are executable: `chmod +x scripts/*.sh`
+- Check bash path in shebang: `#!/usr/bin/env bash`
+
+**Permission denied:**
+```bash
+chmod +x scripts/*.sh
+```
+
+**Unexpected behavior:**
+```bash
+# Enable debug mode
+bash -x scripts/script-name.sh
+
+# Check for syntax errors
+shellcheck scripts/script-name.sh
+```
+
+### Chezmoi Issues
+
+**Changes not appearing in target:**
+```bash
+# Force re-apply
+chezmoi apply --force
+
+# Check what chezmoi sees
+chezmoi status
+chezmoi diff
+```
+
+**Files not tracked:**
+```bash
+# Add to git
+git add scripts/*.sh
+
+# Verify tracking
+git ls-files scripts/
+```
+
+## See Also
+
+- **Root CLAUDE.md** - Overall repository guidance
+- **`.claude/CLAUDE.md`** - High-level design and delegation strategy
+- **docs/claude-completion.md** - Detailed completion system documentation
+- **Chezmoi Expert Skill** - Automatic guidance for chezmoi operations


### PR DESCRIPTION
Add detailed documentation for key repository sections:

- private_dot_config/CLAUDE.md: Chezmoi naming conventions, config management, cross-platform templates, tool-specific guides
- scripts/CLAUDE.md: Maintenance scripts documentation (completion generation, command migration, reference updates)
- .claude/commands/CLAUDE.md: Slash commands guide with 13 namespaces, 40+ commands, creation guide, best practices
- .claude/skills/CLAUDE.md: Update skill count from 33 to 63, organize into 9 categories, update last modified date
- CLAUDE.md: Add "Detailed Documentation" section with quick reference table linking all subdirectory docs

Each CLAUDE.md provides comprehensive context for Claude Code to understand repository structure, conventions, and workflows.