### PR TITLE
chore(mise): manage fzf and starship via mise

### DIFF
--- a/private_dot_config/mise/config.toml.tmpl
+++ b/private_dot_config/mise/config.toml.tmpl
@@ -102,6 +102,8 @@ rust = "latest"
 # Terminal & Shell
 "aqua:ajeetdsouza/zoxide" = "latest"
 "aqua:atuinsh/atuin" = "latest"
+"aqua:junegunn/fzf" = "latest"
+"ubi:starship/starship" = "latest"
 
 # Development Tools
 "aqua:cli/cli" = "latest"                     # gh (GitHub CLI)


### PR DESCRIPTION
## Summary
- Add `"aqua:junegunn/fzf" = "latest"` and `"ubi:starship/starship" = "latest"` to the Terminal & Shell section.
- Consolidates drift: both tools were already in `~/.config/mise/config.toml` (rendered) but never declared in this source template, so a fresh `chezmoi apply` on a clean machine would not install them.

## Test plan
- [ ] `chezmoi diff` is clean for the mise config after apply
- [ ] `mise ls` lists fzf and starship as managed tools
- [ ] `command -v fzf && command -v starship` resolve in a fresh shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)