### PR TITLE
Enable git status stash display in global configuration

### DIFF
--- a/run_once_before_00-initial-setup.sh.tmpl
+++ b/run_once_before_00-initial-setup.sh.tmpl
@@ -31,6 +31,7 @@ git config --global push.autoSetupRemote true
 git config --global color.ui auto
 git config --global log.date iso
 git config --global help.autocorrect 20
+git config --global status.showStash true
 
 # Install pre-commit hooks (if pre-commit is available)
 if command -v pre-commit &> /dev/null; then


### PR DESCRIPTION
## Summary
Added a git configuration setting to display stashed changes in the status output by default.

## Changes
- Enable `status.showStash` in global git configuration during initial setup
  - This makes `git status` automatically show the count of stashed changes, improving visibility into saved work-in-progress changes

## Details
The new configuration line `git config --global status.showStash true` is added to the initial setup script, ensuring that all new git repositories will display stash information in status output without requiring manual configuration.

https://claude.ai/code/session_012W9FWKwZpLhsYnHeySZmJ2