### PR TITLE
fix(tmux): preserve COLORTERM=truecolor and set FORCE_COLOR=3

### DIFF
--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -10,6 +10,16 @@ set -g default-terminal tmux-256color
 # disabled margins, because programs were tearing panes horizontally with them
 set -g terminal-features "xterm-kitty*:256:clipboard:ccolour:cstyle:extkeys:focus:overline:rectfill:RGB:strikethrough:sync:title:usstyle:UTF-8,xterm-256color:256:clipboard:ccolour:cstyle:extkeys:focus:overline:rectfill:RGB:strikethrough:sync:title:usstyle:UTF-8"
 
+# Some TUIs check $COLORTERM (not terminfo) to decide whether to emit
+# 24-bit sequences. Kitty sets it to "truecolor" in the outer shell;
+# make sure tmux keeps it set inside panes and refreshes it on attach.
+set -ga update-environment 'COLORTERM'
+set-environment -g COLORTERM 'truecolor'
+
+# Some Node TUIs (chalk/ink) check $TERM and downshift on tmux-*
+# despite COLORTERM=truecolor. FORCE_COLOR=3 forces 24-bit.
+set-environment -g FORCE_COLOR '3'
+
 # allow applications to create paste buffers with an escape sequence (OSC 52)
 set -g set-clipboard on
 


### PR DESCRIPTION
## Summary

- Carries `COLORTERM` through `update-environment` and sets it to `truecolor` on the tmux server, so TUIs that check `$COLORTERM` (not terminfo) keep emitting 24-bit sequences inside tmux panes.
- Sets `FORCE_COLOR=3` on the tmux server for Node TUIs (chalk/ink-based) that still downshift on `TERM=tmux-*` even with `COLORTERM=truecolor`.

## Test plan

- [ ] Outside tmux: `echo $COLORTERM` shows `truecolor` (kitty default).
- [ ] After `chezmoi apply ~/.tmux.conf` + tmux server reload: inside a fresh pane `echo $COLORTERM` shows `truecolor` and `echo $FORCE_COLOR` shows `3`.
- [ ] Sanity-check a Node TUI (e.g. `claude`, `chalk` demo) — colors render at 24-bit fidelity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)