### PR TITLE
docs(claude): document settings.json runtime drift workflow

### DIFF
--- a/exact_dot_claude/rules/chezmoi-conventions.md
+++ b/exact_dot_claude/rules/chezmoi-conventions.md
@@ -31,6 +31,29 @@ Derived from git history patterns (1404 commits, 2018–2026).
 - After modifying `exact_dot_claude/rules/`, run `chezmoi apply --force ~/.claude`
 - Use `chezmoi diff` to preview changes before applying
 
+## Runtime Drift (Claude Code's `settings.json`)
+
+Some target files are mutated by the application at runtime, not just by `chezmoi apply`. Claude Code writes to `~/.claude/settings.json` when the user toggles plugins, dismisses surveys, changes editor mode, enables features, or modifies anything via `/config` or `/plugin`. The chezmoi source has no idea those mutations happened.
+
+The footgun: after editing the source and running `chezmoi apply`, runtime drift gets clobbered. The user loses plugin enable/disable choices, dismissed survey state, etc.
+
+**Workflow when editing chezmoi-managed `settings.json`:**
+
+1. `chezmoi diff ~/.claude/settings.json` — preview what apply *would* change.
+2. If the diff shows entries beyond your intended edit (e.g. `gopls-lsp` flipped, `inputNeededNotifEnabled` added, `feedbackSurveyState` updated), those are runtime mutations. Do not blow them away.
+3. **Sync source from target by direct editing** — copy the runtime mutations into the chezmoi source until `chezmoi diff` shows only your intended change. Alternative: `chezmoi re-add ~/.claude/settings.json` (overwrites source with target, then re-do your edit).
+4. `chezmoi apply --force ~/.claude/settings.json` — `--force` skips the TTY prompt that fires when chezmoi detects the target changed since it last wrote it. Safe *only* after the diff is verified clean.
+
+In headless environments (Claude Code agent sessions, CI), the TTY prompt errors out with `could not open a new TTY` — `--force` is the path past that, but only after the diff confirms no drift will be lost.
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `chezmoi diff` shows entries you didn't edit | Claude Code mutated the target | Sync source first |
+| `chezmoi apply` errors `could not open a new TTY` | Target changed since chezmoi last wrote it | Verify diff, then `--force` |
+| Plugin enable/disable choices revert after apply | Source was applied over runtime mutations | Re-toggle, then `chezmoi re-add` to capture |
+
+Applies equally to any other tool that writes to its own chezmoi-managed config: `~/.config/gh/config.yml`, `~/.config/mise/config.toml` when mise mutates it, etc. Check `chezmoi diff` before applying.
+
 ## Script Conventions
 
 - `run_onchange_*` scripts execute when their template hash changes

--- a/exact_dot_claude/settings.json
+++ b/exact_dot_claude/settings.json
@@ -1,9 +1,12 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "skillListingBudgetFraction": 0.1,
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "1",
-    "ENABLE_TOOL_SEARCH": "1"
+    "ENABLE_TOOL_SEARCH": "1",
+    "CLAUDE_HOOKS_ENABLE_BASH_ANTIPATTERNS_TEACH": "1",
+    "CLAUDE_HOOKS_ENABLE_CALENDAR_ESTIMATES": "1"
   },
   "permissions": {
     "allow": [
@@ -132,10 +135,6 @@
       "~/repos/ForumViriumHelsinki/infrastructure.wiki"
     ]
   },
-  "statusLine": {
-    "type": "command",
-    "command": "bash ~/.claude/statusline-command.sh"
-  },
   "hooks": {
     "SessionStart": [
       {
@@ -159,6 +158,10 @@
         ]
       }
     ]
+  },
+  "statusLine": {
+    "type": "command",
+    "command": "bash ~/.claude/statusline-command.sh"
   },
   "enabledPlugins": {
     "bevy-plugin@laurigates-claude-plugins": false,
@@ -198,7 +201,7 @@
     "pyright-lsp@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": false,
     "rust-analyzer-lsp@claude-plugins-official": false,
-    "gopls-lsp@claude-plugins-official": false,
+    "gopls-lsp@claude-plugins-official": true,
     "swift-lsp@claude-plugins-official": false,
     "clangd-lsp@claude-plugins-official": false,
     "codebase-attributes-plugin@laurigates-claude-plugins": false,
@@ -230,11 +233,12 @@
   "verbose": false,
   "autoCompactEnabled": false,
   "teammateMode": "tmux",
-  "remoteControlAtStartup": false,
+  "inputNeededNotifEnabled": true,
   "agentPushNotifEnabled": true,
   "skipAutoPermissionPrompt": true,
   "voiceEnabled": true,
   "feedbackSurveyState": {
     "lastShownTime": 1754075292901
-  }
+  },
+  "remoteControlAtStartup": true
 }


### PR DESCRIPTION
## Summary

- Adds a new section to `chezmoi-conventions.md` explaining that Claude Code mutates `~/.claude/settings.json` at runtime (plugin toggles, surveys, editor state) and the chezmoi source has no idea — so editing the source and applying without checking the diff first silently clobbers those mutations.
- Documents the diff-first / `--force` / `re-add` workflow, including the headless-environment TTY-prompt failure mode.
- Syncs `exact_dot_claude/settings.json` with the current runtime state (`gopls-lsp` enabled, `inputNeededNotifEnabled`, `remoteControlAtStartup`, two new env vars, `skillListingBudgetFraction`, statusLine block reposition) so the next `chezmoi apply` is clean.

## Test plan

- [x] `chezmoi diff ~/.claude/settings.json` shows no unexpected entries after the source sync
- [x] Pre-commit hooks pass (conventional commit, secrets, json/yaml/toml lint)
- [ ] Follow-up: verify `chezmoi apply --force ~/.claude/settings.json` runs cleanly post-merge on the target machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)