### PR TITLE
chore(claude): enable 1M context window

### DIFF
--- a/exact_dot_claude/settings.json
+++ b/exact_dot_claude/settings.json
@@ -3,7 +3,6 @@
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "1",
-    "CLAUDE_CODE_DISABLE_1M_CONTEXT": "1",
     "ENABLE_TOOL_SEARCH": "1"
   },
   "permissions": {


### PR DESCRIPTION
## Summary
- Remove CLAUDE_CODE_DISABLE_1M_CONTEXT env var so Opus 4.7 runs with the full 1M context window

## Test plan
- [ ] chezmoi apply and verify new session uses 1M context

🤖 Generated with [Claude Code](https://claude.com/claude-code)