### PR TITLE
fix(pre-commit): use stylua prebuilt-binary hook variant

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,10 @@ repos:
   - repo: https://github.com/JohnnyMorganz/StyLua
     rev: v2.1.0
     hooks:
-      - id: stylua
+      # Prebuilt-binary variant: the default `stylua` hook (language: rust)
+      # builds from source and needs a C linker, which isn't available on
+      # minimal Linux hosts like TrueNAS where apt is disabled.
+      - id: stylua-github
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.7
     hooks:


### PR DESCRIPTION
## Summary

- Switch the stylua pre-commit hook from `id: stylua` (language: rust, builds from source via `cargo install`) to `id: stylua-github` (downloads a prebuilt release binary from the upstream repo).
- Unblocks commits on minimal Linux hosts without a system C linker, while leaving macOS and standard CI runners unaffected.

## Why

The default upstream hook tries to `cargo install stylua` on first use. That requires `cc`, which isn't present on minimal Linux hosts where `apt` is disabled (notably TrueNAS appliances). Result: **every commit fails on those hosts** — even commits that don't touch any Lua files — because pre-commit installs hook envs eagerly. Workaround in use until now was `SKIP=stylua git commit …` per commit (see #199).

The upstream repo ships three variants at `v2.1.0`:

| id | language | works without `cc`? |
|----|----------|---------------------|
| `stylua` | rust | ❌ (current) |
| `stylua-system` | system | ✅, but needs stylua on `$PATH` |
| `stylua-github` | python | ✅, downloads release binary |

`stylua-github` keeps the workflow uniform across machines without requiring a per-host stylua install, matching the preference in #200.

## Test plan

- [x] On TrueNAS host (no `cc`): `pre-commit clean && pre-commit run --all-files` → `StyLua (Github) ... Passed`
- [x] Conventional-commit hook passes against the commit message
- [ ] CI smoke (ubuntu-latest) passes on PR

Fixes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)