### PR TITLE
Add option to install MCP Claude command

### DIFF
--- a/.chezmoidata.toml
+++ b/.chezmoidata.toml
@@ -337,6 +337,15 @@
     description = "Enhanced reasoning with sequential thinking"
     category = "ai"
 
+  [mcp_servers.consult7]
+    enabled = false
+    scope = "project"
+    command = "uvx"
+    args = ["consult7", "${OPENROUTER_API_KEY}"]
+    description = "Consult large context window LLMs via OpenRouter for analyzing extensive codebases"
+    category = "ai"
+    env_vars = ["OPENROUTER_API_KEY"]
+
 [platform]
   # Platform-specific settings will be populated by templates
   cpu_cores = 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,7 @@ All your favorite MCP servers are maintained in `.chezmoidata.toml` (disabled by
 - `playwright` - Browser automation and testing
 - `graphiti-memory` - Graph-based memory and knowledge management
 - `context7` - Upstash context management
+- `consult7` - Consult large context window LLMs via OpenRouter for analyzing extensive codebases
 - `zen-mcp-server` - Zen productivity and focus tools
 - `podio-mcp` - Podio project management integration
 - `argocd-mcp` - ArgoCD GitOps deployment management


### PR DESCRIPTION
Add consult7 MCP server for consulting large context window LLMs via OpenRouter to analyze extensive codebases. Server uses uvx runtime and requires OPENROUTER_API_KEY environment variable.