### PR TITLE
feat(claude): add session-wrap skill with Stop-hook nudge

### DIFF
--- a/exact_dot_claude/hooks/executable_session-wrap-nudge.sh
+++ b/exact_dot_claude/hooks/executable_session-wrap-nudge.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Stop hook — nudges the agent to propose /session-wrap when the user is
+# signaling end-of-session AND the session is FVH-scoped.
+#
+# Fires at most once per session_id (state file). Conservative on all
+# three axes (turn count, FVH context, wind-down phrasing) so it stays
+# quiet on quick lookups and non-FVH work.
+
+set -euo pipefail
+
+input=$(cat)
+
+# Hard exits — never loop or run without the data we need
+stop_active=$(jq -r '.stop_hook_active // false' <<<"$input" 2>/dev/null || echo "false")
+[ "$stop_active" = "true" ] && exit 0
+
+session_id=$(jq -r '.session_id // empty' <<<"$input" 2>/dev/null || echo "")
+cwd=$(jq -r '.cwd // empty' <<<"$input" 2>/dev/null || echo "")
+transcript=$(jq -r '.transcript_path // empty' <<<"$input" 2>/dev/null || echo "")
+
+[ -z "$session_id" ] && exit 0
+[ -z "$transcript" ] && exit 0
+[ ! -f "$transcript" ] && exit 0
+
+# At most one nudge per session
+state_dir="${HOME}/.cache/claude-session-wrap-nudge"
+mkdir -p "$state_dir"
+state_file="$state_dir/$session_id"
+[ -f "$state_file" ] && exit 0
+
+# Need substantial conversation — short sessions don't warrant a wrap
+user_turns=$(grep -c '"role":"user"' "$transcript" 2>/dev/null || echo 0)
+[ "$user_turns" -lt 6 ] && exit 0
+
+# FVH context detection: cwd path, git remote, or active taskwarrior project
+fvh=0
+case "$cwd" in
+    *ForumVirium*|*forumvirium*|*ForumViriumHelsinki*) fvh=1 ;;
+esac
+
+if [ "$fvh" = 0 ] && [ -d "$cwd" ]; then
+    remote=$(git -C "$cwd" config --get remote.origin.url 2>/dev/null || true)
+    case "$remote" in
+        *ForumVirium*|*forumvirium*) fvh=1 ;;
+    esac
+fi
+
+if [ "$fvh" = 0 ] && command -v task >/dev/null 2>&1; then
+    if task +ACTIVE export 2>/dev/null \
+        | jq -e '[.[].project // ""] | map(test("^(fvh|infrastructure)")) | any' \
+            >/dev/null 2>&1; then
+        fvh=1
+    fi
+fi
+
+[ "$fvh" = 0 ] && exit 0
+
+# Wind-down signal in the last 3 user messages. Recent messages are at the
+# end of the transcript, so tail is enough — no need for tac/portability hacks.
+recent=$(grep '"role":"user"' "$transcript" 2>/dev/null | tail -3 || true)
+if ! echo "$recent" | grep -Eiq '\b(wrap up|wrap this|wrap the session|done for (today|now|the day)|calling it|good night|signing off|end of day|gotta go|heading out|i.?m done|thats it for|that.?s it for)\b'; then
+    exit 0
+fi
+
+# Mark and emit. `decision: block` injects the reason as continued context
+# so the agent will produce one more response — a /session-wrap suggestion.
+touch "$state_file"
+
+reason="The user is wrapping up an FVH-scoped session. Before letting the session end, briefly offer to run /session-wrap — it captures loose threads (PRs awaiting review, decisions deferred, manual follow-ups) to taskwarrior plus the FVH Obsidian daily note. Apply the skill's signal filter aggressively: if nothing follow-up-worthy actually surfaced, just acknowledge the wrap and end. Do not run /session-wrap without user confirmation."
+
+jq -nc --arg r "$reason" '{decision: "block", reason: $r}'

--- a/exact_dot_claude/rules/taskwarrior-cross-session.md
+++ b/exact_dot_claude/rules/taskwarrior-cross-session.md
@@ -1,0 +1,69 @@
+# Cross-Session Work Tracking via Taskwarrior
+
+The session-level `TaskCreate` / `TaskList` tools live and die with the conversation. When work emerges during a session that **won't complete in that session** — waiting on a PR to merge, a feature to land, a manual UI step, a verification against an external source, a future re-check — log it to **taskwarrior** so it survives the session boundary.
+
+## When to add a taskwarrior task
+
+Add one when **all** of these are true:
+
+- The work is concrete and actionable (not "think about X someday")
+- It can't be finished before the user ends the session
+- It isn't already tracked somewhere durable (existing GitHub issue, PR, calendar event)
+
+Don't add tasks for:
+
+- Work the agent completed during the session (the in-session `TaskCreate` tool already captured that)
+- Vague aspirations or "maybe someday" ideas — those rot in the queue
+- Items that are *already* a GitHub issue / PR — annotate the existing one or link to it from a parent task, but don't duplicate
+
+## Project naming convention
+
+Always set `project:<descriptive-name>`. Use a single, consistent label per long-running area of work so `task project:<name>` filters cleanly.
+
+| Context | `project:` |
+|---|---|
+| D&D campaign vault (Immeral) | `immeral` |
+| Other long-running personal projects | match the repo / directory name |
+| Cross-project chores (dotfiles, infra) | `dotfiles`, `infra`, etc. |
+
+When unsure what to use for a new context, ask the user once and then stick to it.
+
+## Annotate with references
+
+Every task that links to something durable should carry an annotation pointing at it:
+
+```sh
+task <id> annotate "Doc: Pages/Immeral 2024 Migration Notes.md"
+task <id> annotate "See: https://github.com/owner/repo/issues/123"
+```
+
+This lets a future agent (or the user) pick up the task with full context without scrolling the conversation history.
+
+## Priority and tags
+
+- `priority:H` — affects gameplay / blocks downstream work
+- `priority:M` — improves quality but not blocking
+- `priority:L` — nice-to-have, monitoring, follow-up
+- Tags scope the work area: `+foundry`, `+dnd`, `+migration`, `+chezmoi`, etc.
+
+Default to `priority:M` if unsure; the user can re-rank with `task <id> modify priority:H`.
+
+## Workflow at session end
+
+When wrapping up a session that produced ongoing work:
+
+1. List the items that survived the session (manual sheet edits, audit follow-ups, blocked-on-tool tasks)
+2. Add each to taskwarrior with the right project, tags, priority, and annotations
+3. Briefly tell the user what got logged so they can adjust before context closes
+
+Do this proactively when the work clearly outlives the session — don't wait for the user to ask. But also don't over-log: 3-6 well-chosen tasks beats 20 noisy ones.
+
+## What this is *not*
+
+- **Not** a replacement for GitHub issues. Issues belong to the project; taskwarrior is the user's personal cross-project queue.
+- **Not** a replacement for in-session `TaskCreate`. That tool tracks active work *during* the conversation; taskwarrior tracks work *between* conversations.
+- **Not** a calendar. Use `due:` only when there's an actual deadline.
+
+## Rationale
+
+The default failure mode without this rule: useful follow-up work — "fix the spell-slot consumption on the sheet", "verify the audit items against the PHB", "check if issue #142 has landed" — gets surfaced in conversation, agreed in principle, and then vanishes the moment the session ends. Taskwarrior is the personal queue that bridges sessions. Logging there at the natural checkpoint (end of a piece of work that generated follow-ups) keeps the queue honest and the user out of the "wait, what was I supposed to do next?" trap.

--- a/exact_dot_claude/settings.json
+++ b/exact_dot_claude/settings.json
@@ -128,13 +128,26 @@
     "ask": [],
     "defaultMode": "acceptEdits",
     "additionalDirectories": [
-      "~/Documents/FVH Vault",
+      "~/Documents/LakuVault",
       "~/repos/ForumViriumHelsinki/infrastructure.wiki"
     ]
   },
   "statusLine": {
     "type": "command",
     "command": "bash ~/.claude/statusline-command.sh"
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/session-wrap-nudge.sh"
+          }
+        ]
+      }
+    ]
   },
   "enabledPlugins": {
     "bevy-plugin@laurigates-claude-plugins": false,

--- a/exact_dot_claude/skills/session-wrap/SKILL.md
+++ b/exact_dot_claude/skills/session-wrap/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: session-wrap
+description: Wrap up a working session by capturing loose threads. Updates taskwarrior tasks for the current project (done / annotate / add) and appends genuine follow-ups to the FVH Obsidian daily note when the work is FVH-scoped. Filters aggressively for signal — only logs items that won't resurface on their own. Use when the user says "wrap up", "session wrap", "wrap the session", "I'm done for now", or invokes /session-wrap. May also be triggered by a Stop-hook nudge — when the user signals wind-down on an FVH-scoped session, the hook injects a one-time reminder to offer this skill.
+created: 2026-05-12
+modified: 2026-05-12
+---
+
+# /session-wrap
+
+End-of-session capture for the things that **won't surface on their
+own** the next time the user sits down. The default failure mode this
+skill prevents: useful follow-up work gets agreed in conversation,
+the session ends, and a week later the user can't remember what was
+left hanging.
+
+Two destinations, picked by context:
+
+| Destination | When | What goes there |
+|---|---|---|
+| **taskwarrior** | Every wrap | Mark completed tasks done; annotate in-flight tasks with PR / blocker / current state; add new tasks for surfaced threads |
+| **FVH Obsidian daily note** | Only when session is FVH-scoped | Narrative `## Log` entry; actionable `## Todo` items the user will want tomorrow |
+
+Non-FVH sessions (immeral, claude-plugins, dotfiles, personal projects)
+get **only** the taskwarrior pass — the FVH daily note stays clean.
+
+## Detecting FVH scope
+
+The session is FVH-scoped if **any** of these are true:
+
+- Taskwarrior project for the active work is `fvh.*` or `infrastructure*`
+- Working directory path contains `ForumViriumHelsinki` or `repos/ForumVirium`
+- The user explicitly says so ("this is FVH work", "log to FVH daily")
+- The conversation referenced FVH repos, Podio items, simpl-eval,
+  TFDS, Hetzner, GKE, fvh-cluster, fvh.fi, fvh.io, etc.
+
+Default to **non-FVH** when in doubt — better to skip the daily note
+than spam it. If you're not sure, ask the user once: "FVH-scoped?
+(y/n)".
+
+## The signal filter — what gets logged
+
+This is the whole point of the skill. The user said explicitly: "not
+for everything so i dont drown in signals."
+
+### LOG IT — qualifies
+
+- A PR is open and **waiting** (review, CI, merge gate not yet
+  cleared) — capture the PR URL and the gate
+- A task was started but **couldn't finish this session** — blocked
+  on info, awaiting a reply, build broken, dependency missing
+- A **manual follow-up** action is required outside Claude Code — UI
+  step, person to message, deploy to trigger, infra change to apply,
+  config to edit by hand
+- A **decision was deferred** ("come back to this later", "we'll
+  revisit X")
+- A **loose thread surfaced** that wasn't already tracked — bug
+  noticed in passing, refactor opportunity, doc to write, follow-up
+  to a fix that didn't happen
+- An **investigation found something** worth not losing — surprising
+  discovery, half-explored hypothesis, file/line worth revisiting
+
+### DO NOT LOG — drown-in-signals patterns
+
+- Work that **finished cleanly this session** — commit landed, PR
+  merged, task completed (mark the taskwarrior task done, but don't
+  narrate it in the daily note)
+- Anything **already tracked** as a GitHub issue, PR description, or
+  existing taskwarrior task that didn't change state — duplicates
+  add noise, not signal
+- **Routine ops** the user does every day — running `just lint`,
+  checking PRs, syncing dotfiles
+- **Self-resolving items** — "CI is still running" usually doesn't
+  need a follow-up unless it's been red for a meaningful reason
+- **Conversational context** — what the user asked, what files were
+  read, what the agent decided — that's all in the transcript
+- **Speculation** — "we might want to refactor X someday"; that's a
+  rot-magnet, not a follow-up
+
+When in doubt, ask: *"If I don't write this down, will the user
+notice the gap when they sit down tomorrow?"* If yes → log it. If no
+→ skip it. 3-6 items per wrap is the right shape. 10+ means the
+filter is too loose.
+
+## The workflow
+
+### 1. Survey
+
+Quickly enumerate what the session touched. Look at:
+
+- Recent commits on the active branch (`git log --oneline -20`)
+- Open PRs on the active branch (`gh pr list --head $(git branch --show-current)`)
+- Existing taskwarrior tasks for the inferred project
+  (`task project:<name> status:pending export | jq '.[]'`)
+- Any tasks marked `+ACTIVE` by the in-session work
+- The conversation itself — what was kicked off but not finished,
+  what was discussed but not done
+
+### 2. Categorise
+
+For each candidate item, classify as one of:
+
+| Category | Action |
+|---|---|
+| Done this session | `task <id> done` (taskwarrior only — no daily note) |
+| In-flight, well-tracked | Annotate the existing task with the new state |
+| In-flight, untracked | Either add a new taskwarrior task **or** a daily-note Todo (not both) |
+| Loose thread, FVH | Daily note `## Log` (narrative) or `## Todo` (action) |
+| Loose thread, non-FVH | Taskwarrior only, with `project:<name>` |
+| Noise (per filter above) | Skip silently |
+
+### 3. Preview
+
+Show the user a compact preview before writing **anything**:
+
+```
+About to wrap:
+
+  taskwarrior (project: fvh.cost-attribution)
+    done:   #234 "Land #1778 GKE cost allocation"
+    annot:  #237 "Cluster fallback rules" — PR #1774 waiting on review
+    add:    "Ping Aapo re Hetzner db01-03 shutdown decision (Podio #838)"
+
+  FVH daily 2026-05-12.md
+    Log:    Pulled cost-attribution timeline for data-dev. Open thread:
+            cluster fallback resolution rules (PR #1774, 7+ days stale).
+    Todo:   - [ ] Confirm Hetzner db shutdown date with Aapo (#838)
+            - [ ] Nudge production GKE Standard PR #1607 reviewers
+
+Apply? (y/n)
+```
+
+Wait for the user to confirm. They may want to redact items or add
+ones. Don't write the daily note silently — it's part of their
+personal vault.
+
+### 4. Apply
+
+For taskwarrior:
+
+```sh
+# Mark done
+task <id> done
+
+# Annotate in-flight
+task <id> annotate "PR #1774 awaiting review (data-dev), opened 2026-05-04"
+
+# Add new
+task add project:fvh.archival priority:M +follow-up \
+  "Ping Aapo re Hetzner db01-03 shutdown decision (Podio #838)"
+task <id> annotate "See: https://podio.com/fvh/iot-workspace/apps/datadev-kanban/items/838"
+```
+
+For the FVH daily note at `~/Documents/LakuVault/FVH/notes/YYYY-MM-DD.md`:
+
+- If the file doesn't exist, create it from
+  `~/Documents/LakuVault/Templates/FVH Daily.md` (preserves frontmatter
+  and `## Scheduled tasks` dataview block)
+- Append the narrative items under `## Log`
+- Append the actionable items as `- [ ]` checkboxes under `## Todo`
+- Use Obsidian-style `[[...]]` links for cross-references; full URLs
+  for PRs/Podio/external
+
+### 5. Report
+
+One-paragraph summary of what was written and where, plus the count
+of items skipped as noise so the user can sanity-check the filter
+was tight.
+
+## Project naming rules (taskwarrior)
+
+Follow `~/.claude/rules/taskwarrior-cross-session.md`. Common
+projects in this user's queue:
+
+| Context | `project:` |
+|---|---|
+| FVH infrastructure work | `fvh.<area>` — `fvh.cost-attribution`, `fvh.renovate-cleanup`, `fvh.archival`, etc. |
+| FVH simpl-eval | `infrastructure.simpl-eval` |
+| FVH infrastructure (generic) | `infrastructure` |
+| Personal claude-plugins work | `claude-plugins`, `claude-plugins.friction`, `claude-plugins.project-plugin` |
+| Dotfiles / chezmoi | `dotfiles` |
+| Immeral D&D vault | `immeral` |
+
+If the active work doesn't match any existing project, list options
+with `task _projects` and ask the user once.
+
+## Templates
+
+### FVH daily note — section append targets
+
+The template (Templates/FVH Daily.md) has these sections in order:
+`Log`, `Thoughts`, `Discoveries`, `Todo`, `Recurring reminders`,
+`Links`, `Scheduled tasks`. Append to `## Log` and `## Todo` only.
+Don't touch `Thoughts` / `Discoveries` (those are the user's own
+voice) or `Recurring reminders` / `Links` / `Scheduled tasks`
+(structural).
+
+When appending under `## Todo`, place new items *before* the
+`### Recurring reminders` subheading. The Todo section is a flat
+list of `- [ ]` checkboxes.
+
+### Log entry shape
+
+Keep `## Log` entries short and contextual — one or two sentences
+each, with a `[[wikilink]]` or URL for follow-through. Group by
+topic if you have 3+ items.
+
+```
+- Cost-attribution: data-dev weekly talking points pulled; PR #1778 landed; #1774 still open after 7 days. See [[2026-05-12]] for the full list.
+- Hetzner decom: confirmed db01-03 + dckr2/3 + geo.fvh.fi need owner pings before shutdown. Tracked in Podio #838/839/837.
+```
+
+### Todo entry shape
+
+Each is a single `- [ ]` line with enough context to act without
+re-reading the conversation:
+
+```
+- [ ] Nudge production GKE Standard PR #1607 reviewers (stale 7d, ADR-0024)
+- [ ] Confirm Hetzner db01-03 shutdown date with Aapo (Podio #838)
+- [ ] Decide on OpenCost re-evaluation date (ADR-0029 deferred)
+```
+
+## Edge cases
+
+- **Multiple projects touched in one session** — wrap each project
+  independently; show one preview block per project.
+- **No active project detected** — ask the user which project to log
+  under (or "skip taskwarrior pass").
+- **Daily note already has entries from a prior wrap today** — append
+  cleanly; don't deduplicate aggressively (the user can manually
+  prune). Do skip exact-string duplicates.
+- **User wants to skip the daily note** for an FVH session — honor
+  it. The taskwarrior pass still runs.
+- **User wants to log to daily note for a non-FVH session** — honor
+  it (e.g. dotfiles work that wants narrative continuity). Default
+  off, override on.
+
+## Auto-surfacing via Stop hook
+
+A Stop hook at `~/.claude/hooks/session-wrap-nudge.sh` watches for
+session wind-down signals and injects a one-time reminder per session
+to **offer** this skill. The hook fires only when **all** of these
+hold:
+
+- The session has ≥ 6 user turns (not a quick lookup)
+- FVH context is detected (cwd, git remote, or active taskwarrior
+  `fvh.*` / `infrastructure*` project)
+- One of the last 3 user messages matches a wind-down phrase
+  (`wrap up`, `done for the day`, `calling it`, `signing off`,
+  `gotta go`, `end of day`, etc.)
+- No prior nudge in the same session (state file in
+  `~/.cache/claude-session-wrap-nudge/<session_id>`)
+
+When triggered, the agent should briefly **offer** the wrap, not run
+it. Run only after user confirmation. If the session has no genuine
+follow-up-worthy threads, the right move is to acknowledge the wind-
+down and end — drown-in-signals is the failure mode to avoid.
+
+To disable temporarily: `touch ~/.cache/claude-session-wrap-nudge/<session_id>`
+before the hook fires, or remove the Stop entry from
+`~/.claude/settings.json`.
+
+## Rationale
+
+The taskwarrior-cross-session rule already says "log work that
+outlives the session to taskwarrior". This skill **enforces** that
+rule at the natural checkpoint (end of session) and adds a second
+destination — the FVH daily note — for the narrative continuity that
+taskwarrior alone can't provide. The signal filter is the whole
+value: a wrap that captures 4 real loose threads beats a wrap that
+mechanically lists everything the session touched.


### PR DESCRIPTION
## Summary

- New `session-wrap` skill captures genuine end-of-session loose threads to taskwarrior (always) and to the FVH Obsidian daily note (when FVH-scoped), with an explicit signal filter to keep wraps to 3-6 actionable items
- Stop-hook `~/.claude/hooks/session-wrap-nudge.sh` self-surfaces the skill once per session when four conditions hold: ≥6 user turns, FVH context (cwd/git remote/`+ACTIVE` taskwarrior `fvh.*`/`infrastructure*` project), a wind-down phrase in the last 3 user messages, and no prior nudge state file
- Foundation rule `taskwarrior-cross-session.md` codifies the cross-session work-tracking pattern the skill leans on
- Drive-by fix: `additionalDirectories` pointed at the long-gone `~/Documents/FVH Vault` — the FVH content lives in `~/Documents/LakuVault/FVH/` now, so point at the LakuVault root instead

## Test plan

- [x] Hook smoke-tested against five gating paths: `stop_hook_active=true` (no loop), short session, long+wind-down+non-FVH cwd, long+wind-down+FVH cwd (emits nudge), re-run same session_id (state-file suppression)
- [x] `chezmoi apply` produces `~/.claude/hooks/session-wrap-nudge.sh` with exec bit + correct `hooks.Stop` registration in `~/.claude/settings.json`
- [x] Pre-commit hooks (conventional-commit + gitleaks) pass on both commits
- [ ] Real end-to-end: next FVH session that wraps with "calling it for the day" should see the agent offer `/session-wrap`

🤖 Generated with [Claude Code](https://claude.com/claude-code)