### PR TITLE
chore: remove vectorcode integration

### DIFF
--- a/.chezmoidata.toml
+++ b/.chezmoidata.toml
@@ -41,14 +41,6 @@
     description = "Graph-based memory and knowledge management"
     category = "memory"
 
-  [mcp_servers.vectorcode]
-    enabled = false
-    scope = "project"
-    command = "vectorcode-mcp-server"
-    args = []
-    description = "Semantic code search using embeddings"
-    category = "search"
-
   [mcp_servers.pal]
     enabled = false
     scope = "project"

--- a/.chezmoidata/completions.toml
+++ b/.chezmoidata/completions.toml
@@ -28,7 +28,6 @@
   orb = "orb completion zsh"
   skaffold = "skaffold completion zsh"
   kitty = "kitty +complete setup zsh"
-  vectorcode = "vectorcode -s zsh"
   bun = "bun completions"
   just = "just --completions zsh"
   ruff = "ruff generate-shell-completion zsh"

--- a/.chezmoidata/uv_tools.toml
+++ b/.chezmoidata/uv_tools.toml
@@ -17,7 +17,6 @@
     "ruff",
     "telegram-send",
     "trafilatura",
-    "vectorcode[mcp,cli]",
     "yamllint",
   ]
 

--- a/private_dot_config/mise/config.toml.tmpl
+++ b/private_dot_config/mise/config.toml.tmpl
@@ -72,9 +72,6 @@ rust = "latest"
 # Communication
 "pipx:telegram-send" = "latest"
 
-# Development Productivity
-"pipx:vectorcode[mcp,cli]" = "latest"
-
 # ============================================================================
 # CLI Tools (via aqua backend - security-focused with checksums)
 # ============================================================================

--- a/private_dot_config/nvim/CLAUDE.md
+++ b/private_dot_config/nvim/CLAUDE.md
@@ -26,7 +26,6 @@ Modern Neovim configuration using Lua with lazy.nvim plugin management.
 - **UI**: tokyonight, lualine, noice.nvim
 - **Testing**: neotest
 - **Debugging**: nvim-dap
-- **AI**: VectorCode
 
 ## LSP Approach
 

--- a/private_dot_config/nvim/lua/exact_plugins/vectorcode.lua
+++ b/private_dot_config/nvim/lua/exact_plugins/vectorcode.lua
@@ -1,8 +1,0 @@
-return {
-  {
-    "Davidyz/VectorCode",
-    -- version = "*", -- optional, depending on whether you're on nightly or release
-    -- build = "pipx upgrade vectorcode", -- optional but recommended if you set `version = "*"`
-    dependencies = { "nvim-lua/plenary.nvim" },
-  },
-}


### PR DESCRIPTION
## Summary

- VectorCode (the `Davidyz/VectorCode` Neovim plugin + the `vectorcode[mcp,cli]` Python package) is no longer in use. Drop every reference across the dotfiles toolchain in one coherent change.
- Removed: nvim plugin spec `vectorcode.lua`, the AI line in nvim `CLAUDE.md`, the `pipx:vectorcode[mcp,cli]` entry in mise, the matching entry in `.chezmoidata/uv_tools.toml`, the MCP server registration in `.chezmoidata.toml`, and the shell-completion entry in `.chezmoidata/completions.toml`.

## Test plan

- [ ] `chezmoi apply -v` runs without referencing vectorcode
- [ ] `mise ls` no longer shows `pipx:vectorcode`
- [ ] Neovim starts without lazy.nvim trying to load the VectorCode plugin
- [ ] `ls ~/.zfunc/_vectorcode` does not exist after re-running completions generator

🤖 Generated with [Claude Code](https://claude.com/claude-code)