### PR TITLE
Make smoke test reproducible with Docker locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,66 @@
-# Dotfiles testing container with chezmoi
-# Based on: https://www.jamesridgway.co.uk/blog/dotfiles-with-github-travis-ci-and-docker
-FROM alpine:3
+# Smoke test container matching CI environment
+# Reproduces .github/workflows/smoke.yml locally for faster iteration
+#
+# Usage:
+#   make smoke-build   # Build and run full smoke test
+#   make smoke-lint    # Run linting only
+#   make smoke-shell   # Interactive shell for debugging
+#
+FROM ubuntu:24.04
+
+# Prevent interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TERM=xterm-256color
 
 # Install base dependencies
-RUN apk add --no-cache \
-    bash \
-    fish \
-    git \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
     curl \
-    shadow \
-    age
+    file \
+    git \
+    locales \
+    procps \
+    sudo \
+    unzip \
+    zsh \
+    && rm -rf /var/lib/apt/lists/*
 
-# Install chezmoi
-RUN sh -c "$(curl -fsLS get.chezmoi.io)" -- -b /usr/local/bin
+# Set up locale (required for some tools)
+RUN locale-gen en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
 
-# Create test user with fish as default shell
-RUN adduser -D -s /bin/fish tester
+# Create test user with sudo access (matches CI runner user setup)
+RUN useradd -m -s /bin/zsh -G sudo tester && \
+    echo "tester ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
-# Switch to test user
+# Switch to test user for Homebrew installation
 USER tester
-ENV HOME /home/tester
+ENV HOME=/home/tester
 WORKDIR /home/tester
 
-# Initialize chezmoi with the dotfiles
+# Install Homebrew (Linux)
+RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# Add Homebrew to PATH
+ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
+ENV HOMEBREW_NO_AUTO_UPDATE=1
+ENV HOMEBREW_NO_ANALYTICS=1
+
+# Install core tools via Homebrew (matching CI)
+RUN brew install chezmoi neovim
+
+# Install mise
+RUN curl https://mise.run | sh
+ENV PATH="/home/tester/.local/bin:${PATH}"
+
+# Install Python and pre-commit for linting stage
+RUN brew install python@3.12
+RUN pip3 install --user pre-commit
+
+# Copy dotfiles source
 COPY --chown=tester:tester . /tmp/dotfiles
-RUN chezmoi init --source=/tmp/dotfiles
+WORKDIR /tmp/dotfiles
 
-# Apply dotfiles (with verbose output for debugging)
-RUN chezmoi apply -v
-
-# Verify installation
-RUN chezmoi verify || true
-
-# Set working directory to home
-WORKDIR /home/tester
-
-CMD ["/bin/fish"]
+# Default: run full smoke test (lint + build)
+CMD ["/tmp/dotfiles/scripts/smoke-test-docker.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,33 @@
-version: "3.8"
-
+# Docker Compose for local smoke testing
+# Reproduces CI environment for faster iteration
+#
+# Usage:
+#   docker-compose up --build              # Run full smoke test
+#   docker-compose run --rm smoke lint     # Run lint stage only
+#   docker-compose run --rm smoke build    # Run build stage only
+#   docker-compose run --rm smoke-shell    # Interactive shell for debugging
+#
 services:
-  dotfiles:
-    image: laurigates/dotfiles
+  smoke:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: dotfiles-test
-    # Interactive shell for manual testing
-    stdin_open: true
-    tty: true
-    # Optional: Mount a volume for persistent testing
-    # volumes:
-    #   - dotfiles-test-home:/home/tester
+    container_name: dotfiles-smoke
     environment:
       - TERM=xterm-256color
+      - HOMEBREW_NO_AUTO_UPDATE=1
+      - HOMEBREW_NO_ANALYTICS=1
 
-# Optional: Persistent volume for testing iterations
-# volumes:
-#   dotfiles-test-home:
+  # Interactive shell for debugging failed tests
+  smoke-shell:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: dotfiles-smoke-shell
+    environment:
+      - TERM=xterm-256color
+      - HOMEBREW_NO_AUTO_UPDATE=1
+      - HOMEBREW_NO_ANALYTICS=1
+    stdin_open: true
+    tty: true
+    entrypoint: /bin/zsh

--- a/scripts/smoke-test-docker.sh
+++ b/scripts/smoke-test-docker.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Smoke test script for Docker container
+# Reproduces .github/workflows/smoke.yml locally
+#
+# Usage:
+#   ./scripts/smoke-test-docker.sh         # Run all stages
+#   ./scripts/smoke-test-docker.sh lint    # Run lint stage only
+#   ./scripts/smoke-test-docker.sh build   # Run build stage only
+#
+set -euo pipefail
+
+# Colors for output
+BLUE='\033[34m'
+GREEN='\033[32m'
+YELLOW='\033[33m'
+RED='\033[31m'
+RESET='\033[0m'
+
+# Parse command line arguments
+STAGE="${1:-all}"
+
+log_info() { echo -e "${BLUE}ℹ️  $1${RESET}"; }
+log_success() { echo -e "${GREEN}✅ $1${RESET}"; }
+log_warning() { echo -e "${YELLOW}⚠️  $1${RESET}"; }
+log_error() { echo -e "${RED}❌ $1${RESET}"; }
+log_section() { echo -e "\n${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"; echo -e "${BLUE}📋 $1${RESET}"; echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}\n"; }
+
+# Stage: Lint
+run_lint() {
+    log_section "Stage: LINT"
+
+    log_info "Running pre-commit hooks..."
+    if pre-commit run --all-files; then
+        log_success "pre-commit passed"
+    else
+        log_error "pre-commit failed"
+        return 1
+    fi
+
+    log_info "Running chezmoi verify..."
+    if chezmoi verify .; then
+        log_success "chezmoi verify passed"
+    else
+        log_error "chezmoi verify failed"
+        return 1
+    fi
+
+    log_success "Lint stage completed"
+}
+
+# Stage: Build
+run_build() {
+    log_section "Stage: BUILD"
+
+    # Health checks
+    log_info "Running environment health checks..."
+
+    log_info "Homebrew doctor..."
+    if brew doctor 2>&1; then
+        log_success "Homebrew is healthy"
+    else
+        log_warning "Homebrew has warnings (non-fatal)"
+    fi
+
+    log_info "mise doctor..."
+    if mise doctor 2>&1; then
+        log_success "mise is healthy"
+    else
+        log_warning "mise has warnings"
+    fi
+
+    # Apply dotfiles
+    log_info "Running chezmoi apply..."
+    if chezmoi apply -v; then
+        log_success "chezmoi apply succeeded"
+    else
+        log_error "chezmoi apply failed"
+        return 1
+    fi
+
+    # Test zsh initialization
+    log_info "Testing zsh shell initialization..."
+    if timeout 10s zsh -c "
+        source ~/.zshrc
+        if [[ -n \"\$ZSH_VERSION\" ]]; then
+            echo '✅ zsh configuration loaded successfully'
+        else
+            echo '❌ zsh configuration failed to load'
+            exit 1
+        fi
+        if [[ -n \"\$PROMPT\" ]] || [[ -n \"\$PS1\" ]]; then
+            echo '✅ zsh prompt configured'
+        else
+            echo '❌ zsh prompt not configured'
+            exit 1
+        fi
+    "; then
+        log_success "zsh initialization test passed"
+    else
+        log_error "zsh initialization test failed"
+        return 1
+    fi
+
+    log_success "Build stage completed"
+}
+
+# Main execution
+main() {
+    log_section "Smoke Test Runner"
+    log_info "Stage: ${STAGE}"
+    log_info "Working directory: $(pwd)"
+
+    case "$STAGE" in
+        lint)
+            run_lint
+            ;;
+        build)
+            run_build
+            ;;
+        all)
+            run_lint
+            run_build
+            ;;
+        *)
+            log_error "Unknown stage: $STAGE"
+            log_info "Usage: $0 [lint|build|all]"
+            exit 1
+            ;;
+    esac
+
+    log_section "Smoke Test Complete"
+    log_success "All stages passed!"
+}
+
+main "$@"


### PR DESCRIPTION
Replace minimal Alpine container with Ubuntu-based environment that matches CI workflow. Enables faster local iteration on smoke test failures.

New Makefile targets:
- make smoke        - Run full smoke test in Docker
- make smoke-lint   - Run lint stage only
- make smoke-build  - Run build stage only
- make smoke-shell  - Interactive debugging shell
- make smoke-clean  - Clean up Docker resources