### PR TITLE
Fix performance benchmark workflow error

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -29,7 +29,7 @@ jobs:
           brew install chezmoi neovim zsh hyperfine
 
       - name: Setup mise
-        uses: nick-fields/setup-mise@v0
+        uses: jdx/mise-action@v2
 
       - name: Benchmark chezmoi apply
         id: chezmoi-bench


### PR DESCRIPTION
Replace non-existent nick-fields/setup-mise with the official jdx/mise-action@v2 to fix workflow failure.