### PR TITLE
fix(session-wrap): suppress nudge when wrap is already in progress

### DIFF
--- a/exact_dot_claude/hooks/executable_session-wrap-nudge.sh
+++ b/exact_dot_claude/hooks/executable_session-wrap-nudge.sh
@@ -22,6 +22,13 @@ transcript=$(jq -r '.transcript_path // empty' <<<"$input" 2>/dev/null || echo "
 [ -z "$transcript" ] && exit 0
 [ ! -f "$transcript" ] && exit 0
 
+# Skip if session-wrap is already in progress (user is awaiting y/n confirmation).
+# Check for signature phrases from the skill's Step 3 preview.
+last_assistant=$(grep '"role":"assistant"' "$transcript" 2>/dev/null | tail -1 || true)
+if echo "$last_assistant" | grep -qE 'About to wrap:|Apply\? \(y/n\)'; then
+    exit 0
+fi
+
 # At most one nudge per session
 state_dir="${HOME}/.cache/claude-session-wrap-nudge"
 mkdir -p "$state_dir"


### PR DESCRIPTION
## Summary
- Add signature-match check to suppress the Stop-hook nudge when `/session-wrap` is already in progress
- Detects "About to wrap:" and "Apply? (y/n)" in the last assistant message

Fixes #220

## Test plan
- [ ] Invoke `/session-wrap` in an FVH-scoped session after >6 turns
- [ ] Verify the hook does NOT fire while awaiting y/n confirmation
- [ ] Verify the hook still fires correctly on normal wind-down signals

🤖 Generated with [Claude Code](https://claude.ai/code)