### PR TITLE
chore(completions): register git-repo-agent zsh completion

### DIFF
--- a/.chezmoidata/completions.toml
+++ b/.chezmoidata/completions.toml
@@ -33,3 +33,4 @@
   just = "just --completions zsh"
   ruff = "ruff generate-shell-completion zsh"
   deadbranch = "deadbranch completions zsh"
+  "git-repo-agent" = "git-repo-agent completion zsh"


### PR DESCRIPTION
## Summary

- Register `git-repo-agent completion zsh` in the `zsh_completions` table so chezmoi's `run_onchange` completion generator writes `~/.zfunc/_git-repo-agent` on the next apply.

## Test plan

- [ ] `chezmoi apply` writes `~/.zfunc/_git-repo-agent`
- [ ] `git-repo-agent <TAB>` completes subcommands in zsh after `compinit`
