### PR TITLE
Fix Claude workflows and update to Opus 4.5

### DIFF
--- a/.github/workflows/auto-fix-ci-failures.yml
+++ b/.github/workflows/auto-fix-ci-failures.yml
@@ -184,7 +184,9 @@ jobs:
             **Verification:**
             After making changes, explain what you fixed and why.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--allowed-tools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(bun:*),Bash(npm:*),Bash(npx:*),Bash(gh:*)'"
+          claude_args: |
+            --model claude-opus-4-5-20251101
+            --allowed-tools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(bun:*),Bash(npm:*),Bash(npx:*),Bash(gh:*)"
 
       - name: Push fix branch
         if: steps.claude.outcome == 'success' && steps.claude.outputs.changed == 'true'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -62,4 +62,6 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
-          claude_args: '--allowed-tools "${{ steps.tools-config.outputs.allowed_tools }}"'
+          claude_args: |
+            --model claude-opus-4-5-20251101
+            --allowed-tools "${{ steps.tools-config.outputs.allowed_tools }}"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -107,8 +107,8 @@ jobs:
 
           # Enhanced Claude arguments for workflow integration
           claude_args: |
-            --model claude-sonnet-4-5-20250929
-            --allowedTools "${{ steps.tools-config.outputs.allowed_tools }}"
+            --model claude-opus-4-5-20251101
+            --allowed-tools "${{ steps.tools-config.outputs.allowed_tools }}"
             --max-turns 100
 
       - name: Collect workflow metrics


### PR DESCRIPTION
- Update model from claude-sonnet-4-5-20250929 to claude-opus-4-5-20251101
- Fix --allowedTools to --allowed-tools (correct CLI flag format)
- Add model specification to claude-code-review and auto-fix workflows
- Use multi-line claude_args format for better readability