### PR TITLE
feat(claude): add session-spinup skill with SessionStart hook

### DIFF
--- a/exact_dot_claude/hooks/executable_session-spinup-nudge.sh
+++ b/exact_dot_claude/hooks/executable_session-spinup-nudge.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# SessionStart hook — nudges the agent to propose /session-spinup when the
+# user is starting/resuming an FVH-scoped session AND there is at least one
+# loose thread waiting (taskwarrior, daily-note Todos, or git state).
+#
+# Fires at most once per session_id (state file). Silent on compact/clear —
+# those are mid-session continuations where the user already has context.
+
+set -euo pipefail
+
+input=$(cat)
+
+session_id=$(jq -r '.session_id // empty' <<<"$input" 2>/dev/null || echo "")
+cwd=$(jq -r '.cwd // empty' <<<"$input" 2>/dev/null || echo "")
+source=$(jq -r '.source // empty' <<<"$input" 2>/dev/null || echo "")
+
+[ -z "$session_id" ] && exit 0
+
+# Only nudge on fresh entry — compact/clear preserve in-memory context
+case "$source" in
+    startup|resume) ;;
+    *) exit 0 ;;
+esac
+
+# At most one nudge per session
+state_dir="${HOME}/.cache/claude-session-spinup-nudge"
+mkdir -p "$state_dir"
+state_file="$state_dir/$session_id"
+[ -f "$state_file" ] && exit 0
+
+# FVH context detection: cwd path, git remote, or active taskwarrior project
+fvh=0
+case "$cwd" in
+    *ForumVirium*|*forumvirium*) fvh=1 ;;
+esac
+
+if [ "$fvh" = 0 ] && [ -d "$cwd" ]; then
+    remote=$(git -C "$cwd" config --get remote.origin.url 2>/dev/null || true)
+    case "$remote" in
+        *ForumVirium*|*forumvirium*) fvh=1 ;;
+    esac
+fi
+
+if [ "$fvh" = 0 ] && command -v task >/dev/null 2>&1; then
+    if task +ACTIVE export 2>/dev/null \
+        | jq -e '[.[].project // ""] | map(test("^(fvh|infrastructure)")) | any' \
+            >/dev/null 2>&1; then
+        fvh=1
+    fi
+fi
+
+[ "$fvh" = 0 ] && exit 0
+
+# "Something to surface" gate — at least one of these must be non-empty.
+# The hook only signals presence; the skill enumerates the items.
+has_threads=0
+
+# 1. Pending or +ACTIVE taskwarrior tasks under an FVH-ish project.
+#    Uses `export | jq` (exit 0 on empty) per parallel-safe-queries rule.
+if command -v task >/dev/null 2>&1; then
+    pending_count=$(task '(status:pending or +ACTIVE)' export 2>/dev/null \
+        | jq -r '[.[] | select((.project // "") | test("^(fvh|infrastructure)"))] | length' \
+        2>/dev/null || echo 0)
+    if [ "${pending_count:-0}" -gt 0 ]; then
+        has_threads=1
+    fi
+fi
+
+# 2. Unchecked Todos in the most recent FVH daily note (last 7 days).
+if [ "$has_threads" = 0 ]; then
+    notes_dir="${HOME}/Documents/LakuVault/FVH/notes"
+    if [ -d "$notes_dir" ]; then
+        for offset in 0 1 2 3 4 5 6 7; do
+            day=$(date -v-"${offset}"d +%Y-%m-%d 2>/dev/null || date -d "-${offset} day" +%Y-%m-%d 2>/dev/null || echo "")
+            [ -z "$day" ] && continue
+            note="$notes_dir/$day.md"
+            [ -f "$note" ] || continue
+            # Extract the ## Todo section (stop at next ## or ### Recurring reminders).
+            todo_lines=$(awk '
+                /^## Todo[[:space:]]*$/ { in_todo = 1; next }
+                in_todo && /^### Recurring reminders/ { in_todo = 0 }
+                in_todo && /^## / { in_todo = 0 }
+                in_todo { print }
+            ' "$note" 2>/dev/null | grep -c '^- \[ \]' 2>/dev/null || echo 0)
+            if [ "${todo_lines:-0}" -gt 0 ]; then
+                has_threads=1
+                break
+            fi
+        done
+    fi
+fi
+
+# 3. Git state — uncommitted changes or unpushed commits on the current branch.
+if [ "$has_threads" = 0 ] && [ -d "$cwd" ] && git -C "$cwd" rev-parse --git-dir >/dev/null 2>&1; then
+    dirty=$(git -C "$cwd" status --porcelain 2>/dev/null | head -n1 || true)
+    if [ -n "$dirty" ]; then
+        has_threads=1
+    else
+        unpushed=$(git -C "$cwd" log '@{u}..HEAD' --oneline 2>/dev/null | head -n1 || true)
+        if [ -n "$unpushed" ]; then
+            has_threads=1
+        fi
+    fi
+fi
+
+[ "$has_threads" = 0 ] && exit 0
+
+# Mark and emit. `decision: block` injects the reason as continued context
+# so the agent's first response will offer /session-spinup.
+touch "$state_file"
+
+reason="The user is opening an FVH-scoped session and there is at least one open thread to surface (taskwarrior queue, an unchecked Todo from a recent FVH daily note, uncommitted changes, or unpushed commits). Briefly offer to run /session-spinup — it is read-only and surfaces the project's open threads (taskwarrior, FVH daily-note Todos, current git state, open PRs) before the user dives in. Offer the skill; do not run it without user confirmation."
+
+jq -nc --arg r "$reason" '{decision: "block", reason: $r}'

--- a/exact_dot_claude/hooks/executable_session-wrap-nudge.sh
+++ b/exact_dot_claude/hooks/executable_session-wrap-nudge.sh
@@ -32,15 +32,21 @@ state_file="$state_dir/$session_id"
 user_turns=$(grep -c '"role":"user"' "$transcript" 2>/dev/null || echo 0)
 [ "$user_turns" -lt 6 ] && exit 0
 
+# Read the git origin once — used for both FVH detection and the
+# GitHub-issue follow-up gate below
+origin=""
+if [ -d "$cwd" ]; then
+    origin=$(git -C "$cwd" config --get remote.origin.url 2>/dev/null || true)
+fi
+
 # FVH context detection: cwd path, git remote, or active taskwarrior project
 fvh=0
 case "$cwd" in
-    *ForumVirium*|*forumvirium*|*ForumViriumHelsinki*) fvh=1 ;;
+    *ForumVirium*|*forumvirium*) fvh=1 ;;
 esac
 
-if [ "$fvh" = 0 ] && [ -d "$cwd" ]; then
-    remote=$(git -C "$cwd" config --get remote.origin.url 2>/dev/null || true)
-    case "$remote" in
+if [ "$fvh" = 0 ]; then
+    case "$origin" in
         *ForumVirium*|*forumvirium*) fvh=1 ;;
     esac
 fi
@@ -55,6 +61,14 @@ fi
 
 [ "$fvh" = 0 ] && exit 0
 
+# Only mention GitHub follow-up issues when the cwd is a git repo with a
+# github.com origin — skips the suggestion for non-git sessions and for
+# local-only / self-hosted-remote repos where it'd be a confusing prompt
+has_github=0
+case "$origin" in
+    *github.com*) has_github=1 ;;
+esac
+
 # Wind-down signal in the last 3 user messages. Recent messages are at the
 # end of the transcript, so tail is enough — no need for tac/portability hacks.
 recent=$(grep '"role":"user"' "$transcript" 2>/dev/null | tail -3 || true)
@@ -66,6 +80,11 @@ fi
 # so the agent will produce one more response — a /session-wrap suggestion.
 touch "$state_file"
 
-reason="The user is wrapping up an FVH-scoped session. Before letting the session end, briefly offer to run /session-wrap — it captures loose threads (PRs awaiting review, decisions deferred, manual follow-ups) to taskwarrior plus the FVH Obsidian daily note. Apply the skill's signal filter aggressively: if nothing follow-up-worthy actually surfaced, just acknowledge the wrap and end. Do not run /session-wrap without user confirmation."
+followup_dests="taskwarrior plus the FVH Obsidian daily note"
+if [ "$has_github" = 1 ]; then
+    followup_dests="taskwarrior, the FVH Obsidian daily note, and a separate GitHub issue for each post-merge follow-up (linked from the PR description, per ~/.claude/CLAUDE.md)"
+fi
+
+reason="The user is wrapping up an FVH-scoped session. Before letting the session end, briefly offer to run /session-wrap — it captures loose threads (PRs awaiting review, decisions deferred, manual follow-ups) to ${followup_dests}. Apply the skill's signal filter aggressively: if nothing follow-up-worthy actually surfaced, just acknowledge the wrap and end. Do not run /session-wrap without user confirmation."
 
 jq -nc --arg r "$reason" '{decision: "block", reason: $r}'

--- a/exact_dot_claude/settings.json
+++ b/exact_dot_claude/settings.json
@@ -137,6 +137,17 @@
     "command": "bash ~/.claude/statusline-command.sh"
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/session-spinup-nudge.sh"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "matcher": "",

--- a/exact_dot_claude/skills/session-spinup/SKILL.md
+++ b/exact_dot_claude/skills/session-spinup/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: session-spinup
+description: Spin up a working session by surfacing the project's open threads. Pulls the taskwarrior queue for the inferred project, the unchecked Todos from the most recent FVH daily note when work is FVH-scoped, and recent git state (current branch, uncommitted changes, unpushed commits, open PRs). Read-only — does not write to taskwarrior or the vault. Use when the user says "spin up", "session start", "pick up where I left off", "what was I doing", or invokes /session-spinup. May also be triggered by a SessionStart hook nudge — when an FVH-scoped session opens with pending threads, the hook injects a one-time reminder to offer this skill.
+created: 2026-05-13
+modified: 2026-05-13
+---
+
+# /session-spinup
+
+Read-only orientation at session start. The inverse of `/session-wrap`:
+where wrap writes loose threads, spinup reads them back. The default
+failure mode this skill prevents: the user sits down, doesn't remember
+what was open, and starts fresh on something else while yesterday's PR
+sits stale and the daily-note Todo from yesterday rots unchecked.
+
+Three sources, picked by context:
+
+| Source | When | What comes from there |
+|---|---|---|
+| **taskwarrior** | Every spin-up | Pending tasks for the inferred project; `+ACTIVE` tasks (lock state); recently-annotated tasks |
+| **FVH Obsidian daily note** | Only when FVH-scoped | Unchecked `- [ ]` items under `## Todo` from the most recent FVH daily note (up to 7 days back) |
+| **git state** | Every spin-up | Current branch, uncommitted changes, unpushed commits, open PRs from this branch |
+
+Non-FVH sessions (immeral, claude-plugins, dotfiles, personal projects)
+get **only** the taskwarrior + git passes — the daily-note source stays
+silent.
+
+## Detecting FVH scope
+
+The session is FVH-scoped if **any** of these are true:
+
+- Taskwarrior project for the active work is `fvh.*` or `infrastructure*`
+- Working directory path contains `ForumViriumHelsinki` or `repos/ForumVirium`
+- The user explicitly says so ("this is FVH work", "FVH spinup")
+- The conversation referenced FVH repos, Podio items, simpl-eval,
+  TFDS, Hetzner, GKE, fvh-cluster, fvh.fi, fvh.io, etc.
+
+Default to **non-FVH** when in doubt — better to skip the daily-note
+read than to dredge through it for a non-FVH session.
+
+## The signal filter — what gets surfaced
+
+This is the whole point of the skill. Spinup is the mirror of wrap:
+surface only what the user would otherwise miss when they sit down.
+
+### SURFACE IT — qualifies
+
+- An **open PR** from a recent branch, not yet merged — especially if
+  it has been waiting on review/CI for a meaningful number of days
+- A **`+ACTIVE` task** (work-in-progress lock state) — the user was
+  in the middle of something
+- An **unchecked Todo from yesterday** (or the most recent daily note
+  within 7 days) under `## Todo`
+- **Uncommitted changes** that aren't WIP-junk — actual in-flight
+  edits the user paused on
+- **Unpushed commits** on the current branch — work that hasn't
+  reached the remote yet
+- A **task annotated as "blocked on X"** where X may now be unblocked
+  (e.g. PR landed, reviewer responded, deploy completed)
+
+### DO NOT SURFACE — noise
+
+- Tasks **completed yesterday** (`status:completed`) — they're done
+- **Merged PRs** — no action required
+- **Routine daily reminders** — the daily note's
+  `### Recurring reminders` subsection is structural, not signal
+- **Scheduled tasks** dataview block — Obsidian's own machinery
+  surfaces those at render time
+- The **conversational context** — there isn't one yet; this is a
+  fresh session
+- **Tasks pending for weeks with no recent annotation** — they're not
+  this session's signal; let `/task-status` handle the cross-project
+  rot sweep
+
+Same 3-6 items target as wrap. 10+ means the filter is too loose —
+trim to what the user would actually want to act on this session.
+
+## The workflow
+
+### 1. Detect
+
+Infer the active project from:
+
+- `cwd` — `repos/ForumViriumHelsinki/infrastructure` → `infrastructure`;
+  `.local/share/chezmoi` → `dotfiles`; `repos/laurigates/claude-plugins`
+  → `claude-plugins`
+- `git remote get-url origin` — falls back to repo name when cwd is
+  ambiguous
+- Any taskwarrior task currently `+ACTIVE` — its `project:` wins over
+  cwd-inferred name (the user was mid-task)
+
+If multiple projects are detectable (monorepo, multi-package), survey
+each in its own section.
+
+### 2. Survey
+
+Pull from the three sources in parallel-safe form:
+
+```sh
+# Taskwarrior — `export | jq` is exit-0 on empty (see rules/parallel-safe-queries.md)
+task project:<name> '(status:pending or +ACTIVE)' export | jq '.[]'
+
+# Git state
+git -C "$cwd" status --porcelain
+git -C "$cwd" log '@{u}..HEAD' --oneline
+git -C "$cwd" branch --show-current
+
+# Open PRs for the current branch
+gh pr list --head "$(git -C "$cwd" branch --show-current)" \
+  --json number,title,url,state,createdAt --jq '.[]'
+```
+
+For the daily-note source (FVH only), walk back from today:
+
+```sh
+for offset in 0 1 2 3 4 5 6 7; do
+    day=$(date -v-"${offset}"d +%Y-%m-%d)  # macOS; GNU: date -d "-${offset} day"
+    note="$HOME/Documents/LakuVault/FVH/notes/$day.md"
+    [ -f "$note" ] || continue
+    awk '
+        /^## Todo[[:space:]]*$/ { in_todo = 1; next }
+        in_todo && /^### Recurring reminders/ { in_todo = 0 }
+        in_todo && /^## / { in_todo = 0 }
+        in_todo && /^- \[ \]/ { print }
+    ' "$note"
+    break  # first note found wins
+done
+```
+
+### 3. Present
+
+Compact briefing, one section per source. No mutating actions in this
+phase — spinup is read-only. Example:
+
+```
+Spin-up — project: fvh.cost-attribution (cwd: repos/ForumViriumHelsinki/infrastructure)
+
+  taskwarrior (3 pending)
+    +ACTIVE  #237 "Cluster fallback rules"
+             annot: PR #1774 awaiting review (data-dev), opened 2026-05-04
+             [11 days stale — reviewer may have responded; check]
+    pending  #240 "Confirm Hetzner db01-03 shutdown date with Aapo (#838)"
+    pending  #243 "OpenCost re-evaluation date (ADR-0029 deferred)"
+
+  FVH daily 2026-05-12.md (yesterday)
+    - [ ] Nudge production GKE Standard PR #1607 reviewers (stale 7d)
+    - [ ] Decide on OpenCost re-evaluation date
+
+  git state (branch: feat/cluster-fallback-rules)
+    PR #1774 OPEN — 11d since open, 3 unpushed commits ahead of origin
+
+Next moves:
+  • Resume #237 — check PR #1774 review state
+  • Tackle yesterday's Todo: nudge PR #1607 reviewers
+  • Confirm Hetzner shutdown date (#240, blocks #838)
+```
+
+### 4. Offer next moves
+
+Concrete, actionable options. Let the user pick — don't auto-resume
+a task or start a workflow. The user may want to look at something
+else entirely; the spin-up just makes the open threads visible.
+
+## Project naming rules (taskwarrior)
+
+Follow `~/.claude/rules/taskwarrior-cross-session.md`. Same projects
+as wrap:
+
+| Context | `project:` |
+|---|---|
+| FVH infrastructure work | `fvh.<area>` — `fvh.cost-attribution`, `fvh.renovate-cleanup`, `fvh.archival`, etc. |
+| FVH simpl-eval | `infrastructure.simpl-eval` |
+| FVH infrastructure (generic) | `infrastructure` |
+| Personal claude-plugins work | `claude-plugins`, `claude-plugins.friction`, `claude-plugins.project-plugin` |
+| Dotfiles / chezmoi | `dotfiles` |
+| Immeral D&D vault | `immeral` |
+
+When the cwd doesn't map cleanly to a known project, list options
+with `task _projects` and ask the user once.
+
+## Daily-note read shape
+
+Parse the most recent `~/Documents/LakuVault/FVH/notes/YYYY-MM-DD.md`
+(today first, then walk back up to 7 days; stop at the first match).
+Extract unchecked `- [ ]` lines from the `## Todo` section.
+
+Stop the extraction at the first of:
+
+- `### Recurring reminders` subheading (those are structural reminders,
+  not signal)
+- The next `## ` heading (e.g. `## Links`, `## Scheduled tasks`)
+
+Skip the dataview `## Scheduled tasks` block — Obsidian's own
+machinery surfaces those when the user opens the vault. Spinup is
+filling in what the terminal-only view can't see.
+
+## Edge cases
+
+- **No FVH daily note exists** for the last 7 days — silently skip
+  the daily-note source. Still show taskwarrior + git state.
+- **Multiple projects detectable** from cwd (monorepo, multi-package)
+  — present each project's slice in its own section.
+- **No taskwarrior tasks for the project** — say so explicitly
+  (`nothing pending under project:<name>`) rather than emit an empty
+  section that looks broken.
+- **No open PRs and clean working tree** — say "git state: clean" in
+  one line rather than omitting the section.
+- **User in plan mode / interactive UI** — don't auto-run; just
+  present the briefing.
+- **All sources empty** — say so briefly ("nothing open under
+  `project:<name>`; clean working tree; no recent FVH Todos"), then
+  step out of the way. Spinup is informational; the user can take it
+  from there.
+
+## Auto-surfacing via SessionStart hook
+
+A SessionStart hook at `~/.claude/hooks/session-spinup-nudge.sh`
+watches for fresh session entries and injects a one-time reminder per
+session to **offer** this skill. The hook fires only when **all** of
+these hold:
+
+- The SessionStart `source` is `startup` or `resume` (silent on
+  `compact`/`clear` — those are mid-session continuations)
+- FVH context is detected (cwd, git remote, or active taskwarrior
+  `fvh.*` / `infrastructure*` project)
+- At least **one** of these is non-empty:
+  - Pending or `+ACTIVE` taskwarrior tasks under an FVH project
+  - Unchecked `- [ ]` items in the most recent FVH daily note (7 days)
+  - Uncommitted changes or unpushed commits on the current branch
+- No prior nudge in the same session (state file in
+  `~/.cache/claude-session-spinup-nudge/<session_id>`)
+
+When triggered, the agent should briefly **offer** the spin-up, not
+run it. Run only after user confirmation. If everything is clean
+(taskwarrior empty, no FVH Todos, clean tree), the hook stays silent
+— spinup doesn't nudge for nothing.
+
+To disable temporarily: `touch ~/.cache/claude-session-spinup-nudge/<session_id>`
+before the hook fires, or remove the SessionStart entry from
+`~/.claude/settings.json`.
+
+## Rationale
+
+The taskwarrior-cross-session rule says "log work that outlives the
+session". `/session-wrap` writes; this skill is the read-side at the
+natural pickup checkpoint. Without it, the queue and the FVH daily
+note become write-only: the user diligently logs follow-ups at end of
+session, then never sees them when they sit down next. Spinup closes
+that loop — at minimum the taskwarrior queue, plus the FVH daily
+note's Todos and the git state, all visible in 30 seconds before the
+user picks the next move.

--- a/exact_dot_claude/skills/session-wrap/SKILL.md
+++ b/exact_dot_claude/skills/session-wrap/SKILL.md
@@ -13,15 +13,18 @@ skill prevents: useful follow-up work gets agreed in conversation,
 the session ends, and a week later the user can't remember what was
 left hanging.
 
-Two destinations, picked by context:
+Three destinations, picked by context:
 
 | Destination | When | What goes there |
 |---|---|---|
 | **taskwarrior** | Every wrap | Mark completed tasks done; annotate in-flight tasks with PR / blocker / current state; add new tasks for surfaced threads |
 | **FVH Obsidian daily note** | Only when session is FVH-scoped | Narrative `## Log` entry; actionable `## Todo` items the user will want tomorrow |
+| **GitHub issues** | Only when cwd is a git repo with a `github.com` origin AND a PR was merged this session (or is about to be) with post-merge follow-ups | One issue per follow-up, linked from the PR description (per `~/.claude/CLAUDE.md` — checklists in PR bodies vanish after merge) |
 
 Non-FVH sessions (immeral, claude-plugins, dotfiles, personal projects)
-get **only** the taskwarrior pass — the FVH daily note stays clean.
+get **only** the taskwarrior pass (plus GitHub issues if applicable) —
+the FVH daily note stays clean. Sessions outside any git repo, or in a
+repo without a github.com origin, skip the GitHub-issue pass entirely.
 
 ## Detecting FVH scope
 
@@ -106,6 +109,7 @@ For each candidate item, classify as one of:
 | In-flight, untracked | Either add a new taskwarrior task **or** a daily-note Todo (not both) |
 | Loose thread, FVH | Daily note `## Log` (narrative) or `## Todo` (action) |
 | Loose thread, non-FVH | Taskwarrior only, with `project:<name>` |
+| Post-merge follow-up (GitHub repo) | One `gh issue create` per follow-up; link each from the just-merged PR description. Skip if cwd has no github.com origin |
 | Noise (per filter above) | Skip silently |
 
 ### 3. Preview


### PR DESCRIPTION
## Summary

- Adds `/session-spinup` skill — companion to `/session-wrap` — that surfaces the project's open threads at the start of an FVH-scoped session (taskwarrior queue, unchecked Todos in the most recent FVH daily note, recent git state). Read-only.
- Wires a SessionStart hook that nudges the agent once per `session_id` when the fresh entry is `startup` or `resume` and at least one loose thread is waiting. Silent on `compact`/`clear`, which preserve in-memory context.
- Refines `/session-wrap`:
  - caches the git origin URL once for FVH detection
  - drops the redundant `*ForumViriumHelsinki*` glob (already covered by `*forumvirium*`)
  - adds a third destination — post-merge GitHub follow-up issues — gated on cwd being a git repo with a `github.com` origin. Mirrors the rule in `~/.claude/CLAUDE.md` about checklists rotting after PR merge.

## Test plan

- [ ] Open a fresh Claude Code session in an FVH-scoped repo (e.g. `~/repos/ForumViriumHelsinki/...`); confirm the nudge fires once, then doesn't fire again on the next prompt in the same session.
- [ ] Open a fresh session in a non-FVH repo; confirm no nudge.
- [ ] Trigger compact mid-session; confirm no nudge on resume (since context is preserved).
- [ ] In an FVH session, wind down ("I think I'm done for today"); confirm `/session-wrap` is offered and the reason text mentions GitHub follow-up issues only when the cwd has a github.com origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)