### PR TITLE
fix(zsh): redirect TMPDIR to ~/tmp on TrueNAS hosts

### DIFF
--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -14,4 +14,11 @@ path+="/Applications/Obsidian.app/Contents/MacOS"
 export PATH
 
 source ~/.api_tokens
+
+{{- if and (eq .chezmoi.os "linux") (.chezmoi.kernel.osrelease | contains "truenas") }}
+# TrueNAS: /tmp is mounted noexec, breaking chezmoi's run_* scripts.
+# Redirect TMPDIR to an exec-allowed dataset.
+export TMPDIR="$HOME/tmp"
+[ -d "$TMPDIR" ] || mkdir -p "$TMPDIR"
+{{- end }}
 # vim:ft=sh


### PR DESCRIPTION
## Summary

- TrueNAS mounts `/tmp` as tmpfs with `noexec`, which breaks chezmoi's `run_*` scripts (`fork/exec` on the materialized script returns EACCES).
- Export `TMPDIR=$HOME/tmp` (on the `main/home` ZFS dataset, exec-allowed) when `.chezmoi.kernel.osrelease` contains `truenas`.
- No-op on macOS and other Linux hosts.

## Bootstrap

Applying this change itself still needs the workaround once, since the failing script runs before the new `~/.zshenv` is in place:

```sh
TMPDIR="$HOME/tmp" chezmoi apply -v
```

After that, every new shell exports `TMPDIR` itself and bare `chezmoi apply` works.

## Test plan

- [x] `chezmoi execute-template < dot_zshenv.tmpl` renders the export on the TrueNAS host.
- [ ] Same render on macOS produces no `TMPDIR` block (gated by `osrelease` substring).
- [ ] `TMPDIR=$HOME/tmp chezmoi apply -v` runs `run_once_before_00-initial-setup.sh.tmpl` successfully end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)