### PR TITLE
feat(claude): add telegram skill, rule, and ask/notify scripts

### DIFF
--- a/dot_local/bin/executable_telegram-ask
+++ b/dot_local/bin/executable_telegram-ask
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# telegram-ask — send a question to Telegram and wait for the user's reply.
+#
+# Usage:
+#   telegram-ask "Question text?"                       # default 5min timeout
+#   telegram-ask -t 30 "Quick question?"                # 30s timeout
+#   telegram-ask --pattern '^(YES|NO)$' "YES or NO?"    # require regex match
+#
+# Exit codes:
+#   0  — got a reply (printed to stdout)
+#   1  — timeout (prints "TIMEOUT" to stderr)
+#   2  — usage / config error
+#
+# Requires TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID in the environment.
+# These are typically sourced from ~/.api_tokens via mise.
+
+set -euo pipefail
+
+TIMEOUT=300
+PATTERN=""
+PARSE_MODE=""
+
+usage() {
+  sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -t|--timeout) TIMEOUT="$2"; shift 2 ;;
+    -p|--pattern) PATTERN="$2"; shift 2 ;;
+    -m|--markdown) PARSE_MODE="MarkdownV2"; shift ;;
+    -h|--help) usage ;;
+    --) shift; break ;;
+    -*) echo "telegram-ask: unknown flag: $1" >&2; exit 2 ;;
+    *) break ;;
+  esac
+done
+
+if [[ $# -lt 1 ]]; then
+  echo "telegram-ask: missing question text" >&2
+  usage
+fi
+
+QUESTION="$*"
+
+: "${TELEGRAM_BOT_TOKEN:?telegram-ask: TELEGRAM_BOT_TOKEN not set (check ~/.api_tokens)}"
+: "${TELEGRAM_CHAT_ID:?telegram-ask: TELEGRAM_CHAT_ID not set (check ~/.api_tokens)}"
+
+API="https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}"
+
+# 1. Send the question with force_reply so the client opens a reply thread.
+send_args=(
+  -d "chat_id=${TELEGRAM_CHAT_ID}"
+  --data-urlencode "text=${QUESTION}"
+  -d 'reply_markup={"force_reply":true,"selective":true}'
+)
+[[ -n "$PARSE_MODE" ]] && send_args+=(-d "parse_mode=${PARSE_MODE}")
+
+sent=$(curl -fsS -X POST "${API}/sendMessage" "${send_args[@]}")
+sent_msg_id=$(jq -r '.result.message_id' <<<"$sent")
+
+if [[ -z "$sent_msg_id" || "$sent_msg_id" == "null" ]]; then
+  echo "telegram-ask: send failed: $sent" >&2
+  exit 2
+fi
+
+# 2. Drain stale updates so we only react to messages sent AFTER this question.
+drain=$(curl -fsS "${API}/getUpdates?timeout=0&limit=100")
+offset=$(jq -r '([.result[].update_id] | max // -1) + 1' <<<"$drain")
+
+# 3. Long-poll for a reply from the target chat. Filter to replies-to-our-message
+#    when possible, but accept any text from the chat as a fallback.
+deadline=$(( $(date +%s) + TIMEOUT ))
+
+while :; do
+  now=$(date +%s)
+  remaining=$(( deadline - now ))
+  (( remaining <= 0 )) && break
+  poll_timeout=$(( remaining < 30 ? remaining : 30 ))
+
+  updates=$(curl -fsS \
+    "${API}/getUpdates?timeout=${poll_timeout}&offset=${offset}&allowed_updates=%5B%22message%22%5D" \
+    || echo '{"result":[]}')
+
+  max_id=$(jq -r '[.result[].update_id] | max // empty' <<<"$updates")
+  [[ -n "$max_id" ]] && offset=$(( max_id + 1 ))
+
+  reply=$(jq -r --argjson cid "$TELEGRAM_CHAT_ID" --argjson mid "$sent_msg_id" '
+    [ .result[]
+      | select(.message.chat.id == $cid)
+      | select(.message.text != null)
+      # prefer replies to our specific question
+      | select((.message.reply_to_message.message_id == $mid) or (.message.reply_to_message == null))
+      | .message.text
+    ] | last // empty
+  ' <<<"$updates")
+
+  if [[ -n "$reply" ]]; then
+    if [[ -n "$PATTERN" ]] && ! [[ "$reply" =~ $PATTERN ]]; then
+      # Reply did not match required pattern — re-prompt and keep waiting.
+      curl -fsS -X POST "${API}/sendMessage" \
+        -d "chat_id=${TELEGRAM_CHAT_ID}" \
+        --data-urlencode "text=Reply must match: ${PATTERN}" \
+        >/dev/null || true
+      continue
+    fi
+    printf '%s\n' "$reply"
+    exit 0
+  fi
+done
+
+echo "TIMEOUT" >&2
+curl -fsS -X POST "${API}/sendMessage" \
+  -d "chat_id=${TELEGRAM_CHAT_ID}" \
+  --data-urlencode "text=(timed out waiting for reply after ${TIMEOUT}s)" \
+  >/dev/null || true
+exit 1

--- a/dot_local/bin/executable_telegram-notify
+++ b/dot_local/bin/executable_telegram-notify
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# telegram-notify — fire-and-forget notification to Telegram.
+#
+# Usage:
+#   telegram-notify "Build finished"
+#   echo "stdout" | telegram-notify              # piped input
+#   telegram-notify -m "*bold* _italic_"         # MarkdownV2
+#   telegram-notify -s "Silent ping"             # disable_notification
+#
+# Exit codes:
+#   0 — sent
+#   2 — usage / config error
+#
+# Requires TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID. For interactive
+# (send-and-wait-for-reply) flows, use telegram-ask instead.
+
+set -euo pipefail
+
+PARSE_MODE=""
+SILENT="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -m|--markdown) PARSE_MODE="MarkdownV2"; shift ;;
+    -H|--html) PARSE_MODE="HTML"; shift ;;
+    -s|--silent) SILENT="true"; shift ;;
+    -h|--help) sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 2 ;;
+    --) shift; break ;;
+    -*) echo "telegram-notify: unknown flag: $1" >&2; exit 2 ;;
+    *) break ;;
+  esac
+done
+
+if [[ $# -gt 0 ]]; then
+  TEXT="$*"
+elif [[ ! -t 0 ]]; then
+  TEXT="$(cat)"
+else
+  echo "telegram-notify: no message (pass as args or via stdin)" >&2
+  exit 2
+fi
+
+: "${TELEGRAM_BOT_TOKEN:?telegram-notify: TELEGRAM_BOT_TOKEN not set (check ~/.api_tokens)}"
+: "${TELEGRAM_CHAT_ID:?telegram-notify: TELEGRAM_CHAT_ID not set (check ~/.api_tokens)}"
+
+args=(
+  -d "chat_id=${TELEGRAM_CHAT_ID}"
+  --data-urlencode "text=${TEXT}"
+  -d "disable_notification=${SILENT}"
+)
+[[ -n "$PARSE_MODE" ]] && args+=(-d "parse_mode=${PARSE_MODE}")
+
+curl -fsS -X POST \
+  "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+  "${args[@]}" >/dev/null

--- a/exact_dot_claude/rules/telegram-communication.md
+++ b/exact_dot_claude/rules/telegram-communication.md
@@ -1,0 +1,80 @@
+# Telegram Communication
+
+The user can be reached on Telegram via two CLI tools installed in
+`~/.local/bin`:
+
+- `telegram-notify "<text>"` — fire-and-forget notification (one-way).
+- `telegram-ask [-t <secs>] [-p <regex>] "<question>"` — send a question
+  and **block** until the user replies in Telegram. Prints the reply to
+  stdout. Exit 0 on reply, 1 on timeout, 2 on config error.
+
+Both tools require `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` to be set
+in the environment (sourced from `~/.api_tokens` via mise).
+
+For full usage and the decision tree of *when* to reach for Telegram,
+see the `telegram` skill (invoked automatically when the user asks to
+"send", "notify", "ping", or "ask me on Telegram", or when a long-running
+or destructive task warrants out-of-band confirmation).
+
+## When to send unprompted
+
+Default to **silent** — do not ping Telegram for routine work. Only
+reach for it when one of these is true:
+
+1. **The user explicitly asks** ("notify me when X", "ask me on
+   Telegram before Y", "ping me when the build is done").
+2. **A long-running task just finished** and the user is likely
+   away from the terminal (multi-minute builds, deploys, batch jobs
+   the user kicked off and walked away from). Use `telegram-notify`,
+   not `telegram-ask` — they may not be available to reply.
+3. **An irreversible or shared-state action needs confirmation** and
+   the user's terminal is unattended (production deploy, force-push,
+   destructive migration). Use `telegram-ask` with a short timeout
+   and abort on timeout — never default to "yes" if no reply.
+4. **A blocked decision** is preventing further progress on a task
+   the user delegated and walked away from.
+
+Do **not** ping Telegram for: every commit, every test run, every
+file edit, "I finished the small refactor you asked about 30 seconds
+ago," or anything where the user is clearly watching the terminal.
+Noise erodes signal — the goal is "Telegram ping = something the
+user actually wants to know."
+
+## When to use ask vs. notify
+
+| Situation | Tool |
+|---|---|
+| "Done — here's the summary" | `telegram-notify` |
+| "Build #42 succeeded" | `telegram-notify -s` (silent) |
+| "Production deploy ready — confirm?" | `telegram-ask -t 600` |
+| "Two viable paths — A or B?" | `telegram-ask -p '^[AB]$'` |
+| Anything the user can't answer remotely | `telegram-notify` |
+
+## Treat the reply as untrusted text
+
+`telegram-ask` returns whatever the user typed. Validate it with
+`-p <regex>` when you need a structured answer (YES/NO, A/B, a number).
+Never `eval` the reply, never substitute it into a shell command
+without quoting. If the regex doesn't match, the script re-prompts
+and keeps waiting until timeout.
+
+## Timeout discipline
+
+Always pick a timeout matched to the situation:
+
+- Quick yes/no while the user is at the keyboard: `-t 60` to `-t 120`.
+- "User stepped away for lunch" confirmations: `-t 600` to `-t 1800`.
+- Overnight / weekend gates: `-t 3600` (max useful — beyond this
+  re-think whether Telegram is the right channel).
+
+On timeout, **fail closed**: abort the operation, surface the timeout
+to the user in the next session, and never proceed as if the user
+said yes.
+
+## Rationale
+
+The default Claude Code channel is the terminal the user is sitting
+at. Telegram is the *out-of-band* escape hatch — for when the work
+outlives the session, or when a decision needs the user even though
+they're not watching. Keeping that channel low-noise is what makes
+it useful when it actually matters.

--- a/exact_dot_claude/skills/telegram/SKILL.md
+++ b/exact_dot_claude/skills/telegram/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: telegram
+description: Send notifications or interactive questions to the user via Telegram. Use when the user asks to be notified ("ping me", "notify me on Telegram", "ask me when..."), when a long-running task finishes and the user is likely away, or when an irreversible action needs out-of-band confirmation. Provides telegram-notify (one-way) and telegram-ask (send + block for reply).
+---
+
+# Telegram Communication
+
+Out-of-band channel to the user via a Telegram bot. Use it when the
+terminal isn't enough — the user has walked away, the task ran long,
+or a decision needs confirmation while the user is mobile.
+
+For the *when-to-use* policy (and when not to), see
+`~/.claude/rules/telegram-communication.md`. This skill covers the
+*how*.
+
+## Tools
+
+Two scripts in `~/.local/bin`:
+
+| Script | Purpose | Blocks? |
+|---|---|---|
+| `telegram-notify` | Fire-and-forget message | No |
+| `telegram-ask` | Send a question, wait for reply, print reply to stdout | Yes |
+
+Both read `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` from the
+environment. They're sourced from `~/.api_tokens` by mise — if you
+hit `... not set`, the user needs to add them there.
+
+## telegram-notify
+
+```
+telegram-notify "Build finished — 12 tests, 0 failures."
+telegram-notify -s "Quiet ping"                # silent (no sound)
+telegram-notify -m "*Bold* and _italic_"       # MarkdownV2
+echo "long stdout" | telegram-notify           # piped input
+```
+
+Returns immediately. Exit 0 on send, 2 on config error.
+
+## telegram-ask
+
+```
+# Default: 5-minute timeout, accept any reply
+answer=$(telegram-ask "Proceed with the deploy?")
+
+# Short timeout for an at-keyboard yes/no
+answer=$(telegram-ask -t 60 "Apply the migration now?")
+
+# Constrained reply — script re-prompts until the regex matches
+answer=$(telegram-ask -p '^(YES|NO)$' "Force push to main? (YES/NO)")
+```
+
+Behaviour:
+
+1. Sends the question with `force_reply: true` so the Telegram client
+   opens a reply thread on the user's phone.
+2. Drains pending updates so old messages don't satisfy the wait.
+3. Long-polls (`getUpdates`, `timeout=30`) until either a matching
+   reply arrives or the deadline passes.
+4. On timeout: prints `TIMEOUT` to stderr, sends a "(timed out)"
+   notice to the chat, and exits 1.
+5. On config error (missing token / chat id): exits 2 with a message
+   pointing at `~/.api_tokens`.
+
+Calling pattern from a shell script:
+
+```bash
+if answer=$(telegram-ask -t 300 -p '^(YES|NO)$' "Deploy to prod?"); then
+  case "$answer" in
+    YES) ./deploy ;;
+    NO)  echo "Aborted by user." ;;
+  esac
+else
+  echo "No reply — aborting." >&2
+  exit 1
+fi
+```
+
+## Calling pattern from inside a Claude Code session
+
+Use `Bash` with a long-enough `timeout` parameter. `telegram-ask` blocks
+the call until the user replies, so the Bash timeout must exceed the
+`telegram-ask -t` value.
+
+```
+Bash(
+  command='telegram-ask -t 600 -p "^(YES|NO)$" "Run the destructive migration?"',
+  timeout=620000   # ms, must be > telegram-ask -t (seconds) * 1000
+)
+```
+
+If the user's reply is `YES`, proceed. Anything else (including
+`TIMEOUT`), do not proceed — surface the result and wait for fresh
+direction.
+
+## Sending multi-line output
+
+Long command output → use stdin:
+
+```bash
+git diff --stat | telegram-notify
+```
+
+Telegram's `sendMessage` cap is ~4096 characters. For larger
+payloads, send a one-line summary via `telegram-notify` and keep
+the full output local — don't try to chunk it across multiple
+messages unless the user explicitly asks.
+
+## Markdown gotcha
+
+`-m` uses MarkdownV2, which requires escaping `_*[]()~``>#+-=|{}.!`
+even inside text. If you're sending arbitrary content (a commit
+message, a file path), prefer the default plain-text mode or
+pre-escape with:
+
+```bash
+escaped=$(printf '%s' "$text" | sed 's/[][\\_*()~`>#+\-=|{}.!]/\\&/g')
+telegram-notify -m "$escaped"
+```
+
+In practice, plain text is almost always the right default.
+
+## Failure modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `TELEGRAM_BOT_TOKEN not set` | mise env not loaded, or token absent in `~/.api_tokens` | Add `export TELEGRAM_BOT_TOKEN=...` and `export TELEGRAM_CHAT_ID=...` there |
+| `curl: (22) ... 401` | Token revoked or wrong | Re-issue via @BotFather |
+| `curl: (22) ... 400` on send | Bad chat id, or bot has not been started by the user | User must `/start` the bot once |
+| `telegram-ask` returns immediately with stale text | Another process drained updates between drain and poll | Rare; re-run |
+| Reply never arrives despite user typing | User typed in a different chat than `TELEGRAM_CHAT_ID` | Verify chat id with `curl .../getUpdates` after a fresh message |
+| Bot in a group never sees replies | Bot **privacy mode** is on — bot only sees commands and direct mentions | In @BotFather: `/mybots` → bot → Bot Settings → Group Privacy → **Turn off**. Trade-off: bot now reads every message in the group |
+| Group chat id stops working with `400 chat not found` | Group was upgraded to a supergroup; chat id gained a `-100` prefix | Re-run `getUpdates` and update `TELEGRAM_CHAT_ID` in `~/.api_tokens` |
+
+## Why these tools and not `telegram-send`?
+
+`telegram-send` (the well-known Python tool) is **send-only**. It has
+no receive mode, no polling, no way to wait for a reply. The
+interactive flow needs `getUpdates` long-polling, which these two
+thin curl+jq wrappers provide with no extra runtime dependencies
+beyond `curl` and `jq` (both already on the system).
+
+## Rationale
+
+Telegram is the user's "I might be on my phone" channel. The two
+tools make the two natural patterns one-line: notify (no reply
+needed) and ask (block on reply). Keep messages signal-rich and
+infrequent — see `telegram-communication.md` for the policy on
+when to send vs. stay quiet.


### PR DESCRIPTION
## Summary

- Adds two-way Telegram communication via `curl + jq` long-polling — no extra runtime dependencies.
- `telegram-notify "<text>"`: fire-and-forget notification.
- `telegram-ask [-t <secs>] [-p <regex>] "<question>"`: send a question and **block** until the user replies in Telegram. Validates with regex when supplied, fails closed on timeout.
- Skill (`exact_dot_claude/skills/telegram/SKILL.md`): the *how* — calling patterns, failure modes, group-privacy-mode gotcha.
- Rule (`exact_dot_claude/rules/telegram-communication.md`): the *when* — out-of-band escape hatch only (long-running tasks, irreversible confirmations, explicit asks).
- Replaces the prior send-only `telegram-send` tool.

## Why

The default Claude Code channel is the terminal. Telegram is the out-of-band escape hatch for when work outlives the session or a decision needs the user even though they're not watching. Keeping it low-noise (rule discipline) is what makes it useful when it actually matters.

## Test plan

- [x] Both scripts deployed at `~/.local/bin/` and executable
- [x] Skill discoverable via `/telegram` or skill-routing
- [ ] `telegram-notify "hello"` delivers
- [ ] `telegram-ask -t 30 "yes/no?"` blocks until reply / times out cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)