### PR TITLE
fix(ci): add id-token: write permission to auto-fix-ci-failures workflow

### DIFF
--- a/.github/workflows/auto-fix-ci-failures.yml
+++ b/.github/workflows/auto-fix-ci-failures.yml
@@ -10,6 +10,7 @@ permissions:
   contents: write
   pull-requests: write
   actions: read
+  id-token: write # Required for Claude Code Action OIDC authentication
   # issues: write removed - not used in workflow
 
 concurrency:


### PR DESCRIPTION
## Problem

The `auto-fix-ci-failures.yml` workflow fails with OIDC token errors when triggered:

```
Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
```

## Root Cause

The Claude Code Action (`anthropics/claude-code-action@v1`) requires `id-token: write` permission for OIDC authentication, but the workflow only declared `contents: write`, `pull-requests: write`, and `actions: read`.

## Fix

Added `id-token: write` to the permissions block:

```yaml
permissions:
  contents: write
  pull-requests: write
  actions: read
  id-token: write # Required for Claude Code Action OIDC authentication
```

## Notes

Per GitHub's OIDC documentation, `id-token: write` only allows the workflow to fetch short-lived OIDC tokens — it does **not** grant permission to modify any resources. This is the minimal additional permission required.

A previous `@claude` run on the issue could not push this change because the GitHub App lacks the `workflows` permission needed to modify files under `.github/workflows/`. This PR applies the change from the remote execution environment.

Closes #181

https://claude.ai/code/session_018GwumdMZaRZHpdTYDrzPXJ

---
_Generated by [Claude Code](https://claude.ai/code/session_018GwumdMZaRZHpdTYDrzPXJ)_