### PR TITLE
chore(mise): make pipx-via-uvx routing explicit

### DIFF
--- a/private_dot_config/mise/config.toml.tmpl
+++ b/private_dot_config/mise/config.toml.tmpl
@@ -29,7 +29,11 @@ go = "1.23"
 rust = "latest"
 
 # ============================================================================
-# Python Tools (via pipx backend - automatically uses uvx if uv is installed)
+# Python Tools (via pipx backend, routed through uvx)
+# mise's pipx backend falls back to uvx only when uv is itself mise-managed
+# (see jdx/mise#7477 — system-PATH uv is not detected). uv is registered as
+# a managed tool below; pipx.uvx = true under [settings] makes the routing
+# explicit so it doesn't break if that detection logic changes.
 # ============================================================================
 # NOTE: During migration, some tools are defined in both .chezmoidata.toml (uv_tools)
 # and here (pipx backend). This temporary duplication ensures backward compatibility.
@@ -546,6 +550,10 @@ legacy_version_file = true
 
 # Enable experimental features
 experimental = true
+
+# Always route the pipx backend through uvx (see comment above the
+# Python Tools section). Belt-and-suspenders for jdx/mise#7477.
+pipx.uvx = true
 
 # ============================================================================
 # Hooks


### PR DESCRIPTION
## Summary

- Rewrite the misleading comment above the Python Tools block. Previous comment claimed mise's pipx backend "automatically uses uvx if uv is installed", but mise only detects mise-managed uv — system-PATH uv is invisible to the auto-detection (see [jdx/mise#7477](https://github.com/jdx/mise/discussions/7477)).
- Add `pipx.uvx = true` under `[settings]` to make the routing explicit and version-independent.

## Why

PR #199 surfaced this when `mise install pipx:pre-commit` failed on a host where uv was on `\$PATH` but not mise-managed. The fallback silently tried `pipx`, which wasn't installed → install failed. After PR #199 added `uv = "latest"` as a mise-managed tool, the fallback worked — but the behavior is still implicit and would break again if uv ever stops being mise-managed.

## Test plan

- [x] `mise settings get pipx.uvx` returns `true` after apply
- [x] `mise install pipx:pre-commit` succeeds without `MISE_PIPX_UVX=true` env override
- [ ] On macOS: confirm same behavior (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)