### PR TITLE
fix: add date-fns.org to lychee ignore list

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -14,3 +14,6 @@ https://biomejs\.dev/.*
 
 # ST Microelectronics site is slow and often times out
 https://www\.st\.com/.*
+
+# date-fns.org occasionally returns 509 errors from CI runners
+https://date-fns\.org/.*


### PR DESCRIPTION
The link https://date-fns.org/ is valid but occasionally returns 509 errors from CI runners due to transient server issues. Adding it to the ignore list prevents false positive broken link reports.

Fixes #204

Generated with [Claude Code](https://claude.ai/claude-code)