### PR TITLE
chore(claude): quote env var value and enable project-plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,6 @@
 {
   "env": {
-    "CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION": 1
+    "CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION": "1"
   },
   "permissions": {
     "allow": [
@@ -67,7 +67,7 @@
     "migration-patterns-plugin@laurigates-claude-plugins": false,
     "networking-plugin@laurigates-claude-plugins": false,
     "obsidian-plugin@laurigates-claude-plugins": true,
-    "project-plugin@laurigates-claude-plugins": false,
+    "project-plugin@laurigates-claude-plugins": true,
     "prompt-engineering-plugin@laurigates-claude-plugins": true,
     "prose-plugin@laurigates-claude-plugins": true,
     "python-plugin@laurigates-claude-plugins": true,


### PR DESCRIPTION
## Summary

- Quote `CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION`: `1` → `"1"`. The env block expects string values; the bare integer silently no-ops on some loaders.
- Enable `project-plugin@laurigates-claude-plugins`. Its `project-discovery` / `project-continue` / `project-distill` skills are the ones reached for at session start in this repo.

## Test plan

- [ ] Branch-protection hook stays disabled (confirmed by being able to commit on a feature branch without override)
- [ ] `/project:continue` skill is available in a fresh session in this repo
