### PR TITLE
chore(mcp): install pal-mcp-server fork as a uv tool

### DIFF
--- a/.chezmoidata.toml
+++ b/.chezmoidata.toml
@@ -44,8 +44,8 @@
   [mcp_servers.pal]
     enabled = false
     scope = "project"
-    command = "uvx"
-    args = ["--from", "git+https://github.com/BeehiveInnovations/pal-mcp-server.git", "pal-mcp-server"]
+    command = "pal-mcp-server"
+    args = []
     description = "PAL (Provider Abstraction Layer) - Multi-provider LLM integration"
     category = "productivity"
 

--- a/.chezmoidata/uv_tools.toml
+++ b/.chezmoidata/uv_tools.toml
@@ -21,5 +21,9 @@
   ]
 
   # Git-based tools with special installation requirements
-  # NOTE: pal-mcp-server is run via uvx at runtime, no global installation needed
-  git_tools = []
+  # Each entry: { package = "<name in `uv tool list`>", url = "git+https://…", with = ["extra-dep", …] }
+  # (`with` is optional). pal-mcp-server is installed globally so MCP configs can
+  # invoke the bare `pal-mcp-server` command instead of re-resolving git via uvx on every launch.
+  git_tools = [
+    { package = "pal-mcp-server", url = "git+https://github.com/laurigates/pal-mcp-server" },
+  ]

--- a/.mcp.json
+++ b/.mcp.json
@@ -15,12 +15,7 @@
       ]
     },
     "pal": {
-      "command": "uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/BeehiveInnovations/pal-mcp-server.git",
-        "pal-mcp-server"
-      ]
+      "command": "pal-mcp-server"
     },
     "playwright": {
       "command": "bunx",


### PR DESCRIPTION
## What
Switch the `pal` MCP server from `uvx --from git+https://github.com/BeehiveInnovations/pal-mcp-server.git` to the globally-installed `pal-mcp-server` command (laurigates/pal-mcp-server fork), and declare the install in the uv_tools registry.

## Why
`uvx --from git+...` re-resolves the git source on every MCP launch, generating a process-spawn storm that taxes the macOS security stack (EndpointSecurity/XProtect inspect every spawn). Installing the fork once via `uv tool install` and invoking the bare command eliminates the per-launch git churn and picks up the fork's improvements.

## Files
- `.mcp.json` — repo-local project MCP config
- `.chezmoidata.toml` — `[mcp_servers.pal]` registry entry
- `.chezmoidata/uv_tools.toml` — `git_tools` install declaration

🤖 Generated with [Claude Code](https://claude.com/claude-code)