### PR TITLE
fix(mise): register chezmoi as a managed tool

### DIFF
--- a/private_dot_config/mise/config.toml.tmpl
+++ b/private_dot_config/mise/config.toml.tmpl
@@ -114,6 +114,7 @@ d2 = "latest"
 "npm:pyright" = "latest"
 "npm:typescript-language-server" = "latest"
 "go:golang.org/x/tools/gopls" = "latest"
+chezmoi = "latest"
 
 # ============================================================================
 # Environment Variables


### PR DESCRIPTION
## Summary
- Add `chezmoi = "latest"` to `[tools]` in `private_dot_config/mise/config.toml.tmpl`.
- Without this entry, mise never adds the chezmoi install dir to PATH on shell activation, so `chezmoi` isn't on PATH even though prior `mise use` runs leave the binary on disk under `~/.local/share/mise/installs/chezmoi/`.

## Test plan
- [ ] `chezmoi apply` then `exec zsh`
- [ ] `command -v chezmoi` resolves
- [ ] `chezmoi --version` returns the installed version

🤖 Generated with [Claude Code](https://claude.com/claude-code)