### PR TITLE
Run local smoke tests and fix issues

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -113,7 +113,7 @@
     {
       "path": "detect_secrets.filters.regex.should_exclude_file",
       "pattern": [
-        "private_dot_config/private_atuin/.*|macos-settings.toml|\\.claude/commands/.*|\\.claude/skills/.*/SKILL\\.md|\\.claude/skills/.*/REFERENCE\\.md|\\.claude/docs/.*|lazy-lock\\.json"
+        "private_dot_config/private_atuin/.*|macos-settings.toml|\\.claude/commands/.*|\\.claude/skills/.*/SKILL\\.md|\\.claude/skills/.*/REFERENCE\\.md|\\.claude/docs/.*|exact_dot_claude/docs/.*|lazy-lock\\.json"
       ]
     }
   ],

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -130,7 +130,7 @@ function fzf_apropos() {
 export SDL_VIDEO_FULLSCREEN_HEAD=0
 # export DOCKER_DEFAULT_PLATFORM=linux/amd64
 
-export MAKEFLAGS="-j{{ .cpu.threads }}"
+export MAKEFLAGS="-j{{ output "nproc" | trim }}"
 export BAT_THEME=TwoDark
 export BAT_STYLE=plain
 

--- a/private_dot_config/private_fish/config.fish.tmpl
+++ b/private_dot_config/private_fish/config.fish.tmpl
@@ -1,4 +1,4 @@
-set -x MAKEFLAGS "-j{{ .cpu.threads }}"
+set -x MAKEFLAGS "-j{{ output "nproc" | trim }}"
 set -x BAT_THEME TwoDark
 
 set -x OLLAMA_ORIGINS "app://obsidian.md*"


### PR DESCRIPTION
- Add ensure_dependencies() to auto-install pre-commit and chezmoi
- Fix chezmoi installer URL (get.chezmoi.io → www.chezmoi.io/get)
- Replace chezmoi verify with chezmoi diff for template validation (verify checks destination=target which fails before apply)
- Add --source=. flag to chezmoi commands for fresh environments
- Make brew/mise/zsh checks optional with graceful warnings
- Add exact_dot_claude/docs/* to secrets baseline exclusions
- Fix .cpu.threads template variable to use {{ output "nproc" | trim }} in both fish and zsh config templates (was referencing undefined data)