### PR TITLE
Fix Claude workflow not executing

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -48,7 +48,14 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          prompt: |
+
+          # Model selection
+          model: claude-opus-4-5-20251101
+
+          # Tool allowlist from generated config
+          allowed_tools: ${{ steps.tools-config.outputs.allowed_tools }}
+
+          direct_prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices
             - Potential bugs or issues
@@ -59,9 +66,3 @@ jobs:
             Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
 
             Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
-
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
-          claude_args: |
-            --model claude-opus-4-5-20251101
-            --allowed-tools "${{ steps.tools-config.outputs.allowed_tools }}"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -105,11 +105,14 @@ jobs:
 
           # MCP servers configured via .mcp.json in repository root
 
-          # Enhanced Claude arguments for workflow integration
-          claude_args: |
-            --model claude-opus-4-5-20251101
-            --allowed-tools "${{ steps.tools-config.outputs.allowed_tools }}"
-            --max-turns 100
+          # Model selection
+          model: claude-opus-4-5-20251101
+
+          # Tool allowlist from generated config
+          allowed_tools: ${{ steps.tools-config.outputs.allowed_tools }}
+
+          # Max turns for complex tasks
+          max_turns: 100
 
       - name: Collect workflow metrics
         if: always()


### PR DESCRIPTION
The claude_args multi-line YAML format caused silent failures ("operation was canceled") because:
- Multi-line block scalars (|) create embedded newlines between args
- Embedded quotes around variable expansions cause parsing issues

Use the action's native input parameters instead:
- model: for model selection
- allowed_tools: for tool allowlist
- max_turns: for conversation limits
- direct_prompt: for PR review prompt (renamed from prompt)

This matches the claude-code-action v1 expected interface.