### PR TITLE
docs(claude): add repo-deletion-safety rule

### DIFF
--- a/exact_dot_claude/rules/repo-deletion-safety.md
+++ b/exact_dot_claude/rules/repo-deletion-safety.md
@@ -1,0 +1,64 @@
+# Repo Deletion Safety
+
+Before `rm -rf`'ing a git repository, verify that its work is preserved
+somewhere else. A local checkout that has no remote is the *only* copy —
+deletion is permanent and silently destroys committed history plus all
+uncommitted work.
+
+## Preflight check
+
+```
+git -C <repo> remote -v
+```
+
+| Output | Meaning | Action |
+|---|---|---|
+| Has `origin <url>` | Pushed work lives on the remote | Local delete is safe; uncommitted work and unpushed commits are still lost — surface them first |
+| Empty / no output | **Local-only repo** | Stop. The repo's entire history is in this checkout |
+
+Always run this check before deleting, even when the user has explicitly
+said "delete this repo" — they may not realize a particular checkout is
+local-only.
+
+## When the repo is local-only
+
+Surface the situation and offer three options, in increasing
+destructiveness, before doing anything:
+
+1. **Push to a new GitHub repo first.** Preserves the work on the
+   remote, then the local checkout can be deleted safely. Requires
+   creating the GitHub repo (or knowing it exists empty).
+2. **Tar to a labelled backup.** `tar -czf
+   ~/Backups/<name>-$(date -I).tar.gz <repo>`. Preserves the work on
+   disk under a date-stamped name; the local checkout can then be
+   deleted.
+3. **Delete with no backup.** Confirm the user genuinely wants the work
+   gone — including any uncommitted files, branches, and stashes.
+
+Default when the user says a generic "go" / "yes" without specifying:
+option 2 (tar backup, then delete). It preserves the work without
+requiring remote setup or losing anything, and the backup can be
+deleted later when confidence builds.
+
+## Also surface before deleting
+
+Even when a remote exists, these conditions warrant a pause:
+
+- **Uncommitted changes.** `git status --porcelain` is non-empty —
+  those files are not on any remote.
+- **Unpushed commits.** `git log @{u}..HEAD --oneline` is non-empty —
+  those commits exist only locally.
+- **Stashes.** `git stash list` is non-empty — stashes are pure
+  working-copy state.
+- **Untracked branches.** `git branch -vv` shows branches without
+  upstreams — those branches' commits may be local-only.
+
+If any are present, list them in the same message as the deletion
+prompt so the user can decide knowing what disappears.
+
+## Rationale
+
+The general system-prompt rule ("destructive operations need
+confirmation") covers the *spirit*. This rule is the *concrete check*
+to run before nuking a repo: the failure mode of skipping it is
+silent permanent data loss, with no way to recover.


### PR DESCRIPTION
## Summary

- Adds `exact_dot_claude/rules/repo-deletion-safety.md` — a concrete preflight before `rm -rf` of a git repository.
- Mandates `git remote -v` first; treats local-only repos as the single copy and surfaces three options before deletion (push to new remote / tar backup / confirmed-no-backup delete).
- For generic "go" / "yes", default to tar backup — preserves the work without needing remote setup.
- Even with a remote, surface uncommitted changes / unpushed commits / stashes / branches without upstreams in the deletion prompt so the user knows what disappears.

## Why

The general system-prompt rule covers destructive ops in spirit. This rule operationalizes it for the specific case where the failure mode is silent permanent data loss with no recovery path.

## Test plan

- [x] Markdown renders cleanly
- [ ] Rule surfaces in a fresh session via `.claude/rules/` global include