### PR TITLE
docs(claude): clarify two .claude/ directories and track project skills

### DIFF
--- a/.claude/skills/chezmoi-expert/REFERENCE.md
+++ b/.claude/skills/chezmoi-expert/REFERENCE.md
@@ -1,0 +1,317 @@
+# Chezmoi Expert Reference
+
+Comprehensive reference documentation for advanced chezmoi operations, troubleshooting, and best practices.
+
+## Advanced Commands
+
+### Orphan Management
+
+Files renamed or deleted in source need to be tracked:
+
+```bash
+# Add to .chezmoiremove
+~/.config/app/old-config.yaml
+
+# Workflow for renaming
+1. Rename in source directory
+2. Add old path to .chezmoiremove
+3. Preview: chezmoi apply --dry-run
+4. Apply: chezmoi apply
+```
+
+### State Management
+
+```bash
+# Reset state for file
+chezmoi state delete-bucket --bucket=entryState --key=~/.bashrc
+
+# Dump state for debugging
+chezmoi state dump
+
+# Force re-run of run_once scripts
+chezmoi state reset
+```
+
+### External Files
+
+```toml
+# .chezmoiexternal.toml
+[".oh-my-zsh"]
+  type = "archive"
+  url = "https://github.com/ohmyzsh/ohmyzsh/archive/master.tar.gz"
+  stripComponents = 1
+
+[".config/nvim/autoload/plug.vim"]
+  type = "file"
+  url = "https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim"
+```
+
+## Template Functions
+
+### Built-in Functions
+
+```go
+# Environment variables
+{{ env "HOME" }}
+{{ env "PATH" | split ":" | first }}
+
+# Command execution
+{{ output "uname" "-m" | trim }}
+
+# File operations
+{{ include "~/.config/includes/aliases.sh" }}
+{{ includeTemplate "~/.config/templates/prompt.sh" . }}
+
+# Path checking
+{{ lookPath "docker" }}  # Returns path or empty if not found
+```
+
+### Password Manager Integration
+
+```go
+# 1Password
+{{ onepasswordDocument "vault-id" }}
+{{ (onepasswordItemFields "GitHub" "credential").token.value }}
+
+# Bitwarden
+{{ bitwarden "item" "github-token" }}
+
+# gopass
+{{ gopass "path/to/secret" }}
+```
+
+### JSON Processing
+
+```go
+{{ $config := include "~/.config/app/config.json" | fromJson }}
+{{ $config.theme }}
+{{ $config.settings.editor }}
+```
+
+## Cross-Platform Patterns
+
+### Homebrew Path Handling
+
+```go
+{{- if eq .chezmoi.os "darwin" -}}
+{{-   if eq .chezmoi.arch "arm64" -}}
+export HOMEBREW_PREFIX="/opt/homebrew"
+{{-   else -}}
+export HOMEBREW_PREFIX="/usr/local"
+{{-   end -}}
+{{- else if eq .chezmoi.os "linux" -}}
+export HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew"
+{{- end -}}
+
+# Add to PATH
+export PATH="${HOMEBREW_PREFIX}/bin:${PATH}"
+```
+
+### Conditional Package Installation
+
+```toml
+# .chezmoi.toml.tmpl
+[data.packages]
+  npm = ["typescript", "prettier", "eslint"]
+  pip = ["black", "ruff", "mypy"]
+  cargo = ["ripgrep", "fd-find", "bat"]
+```
+
+```bash
+# run_onchange_install-packages.sh.tmpl
+#!/bin/bash
+{{ range .packages.npm }}
+npm install -g {{ . }}
+{{ end }}
+```
+
+## .chezmoiignore Patterns
+
+```
+# Documentation files
+README.md
+LICENSE
+.git
+
+# Platform-specific exclusions
+{{- if ne .chezmoi.os "darwin" }}
+.config/karabiner     # macOS only
+.config/hammerspoon   # macOS only
+{{- end }}
+
+{{- if ne .chezmoi.os "linux" }}
+.config/systemd       # Linux only
+.config/i3            # Linux only
+{{- end }}
+
+# Hostname-specific exclusions
+{{- if ne .chezmoi.hostname "work-laptop" }}
+.work-config
+{{- end }}
+```
+
+## Security Best Practices
+
+### Never Commit Secrets
+
+```bash
+# Add to .chezmoiignore
+.env
+*.key
+*.pem
+*_token
+*_secret
+```
+
+### Encrypted Files
+
+```bash
+# Configure encryption
+[encryption]
+  recipient = "your-gpg-id"
+
+# Add encrypted file
+chezmoi add --encrypt ~/.ssh/id_rsa
+
+# Results in: encrypted_private_dot_ssh/private_id_rsa.asc
+```
+
+### Environment Variable Secrets
+
+```go
+# Store in environment, reference in templates
+{{ env "GITHUB_TOKEN" }}
+{{ env "AWS_SECRET_KEY" }}
+```
+
+## Multi-Machine Configuration
+
+### Machine-Specific Variables
+
+```toml
+# ~/.config/chezmoi/chezmoi.toml
+[data]
+  machine_type = "personal"  # or "work", "server"
+
+[data.git]
+  email = "personal@email.com"
+
+[data.work]
+  vpn = "company-vpn.example.com"
+```
+
+```go
+# In templates
+{{ if eq .machine_type "work" }}
+export GIT_AUTHOR_EMAIL="{{ .work.email }}"
+source ~/.work-specific
+{{ else }}
+export GIT_AUTHOR_EMAIL="{{ .git.email }}"
+{{ end }}
+```
+
+## CI/CD Integration
+
+### GitHub Actions Validation
+
+```yaml
+name: Validate Dotfiles
+on: [push, pull_request]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install chezmoi
+        run: sh -c "$(curl -fsLS get.chezmoi.io)"
+      - name: Validate
+        run: |
+          chezmoi init --source .
+          chezmoi verify
+          chezmoi apply --dry-run
+```
+
+### Pre-commit Hooks
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: local
+    hooks:
+      - id: chezmoi-diff
+        name: Check chezmoi diff
+        entry: chezmoi diff
+        language: system
+        pass_filenames: false
+```
+
+## Migration Guides
+
+### From GNU Stow
+
+```bash
+# Move stow directory contents
+cp -r ~/dotfiles/* ~/.local/share/chezmoi/
+
+# Rename directories (remove dot prefix)
+cd ~/.local/share/chezmoi
+for dir in .*; do
+  [[ -d "$dir" ]] && mv "$dir" "dot_${dir#.}"
+done
+```
+
+### From Bare Git Repo
+
+```bash
+# Clone existing repo
+git clone --bare https://github.com/user/dotfiles.git ~/.dotfiles
+
+# Initialize chezmoi from it
+chezmoi init --source ~/.dotfiles
+
+# Add files
+chezmoi add $(git --git-dir=$HOME/.dotfiles --work-tree=$HOME ls-files)
+```
+
+## Bootstrap Script
+
+```bash
+#!/bin/sh
+# bootstrap.sh - Setup new machine with chezmoi
+
+# Install chezmoi
+sh -c "$(curl -fsLS get.chezmoi.io)" -- -b ~/.local/bin
+
+# Initialize from repo
+~/.local/bin/chezmoi init --apply https://github.com/user/dotfiles.git
+
+# Verify
+~/.local/bin/chezmoi verify
+```
+
+## Debugging Checklist
+
+1. **File not updating?**
+   - Check if managed: `chezmoi managed | grep <file>`
+   - Check .chezmoiignore: `grep <file> .chezmoiignore`
+   - Force apply: `chezmoi apply --force <file>`
+
+2. **Template errors?**
+   - Test rendering: `chezmoi execute-template < file.tmpl`
+   - Check variables: `chezmoi data`
+   - Debug output: `chezmoi apply -v --debug <file>`
+
+3. **Wrong permissions?**
+   - Check source prefix: Should use `private_` for 0600
+   - Verify: `ls -la $(chezmoi source-path <file>)`
+
+4. **Merge conflicts?**
+   - Three-way merge: `chezmoi merge <file>`
+   - Manual resolution: Edit source, then `chezmoi apply <file>`
+
+## Performance Tips
+
+- Use `chezmoi apply <specific-path>` instead of applying everything
+- Run `chezmoi diff | head -50` to preview large changesets
+- Use `--exclude` to skip large directories: `chezmoi apply --exclude ~/.cache`
+- For bulk operations, use `find` with xargs: `chezmoi managed --include=files | xargs -n 10 chezmoi apply`

--- a/.claude/skills/chezmoi-expert/SKILL.md
+++ b/.claude/skills/chezmoi-expert/SKILL.md
@@ -1,0 +1,124 @@
+---
+created: 2025-12-16
+modified: 2025-12-16
+reviewed: 2025-12-16
+name: chezmoi-expert
+description: |
+  Comprehensive chezmoi dotfiles management expertise including templates, cross-platform
+  configuration, file naming conventions, and troubleshooting. Covers source directory
+  management, reproducible environment setup, and chezmoi templating with Go templates.
+  Use when user mentions chezmoi, dotfiles, cross-platform config, chezmoi apply,
+  chezmoi diff, .chezmoidata, or managing configuration files across machines.
+allowed-tools: Bash, Read, Write, Edit, Grep, Glob
+---
+
+# Chezmoi Expert
+
+Expert knowledge for managing dotfiles with chezmoi, including templates, cross-platform support, and best practices.
+
+## Core Expertise
+
+- **Source vs Target Management**: Always work in `~/.local/share/chezmoi/`, never edit target files directly
+- **File Naming Conventions**: `dot_`, `private_`, `readonly_`, `executable_`, `exact_`, `symlink_` prefixes
+- **Template System**: Go templates with `.chezmoi.*` variables for platform-specific configs
+- **Cross-Platform Support**: Conditional logic for macOS/Linux differences
+
+## Critical Workflow
+
+**ALWAYS follow this workflow:**
+1. `chezmoi diff` - Preview changes before applying
+2. `chezmoi apply --dry-run` - Safe testing
+3. `chezmoi apply -v <path>` - Apply specific paths first
+4. Let user review before full `chezmoi apply`
+
+## Essential Commands
+
+```bash
+# Check differences
+chezmoi diff                    # All pending changes
+chezmoi status                  # Quick status overview
+chezmoi diff ~/.config/nvim     # Specific path changes
+
+# Apply changes
+chezmoi apply --dry-run         # Safe preview
+chezmoi apply -v ~/.config/nvim # Apply specific path
+chezmoi apply -v                # Apply all after review
+
+# Manage files
+chezmoi add ~/.bashrc           # Start managing file
+chezmoi re-add ~/.bashrc        # Update from modified target
+chezmoi managed                 # List managed files
+chezmoi verify                  # Verify target matches source
+
+# Templates
+chezmoi data                    # Show template variables
+chezmoi dump ~/.config/file     # Preview rendered output
+chezmoi execute-template < file # Test template
+```
+
+## File Naming Reference
+
+```
+Source                           → Target
+dot_bashrc                      → ~/.bashrc
+private_dot_ssh/config          → ~/.ssh/config (mode 0600)
+dot_config/nvim/init.lua.tmpl   → ~/.config/nvim/init.lua (templated)
+exact_dot_config/app/           → ~/.config/app/ (exact match)
+executable_script.sh            → ~/script.sh (mode 0755)
+```
+
+## Template Examples
+
+### Platform Detection
+```go
+{{ if eq .chezmoi.os "darwin" }}
+# macOS specific
+export HOMEBREW_PREFIX="/opt/homebrew"
+{{ else if eq .chezmoi.os "linux" }}
+# Linux specific
+export HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew"
+{{ end }}
+```
+
+### Architecture-Specific
+```go
+{{ if eq .chezmoi.arch "arm64" }}
+# Apple Silicon
+export DOCKER_DEFAULT_PLATFORM=linux/arm64/v8
+{{ else if eq .chezmoi.arch "amd64" }}
+# Intel/AMD
+export DOCKER_DEFAULT_PLATFORM=linux/amd64
+{{ end }}
+```
+
+## Special Files
+
+- `.chezmoi.toml.tmpl` - Main configuration template
+- `.chezmoiignore` - Files to ignore
+- `.chezmoiremove` - Files to remove from target
+- `.chezmoiexternal.toml` - External file management
+- `run_once_*.sh` - Run once on first apply
+- `run_onchange_*.sh` - Run when hash changes
+
+## Troubleshooting
+
+### Changes Not Applying
+```bash
+chezmoi managed | grep filename  # Check if managed
+chezmoi apply --force ~/.config/file  # Force apply
+```
+
+### Template Errors
+```bash
+chezmoi execute-template < file.tmpl  # Test rendering
+chezmoi data                          # Check variables
+chezmoi apply -v --debug ~/.config/file  # Debug output
+```
+
+### Merge Conflicts
+```bash
+chezmoi merge ~/.config/file     # Three-way merge
+chezmoi source-path ~/.config/file  # Get source path for manual edit
+```
+
+For detailed reference documentation, see REFERENCE.md.

--- a/.claude/skills/neovim-configuration/SKILL.md
+++ b/.claude/skills/neovim-configuration/SKILL.md
@@ -1,0 +1,142 @@
+---
+created: 2025-12-16
+modified: 2025-12-16
+reviewed: 2025-12-16
+name: neovim-configuration
+description: |
+  Modern Neovim configuration expertise including Lua scripting, plugin management with
+  lazy.nvim, LSP setup with Mason, AI integration with CodeCompanion, and workflow
+  optimization. Covers keymaps, autocommands, and treesitter configuration.
+  Use when user mentions Neovim, nvim, lazy.nvim, Mason, init.lua, Lua config,
+  nvim plugins, or Neovim customization.
+allowed-tools: Glob, Grep, Read, Edit, Write
+---
+
+# Neovim Configuration
+
+Expert knowledge for modern Neovim configuration with Lua scripting, plugin management, LSP setup, and AI integration for optimal development workflows.
+
+## Core Expertise
+
+**Modern Neovim Configuration**
+- Lua-based configuration with lazy.nvim plugin management
+- LSP setup with Mason for language server management
+- AI integration with CodeCompanion and custom prompt strategies
+- Advanced key mapping and workflow optimization
+
+## Key Capabilities
+
+**Plugin Management & Architecture**
+- **lazy.nvim**: Modern plugin manager with lazy loading and performance optimization
+- **Mason.nvim**: Language server, DAP server, linter, and formatter management
+- **Plugin Organization**: Structured configuration with modular plugin setup
+- **Performance Optimization**: Startup time optimization and lazy loading strategies
+
+**Language Server Protocol (LSP) Integration**
+- **LSP Configuration**: Multi-language LSP setup with proper keybindings
+- **Completion**: nvim-cmp with multiple sources and intelligent completion
+- **Diagnostics**: Error handling, linting integration, and diagnostic display
+- **Code Navigation**: Go-to-definition, references, and symbol search
+
+**AI Integration & Automation**
+- **CodeCompanion**: AI-powered code assistance with custom prompts
+- **Custom Strategies**: Domain-specific AI workflows for different development contexts
+- **Prompt Management**: Custom prompts for Arduino, deployment, debugging, and more
+- **Workflow Integration**: AI assistance integrated into development workflows
+
+**Advanced Features**
+- **Treesitter**: Syntax highlighting, text objects, and code understanding
+- **Telescope**: Fuzzy finder for files, buffers, grep, and more
+- **Git Integration**: Fugitive, gitsigns, and version control workflows
+- **Testing Integration**: neotest with multi-language testing support
+- **Debugging**: nvim-dap with debugger integration for multiple languages
+
+**UI/UX Enhancements**
+- **Theme Management**: Color scheme selection and customization
+- **Status Line**: Custom status line with relevant information
+- **File Explorer**: File management with nvim-tree or oil.nvim
+- **Window Management**: Smart window splitting and navigation
+
+## Configuration Workflow
+
+**Neovim Configuration Process**
+1. **Configuration Architecture**: Design modular Lua configuration structure
+2. **Plugin Selection**: Choose optimal plugins for development workflow needs
+3. **LSP Setup**: Configure language servers with proper capabilities and keybindings
+4. **Keybinding Design**: Create intuitive, memorable key mappings
+5. **Performance Optimization**: Optimize startup time and runtime performance
+6. **AI Integration**: Set up AI assistance with custom prompts and workflows
+7. **Testing & Refinement**: Validate configuration across different file types and workflows
+
+## Best Practices
+
+**Configuration Organization**
+- Use modular Lua configuration with clear separation of concerns
+- Implement lazy loading for plugins to optimize startup time
+- Create consistent keybinding patterns across different modes and contexts
+- Maintain configuration documentation and comments for future reference
+
+**LSP & Development Tools**
+- Configure LSP servers with proper capabilities and error handling
+- Set up intelligent completion with multiple sources and filtering
+- Integrate formatters and linters with null-ls or conform.nvim
+- Create language-specific configurations for optimal development experience
+
+**Performance & Reliability**
+- Profile startup time and identify performance bottlenecks
+- Use lazy loading and conditional plugin loading
+- Implement proper error handling for plugin failures
+- Regular configuration maintenance and plugin updates
+
+## Priority Areas
+
+**Give priority to:**
+- Performance issues causing slow startup or laggy editing experience
+- LSP configuration problems preventing proper language support
+- Plugin conflicts or errors disrupting development workflow
+- Keybinding conflicts or inconsistencies affecting productivity
+- AI integration issues preventing effective code assistance
+
+## Common Configuration Patterns
+
+**Lazy.nvim Plugin Setup**
+```lua
+return {
+  "plugin/name",
+  lazy = true,
+  event = "VeryLazy",
+  dependencies = { "dependency/plugin" },
+  config = function()
+    require("plugin").setup({
+      -- configuration
+    })
+  end,
+  keys = {
+    { "<leader>k", "<cmd>Command<cr>", desc = "Description" }
+  }
+}
+```
+
+**LSP Configuration**
+```lua
+local lspconfig = require("lspconfig")
+lspconfig.lua_ls.setup({
+  on_attach = function(client, bufnr)
+    -- Keybindings and capabilities
+  end,
+  settings = {
+    Lua = {
+      diagnostics = { globals = { "vim" } }
+    }
+  }
+})
+```
+
+**Keybinding Pattern**
+```lua
+vim.keymap.set("n", "<leader>f", function()
+  -- Function implementation
+end, { desc = "Description", silent = true })
+```
+
+This expertise creates a highly optimized, modern development environment that enhances productivity through intelligent configuration, seamless tool integration, and AI-powered assistance while maintaining excellent performance and reliability.

--- a/.claude/skills/obsidian-bases/SKILL.md
+++ b/.claude/skills/obsidian-bases/SKILL.md
@@ -1,0 +1,453 @@
+---
+created: 2025-12-16
+modified: 2025-12-16
+reviewed: 2025-12-16
+name: obsidian-bases
+description: Obsidian Bases database feature for YAML-based interactive note views. Use when creating .base files, writing filter queries, building formulas, configuring table/card views, or working with Obsidian properties and frontmatter databases.
+allowed-tools: Read, Write, Edit, Grep, Glob
+---
+
+# Obsidian Bases
+
+Expert knowledge for creating and managing Obsidian Bases - the interactive database feature introduced in Obsidian v1.9.10 that transforms notes into filterable, sortable views using YAML frontmatter properties.
+
+## Core Concepts
+
+**What is Bases?**
+- Native core plugin (no community plugins required)
+- Creates interactive database views from any set of notes
+- Uses `.base` file extension (plain-text YAML format)
+- **Only reads YAML frontmatter** - does not parse note content
+- Faster performance than Dataview with inline editing support
+
+**Key Distinction from Dataview:**
+- Bases: User-friendly, visual, inline editable, YAML frontmatter only
+- Dataview: More powerful queries, inline properties, content parsing
+
+## File Structure
+
+```yaml
+# example.base
+filters:
+  # Global filters (apply to all views)
+  and:
+    - 'status != "done"'
+    - taggedWith(file.file, "project")
+
+formulas:
+  # Computed properties
+  days_left: '(dueDate - today()).days()'
+  status_icon: 'if(done, "✅", "⬜")'
+
+views:
+  - type: table
+    name: "Active Tasks"
+    filters:
+      'dueDate > now()'      # View-specific filter
+    properties:
+      - name: title
+        displayName: "Task"
+      - name: status
+      - name: dueDate
+    sort:
+      - property: dueDate
+        direction: asc
+
+  - type: card
+    name: "Visual View"
+    properties:
+      - name: cover
+      - name: title
+```
+
+## Property Access Patterns
+
+### Note Properties (Frontmatter)
+
+```yaml
+# Shorthand access
+price
+status
+tags
+
+# Explicit prefix
+note.price
+note.status
+
+# Bracket notation (for spaces)
+note["property name"]
+```
+
+### File Properties (Implicit)
+
+```yaml
+file.path      # Full file path
+file.name      # File name only
+file.folder    # Parent folder
+file.size      # File size in bytes
+file.ctime     # Creation time
+file.mtime     # Modification time
+file.ext       # Extension
+file.file      # File object (for filter functions)
+file.links     # Outgoing links
+file.inlinks   # Incoming backlinks
+```
+
+### Formula Properties
+
+```yaml
+formula.my_formula
+formula["formula name"]
+```
+
+## Filter Syntax
+
+### Basic Operators
+
+```yaml
+# Comparison (must have spaces around operators)
+price > 10
+status == "done"
+age >= 18
+
+# Logical operators
+and:
+  - condition1
+  - condition2
+
+or:
+  - condition1
+  - condition2
+
+not:
+  - condition
+```
+
+### Filter Functions
+
+```yaml
+# Tag filtering
+taggedWith(file.file, "project")
+taggedWith(file.file, "project/web")     # Nested tags
+
+# Link filtering
+linksTo(file.file, "Note Name")
+file.hasLink(this.file)                  # Backlinks to current note
+
+# Folder filtering
+inFolder(file.file, "Projects")
+inFolder(file.file, "Projects/Web")      # Nested folders
+
+# Date filtering
+file.mtime > now() - "1 week"            # Modified recently
+dueDate < today()                        # Overdue
+createdDate >= "2025-01-01"              # This year
+
+# Regex matching
+/\d{4}-\d{2}-\d{2}/.matches(file.name)   # Daily note format
+```
+
+### The `this` Variable
+
+Context-aware reference to the active note:
+
+```yaml
+# In sidebar: references active note in main pane
+file.hasLink(this.file)                  # Find backlinks
+
+# In embedded base: references containing note
+file.folder == this.file.folder          # Same folder
+
+# Exclude current note
+file.path != this.file.path
+```
+
+## Formula Syntax
+
+### Basic Formulas
+
+```yaml
+formulas:
+  # Arithmetic
+  total: "price * quantity"
+  discounted: "total * 0.9"
+
+  # String manipulation
+  full_name: 'firstName + " " + lastName'
+
+  # Conditional logic
+  status_emoji: 'if(status == "done", "✅", if(status == "in-progress", "🔄", "⬜"))'
+
+  # Date calculations
+  days_until: '(dueDate - today()).days()'
+  overdue: 'dueDate < today()'
+
+  # Link analysis
+  backlink_count: 'file.inlinks.length'
+  has_backlinks: 'file.inlinks.length > 0'
+```
+
+### Built-in Functions
+
+**Global:**
+- `today()` - Current date
+- `now()` - Current date and time
+- `link(target, displayText?)` - Create link
+- `image(url)` - Create image object
+- `list(value)` - Ensure value is a list
+- `if(condition, trueResult, falseResult?)` - Conditional
+
+**String methods:**
+- `.toUpperCase()`, `.toLowerCase()`
+- `.trim()`, `.split(separator)`
+- `.startsWith(prefix)`, `.endsWith(suffix)`
+- `.replace(search, replacement)`
+
+**Number methods:**
+- `.toFixed(decimals)` - Format decimal places
+- `.round()`, `.floor()`, `.ceil()`
+
+**Date methods:**
+- `.date()` - Convert to date
+- `.startOf(unit)`, `.endOf(unit)`
+- `.format(pattern)`
+- `.days()`, `.months()`, `.years()` - Duration extraction
+
+**List methods:**
+- `.length` - Count elements
+- `[index]` - Access element (0-based)
+- `.filter(condition)` - Filter elements
+- `.map(transformation)` - Transform elements
+- `.join(separator)` - Concatenate to string
+
+### Duration Units
+
+```yaml
+now() + "1 week"
+now() - "30 days"
+file.mtime > now() - "1 month"
+
+# Available units
+y, year, years
+M, month, months
+w, week, weeks
+d, day, days
+h, hour, hours
+m, minute, minutes
+s, second, seconds
+```
+
+## View Types
+
+### Table View
+
+```yaml
+views:
+  - type: table
+    name: "Tasks"
+    properties:
+      - name: title
+        displayName: "Task Name"    # Column header
+        width: 200                   # Optional width
+      - name: status
+      - name: dueDate
+    sort:
+      - property: dueDate
+        direction: asc              # or desc
+```
+
+### Card View
+
+```yaml
+views:
+  - type: card
+    name: "Projects"
+    properties:
+      - name: cover              # Cover image
+      - name: title
+      - name: status
+```
+
+## Common Patterns
+
+### Task Management
+
+```yaml
+filters:
+  taggedWith(file.file, "task")
+
+formulas:
+  overdue: 'dueDate < today()'
+  priority_icon: 'if(priority == "high", "🔴", if(priority == "medium", "🟡", "🟢"))'
+
+views:
+  - type: table
+    name: "Active"
+    filters:
+      'status != "done"'
+    sort:
+      - property: dueDate
+        direction: asc
+```
+
+### Enhanced Backlinks
+
+```yaml
+# Drag to sidebar for context-aware backlinks
+filters:
+  file.hasLink(this.file)
+
+views:
+  - type: table
+    name: "Backlinks"
+    properties:
+      - name: file.name
+        displayName: "Note"
+      - name: file.mtime
+        displayName: "Modified"
+```
+
+### Book/Media Library
+
+```yaml
+filters:
+  taggedWith(file.file, "book")
+
+formulas:
+  year_read: 'dateFinished.date().year()'
+
+views:
+  - type: card
+    name: "Library"
+    properties:
+      - name: cover
+      - name: title
+      - name: author
+
+  - type: table
+    name: "Reading List"
+    filters:
+      'status == "to-read"'
+```
+
+### Weekly Review
+
+```yaml
+filters:
+  file.mtime > now() - "1 week"
+
+formulas:
+  days_ago: '(today() - file.mtime.date()).days()'
+
+views:
+  - type: table
+    name: "Recent Activity"
+    sort:
+      - property: file.mtime
+        direction: desc
+```
+
+## Embedding Bases
+
+```markdown
+![[MyBase.base]]                # Embed entire base
+![[MyBase.base#ViewName]]       # Embed specific view
+```
+
+## Best Practices
+
+**Filter Organization:**
+- Use global filters for the broadest scope (lowest common denominator)
+- Refine with view-level filters for specific subsets
+- Global + view filters combine with AND
+
+**Formula Reusability:**
+- Create formula properties for repeated logic
+- Reference as `formula.name` in views
+- No circular references allowed
+
+**Robust List Handling:**
+```yaml
+# Always wrap in list() for mixed single/array values
+list(tags).length
+list(tags).filter(value.startsWith("project"))
+```
+
+**Date Validation:**
+```yaml
+valid_date: 'if(dueDate, dueDate, "No date")'
+```
+
+## Common Gotchas
+
+**1. Arithmetic operator spacing:**
+```yaml
+# ✅ Correct
+price * 2
+
+# ❌ Wrong (parser error)
+price*2
+```
+
+**2. Quote nesting in YAML:**
+```yaml
+# ✅ Correct - single outer, double inner
+formulas:
+  message: 'Hello "world"'
+
+# ❌ Wrong
+formulas:
+  message: "Hello "world""
+```
+
+**3. Link properties in frontmatter:**
+```yaml
+# ✅ Correct - must quote
+related: "[[Other Note]]"
+
+# ❌ Wrong
+related: [[Other Note]]
+```
+
+**4. File extension required:**
+```markdown
+<!-- ✅ Correct -->
+![[MyBase.base]]
+
+<!-- ❌ Wrong (looks for .md) -->
+![[MyBase]]
+```
+
+**5. Global vs view filter scope:**
+- Cannot override global filter at view level
+- Make global permissive, refine in views
+
+## Current Limitations
+
+- **View types:** Only table and card (no board, calendar, gallery yet)
+- **Images:** Display as text, not rendered in cards
+- **Inline properties:** Only YAML frontmatter (no Dataview inline fields)
+- **Content parsing:** Cannot query note body text
+- **Note creation:** Cannot create new notes from base
+- **Grouping:** No native group-by (use separate views instead)
+- **Aggregations:** No built-in sum/average/count
+
+## Property Types
+
+| Type | Example |
+|------|---------|
+| Text | `"Project Alpha"` |
+| List | `["tag1", "tag2"]` |
+| Number | `42`, `3.14` |
+| Checkbox | `true`, `false` |
+| Date | `2025-11-26` |
+| Date & Time | `2025-11-26T14:30:00` |
+
+**Note:** Property types are vault-wide. If `priority` is Number in one note, it must be Number everywhere.
+
+## Resources
+
+- **Official Docs:** https://help.obsidian.md/bases
+- **Syntax Reference:** https://help.obsidian.md/bases/syntax
+- **Functions:** https://help.obsidian.md/bases/functions
+- **Roadmap:** https://help.obsidian.md/bases/roadmap

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,12 @@ Chezmoi dotfiles repository with cross-platform development environment configur
 - **Essential commands**: `chezmoi diff`, `chezmoi apply --dry-run`, `chezmoi apply`
 - **Cross-platform**: Templates handle OS/arch differences; Chezmoi Expert skill provides guidance
 
-### Claude Code Directory (exact_dot_claude/)
+### Claude Code Directories
 
-The `.claude` directory is managed via `exact_dot_claude/` with exact-match semantics (orphaned files auto-removed). Run `chezmoi apply -v ~/.claude` after changes. Do NOT create `.claude/` in the chezmoi source directory — it's gitignored and used as a runtime directory.
+Two distinct `.claude/`-shaped directories exist here:
+
+- `exact_dot_claude/` — chezmoi source for the user-global `~/.claude/` tree (exact-match semantics; orphaned files auto-removed). Edit source here, then run `chezmoi apply -v ~/.claude` to sync. A PostToolUse hook (`exact_dot_claude/hooks/chezmoi-workflow-nudge.sh`) reminds you to apply after edits under this path.
+- `.claude/` at the repo root — project-scoped Claude Code config for working inside *this* repo: `settings.json` (permissions allowlist, pinned plugins, hooks), `skills/`, `commands/`, `agents/`, `hooks/`. Tracked in git. Only per-machine runtime state (`sessions/`, `projects/`, `todos/`, `.credentials*`) is gitignored.
 
 ## Plugins
 

--- a/exact_dot_claude/rules/chezmoi-conventions.md
+++ b/exact_dot_claude/rules/chezmoi-conventions.md
@@ -20,9 +20,9 @@ Derived from git history patterns (1404 commits, 2018–2026).
 
 ## Directory Semantics
 
-- `exact_dot_claude/` — Orphaned files auto-removed on `chezmoi apply`; critical for keeping `.claude/` clean
-- `private_dot_config/` — Secret-adjacent configs; mode 0600
-- Never create a `.claude/` directory in the chezmoi source — it's gitignored and used as a runtime directory
+- `exact_dot_claude/` — chezmoi source for the user-global `~/.claude/`; orphaned files auto-removed on `chezmoi apply`
+- `private_dot_config/` — secret-adjacent configs; mode 0600
+- A repo-root `.claude/` *inside* the chezmoi source dir is fine — it's the project-scoped Claude Code config for working in the dotfiles repo (`settings.json`, pinned plugins, hooks, project skills). The chezmoi source repo narrows its `.gitignore` so this is trackable while per-machine runtime state (`sessions/`, `projects/`, `todos/`, `.credentials*`) stays ignored. Do NOT confuse it with `exact_dot_claude/` — that one is the source for `~/.claude/`, not for the chezmoi source repo's `.claude/`.
 
 ## Source vs Target
 


### PR DESCRIPTION
## Summary

- Clarify in `CLAUDE.md` and `exact_dot_claude/rules/chezmoi-conventions.md` that two distinct `.claude/`-shaped directories exist in this repo (`exact_dot_claude/` → `~/.claude/`, and the repo-root `.claude/` for project-scoped config) — the prior text said "never create `.claude/` here" which contradicted the current narrowed `.gitignore`.
- Start tracking three project-scoped skills that have been on disk but untracked: `chezmoi-expert`, `neovim-configuration`, `obsidian-bases`. They scope to "working in this repo," matching the purpose of the repo-root `.claude/skills/`.

## Test plan

- [ ] `chezmoi diff` still clean after merge (these files are not chezmoi-managed)
- [ ] Skills appear under `.claude/skills/` and are loadable when working in this repo
