### PR TITLE
feat(kitty): prefix tab titles with cwd basename

### DIFF
--- a/private_dot_config/private_kitty/kitty.conf.tmpl
+++ b/private_dot_config/private_kitty/kitty.conf.tmpl
@@ -324,6 +324,20 @@ inactive_tab_font_style normal
 
 #: Tab bar colors and styles
 
+tab_title_template "{(tab.active_oldest_wd or '').rsplit('/', 1)[-1] or '~'}{f' · {title}' if title else ''}"
+
+#: Show the cwd basename as a directory prefix in the tab title. Claude
+#: Code sets the title via process.title (not OSC 2), so {title} stays
+#: empty for Claude tabs — the cwd basename is the useful signal there.
+#: For tabs running vim/ssh/etc. that DO emit OSC 0/2, append " · {title}"
+#: after the cwd. tab.active_oldest_wd uses proc_pidinfo on macOS — a
+#: live per-render syscall, but cheaper than tab.active_wd.
+
+tab_title_max_length 50
+
+#: Hard cap on rendered tab title cells. The cwd prefix sits at the
+#: front so it survives truncation when {title} is long.
+
 #: # endregion
 
 #: Color scheme # region


### PR DESCRIPTION
## Summary
- Adds `tab_title_template` so each kitty tab leads with the cwd basename, then appends ` · {title}` only when an OSC-set title exists.
- Sets `tab_title_max_length 50` so the cwd prefix survives truncation when titles get long.

## Why
Claude Code uses Node's `process.title` rather than OSC 0/2, but kitty still picks the resulting title up via the window's `{title}` field, so both the directory prefix and Claude's task description render in the tab. For tabs running plain `zsh`, vim, ssh, etc., the same template still works because shell integration emits OSC 2.

## Behaviour
| cwd | program-set title | rendered tab title |
|---|---|---|
| `~/repos/foo/bar` | (empty) | `bar` |
| `~/repos/foo/bar` | `⠐ Refactor module` | `bar · ⠐ Refactor module` |
| `/Users/lgates` | `zsh` | `lgates · zsh` |

Long combined strings hard-truncate at 50 cells; the cwd prefix sits at the front so it always stays visible.

## Test plan
- [x] `chezmoi diff` shows the expected 14-line addition in `private_dot_config/private_kitty/kitty.conf.tmpl`
- [x] `chezmoi apply ~/.config/kitty/kitty.conf` succeeds
- [x] `kitty @ load-config` returns clean
- [x] Live tabs render with the new prefix (verified via `kitty @ ls`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)