### PR TITLE
feat(zsh): colorize and align gh fzf pickers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ pre-commit run detect-secrets --all-files
 
 ## Blueprint Documentation
 
-Blueprint v3.2.0 manages project documentation and rules.
+Blueprint v3.3.0 manages project documentation and rules.
 
 - **PRD**: `docs/prds/project-overview.md` — Feature requirements and scope
 - **ADRs**: `docs/adrs/` — 16 Architecture Decision Records ([index](docs/adrs/README.md))

--- a/docs/blueprint/manifest.json
+++ b/docs/blueprint/manifest.json
@@ -1,10 +1,21 @@
 {
-  "format_version": "3.2.0",
+  "format_version": "3.3.0",
   "created_at": "2026-04-07T00:00:00Z",
-  "updated_at": "2026-04-08T00:00:00Z",
+  "updated_at": "2026-06-03T00:00:00Z",
   "created_by": {
     "blueprint_plugin": "3.2.0"
   },
+  "upgrade_history": [
+    {
+      "from": "3.2.0",
+      "to": "3.3.0",
+      "date": "2026-06-03T00:00:00Z",
+      "changes": [
+        "Added workspaces support for monorepo blueprints (standalone project: no workspaces block needed)",
+        "Enabled cross-workspace cross-references (`<path>/ADR-NNN`, `/ADR-NNN`)"
+      ]
+    }
+  ],
   "project": {
     "name": "chezmoi",
     "detected_stack": [

--- a/dot_taskrc
+++ b/dot_taskrc
@@ -1,0 +1,47 @@
+# [Created by task 3.4.2 4/23/2026 12:23:05]
+data.location=/Users/lgates/.task
+news.version=3.4.2
+
+# To use the default location of the XDG directories,
+# move this configuration file from ~/.taskrc to ~/.config/task/taskrc and update location config as follows:
+
+#data.location=~/.local/share/task
+#hooks.location=~/.config/task/hooks
+
+# Color theme (uncomment one to use)
+#include light-16.theme
+#include light-256.theme
+#include bubblegum-256.theme
+#include dark-16.theme
+#include dark-256.theme
+#include dark-red-256.theme
+#include dark-green-256.theme
+#include dark-blue-256.theme
+#include dark-violets-256.theme
+#include dark-yellow-green.theme
+#include dark-gray-256.theme
+#include dark-gray-blue-256.theme
+#include solarized-dark-256.theme
+#include solarized-light-256.theme
+#include no-color.theme
+
+uda.bpid.type=string
+uda.bpid.label=Blueprint-ID
+uda.bpdoc.type=string
+uda.bpdoc.label=Blueprint-Doc
+uda.bpms.type=string
+uda.bpms.label=Milestone
+uda.ghid.type=numeric
+uda.ghid.label=GH Issue
+uda.ghpr.type=numeric
+uda.ghpr.label=GH PR
+uda.agent.type=string
+uda.agent.label=Agent ID
+uda.pid.type=numeric
+uda.pid.label=Agent PID
+uda.host.type=string
+uda.host.label=Host
+uda.branch.type=string
+uda.branch.label=Git branch
+uda.worktree.type=string
+uda.worktree.label=Worktree path

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -358,6 +358,22 @@ function zvm_after_init() {
 # Custom Functions
 #======================================================================
 
+# Colourise gh fzf-picker tables *after* `column -t` has aligned them, so the
+# padding widths are computed on plain text and the escapes (zero-width under
+# fzf --ansi) never shift a column. Shared by every gh picker below.
+#   … | column -t -s $'\t' | _gh_paint | fzf --ansi …
+_gh_paint() {
+  awk '
+    {
+      gsub(/✓[A-Za-z]*/, "\033[32m&\033[0m")   # success  → green
+      gsub(/✗[A-Za-z]*/, "\033[31m&\033[0m")   # failure  → red
+      gsub(/⏳[A-Za-z]*/, "\033[33m&\033[0m")  # pending  → yellow
+      gsub(/#[0-9]+/,     "\033[36m&\033[0m")  # PR/issue → cyan
+      gsub(/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/, "\033[2m&\033[0m")  # date → dim
+      print
+    }'
+}
+
 # GitHub Issues → Claude: select issue and process with git:issue skill
 ghi() {
   local issue_num
@@ -372,6 +388,7 @@ ghi() {
         .title[:60]
       ] | @tsv' | \
       column -t -s $'\t' | \
+      _gh_paint | \
       fzf --ansi \
           --header '#       Labels               Updated     Title' \
           --preview 'GH_FORCE_TTY=1 gh issue view {1}' \
@@ -423,6 +440,7 @@ ghpc() {
         .title[:45]
       ] | @tsv' | \
       column -t -s $'\t' | \
+      _gh_paint | \
       fzf --ansi \
           --header '#       State  CI    Review  Branch                    Title' \
           --preview 'GH_FORCE_TTY=1 gh pr view {1} && echo && echo "--- Checks ---" && GH_FORCE_TTY=1 gh pr checks {1}' \
@@ -520,7 +538,24 @@ _gh_batch_merge() {
 _gh_pr_multi_select() {
   local repo
   repo=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)
-  gh pr list --limit 100 | \
+  gh pr list --limit 100 \
+      --json number,title,headRefName,isDraft,statusCheckRollup,reviewDecision \
+      --jq '.[] | [
+        "#\(.number)",
+        (if .isDraft then "draft" else "ready" end),
+        (if (.statusCheckRollup | length) == 0 then "⏳CI"
+         elif (.statusCheckRollup | all(.conclusion == "SUCCESS")) then "✓CI"
+         elif (.statusCheckRollup | any(.conclusion == "FAILURE")) then "✗CI"
+         else "⏳CI" end),
+        (if .reviewDecision == "APPROVED" then "✓rev"
+         elif .reviewDecision == "CHANGES_REQUESTED" then "✗rev"
+         elif .reviewDecision == "REVIEW_REQUIRED" then "⏳rev"
+         else "-rev" end),
+        .headRefName[:25],
+        .title[:50]
+      ] | @tsv' | \
+    column -t -s $'\t' | \
+    _gh_paint | \
     fzf --ansi --multi \
         --header "Tab mark · ^a all · ⏎ confirm ${1}-merge · ^/ preview · ^d/u scroll" \
         --bind 'tab:toggle+down,btab:toggle+up' \
@@ -529,7 +564,7 @@ _gh_pr_multi_select() {
         --bind 'ctrl-d:preview-page-down,ctrl-u:preview-page-up' \
         --preview 'GH_FORCE_TTY=1 gh pr view {1} && echo && gh pr diff {1} --color=always | head -100' \
         --preview-window right:65%:wrap | \
-    awk -F'\t' -v repo="$repo" '{printf "%s\t%s\t%s\n", repo, $1, $2}'
+    awk -v repo="$repo" '{num=$1; sub(/^#/,"",num); $1=$2=$3=$4=$5=""; sub(/^ +/,""); printf "%s\t%s\t%s\n", repo, num, $0}'
 }
 
 # Interactive PR merge (squash). No args → multi-select picker (Tab to mark
@@ -560,32 +595,70 @@ ghrb() {
 
 # Pick an open PR; prints its number.
 _gh_pr_pick() {
-  gh pr list --limit 100 | \
+  gh pr list --limit 100 \
+      --json number,title,headRefName,isDraft,statusCheckRollup,reviewDecision \
+      --jq '.[] | [
+        "#\(.number)",
+        (if .isDraft then "draft" else "ready" end),
+        (if (.statusCheckRollup | length) == 0 then "⏳CI"
+         elif (.statusCheckRollup | all(.conclusion == "SUCCESS")) then "✓CI"
+         elif (.statusCheckRollup | any(.conclusion == "FAILURE")) then "✗CI"
+         else "⏳CI" end),
+        (if .reviewDecision == "APPROVED" then "✓rev"
+         elif .reviewDecision == "CHANGES_REQUESTED" then "✗rev"
+         elif .reviewDecision == "REVIEW_REQUIRED" then "⏳rev"
+         else "-rev" end),
+        .headRefName[:25],
+        .title[:50]
+      ] | @tsv' | \
+    column -t -s $'\t' | \
+    _gh_paint | \
     fzf --ansi \
         --preview 'GH_FORCE_TTY=1 gh pr view {1} && echo && gh pr diff {1} --color=always | head -100' \
         --preview-window right:65%:wrap \
         --bind 'ctrl-/:toggle-preview' \
         --bind 'ctrl-d:preview-page-down,ctrl-u:preview-page-up' \
         --header '⏎ select PR | ^/ toggle preview | ^d/u scroll' | \
-    awk '{print $1}'
+    awk '{n=$1; sub(/^#/,"",n); print n}'
 }
 
 # Pick an open issue; prints its number.
 _gh_issue_pick() {
-  gh issue list --limit 100 | \
+  gh issue list --limit 100 \
+      --json number,title,labels,updatedAt \
+      --jq '.[] | [
+        "#\(.number)",
+        (if (.labels | length) > 0 then (.labels | map(.name) | join(","))[:20] else "-" end),
+        (.updatedAt | fromdateiso8601 | strftime("%Y-%m-%d")),
+        .title[:60]
+      ] | @tsv' | \
+    column -t -s $'\t' | \
+    _gh_paint | \
     fzf --ansi \
         --preview 'GH_FORCE_TTY=1 gh issue view {1}' \
         --preview-window right:60%:wrap \
         --bind 'ctrl-/:toggle-preview' \
         --bind 'ctrl-d:preview-page-down,ctrl-u:preview-page-up' \
         --header '⏎ select issue | ^/ toggle preview | ^d/u scroll' | \
-    awk '{print $1}'
+    awk '{n=$1; sub(/^#/,"",n); print n}'
 }
 
 # Pick a recent workflow run; prints its databaseId (ID is field 1).
 _gh_run_pick() {
-  gh run list --limit 50 --json databaseId,status,workflowName,headBranch,displayTitle \
-    --jq '.[] | "\(.databaseId)  \(.status)  \(.workflowName)  \(.headBranch)  \(.displayTitle)"' 2>/dev/null | \
+  gh run list --limit 50 \
+      --json databaseId,status,conclusion,workflowName,headBranch,displayTitle \
+      --jq '.[] | [
+        (.databaseId|tostring),
+        (if .status != "completed" then "⏳\(.status)"
+         elif .conclusion == "success" then "✓ok"
+         elif .conclusion == "failure" then "✗fail"
+         else "•\(.conclusion // .status)" end),
+        .workflowName[:25],
+        .headBranch[:20],
+        .displayTitle[:45]
+      ] | @tsv' 2>/dev/null | \
+    column -t -s $'\t' | \
+    _gh_paint | \
     fzf --ansi \
         --preview 'GH_FORCE_TTY=1 gh run view {1}' \
         --preview-window right:65%:wrap \
@@ -623,14 +696,14 @@ ghrp() {
   list=$(gh search prs --state open --label 'autorelease: pending' \
            "${owner_args[@]}" --limit 100 \
            --json repository,number,title \
-           --jq '.[] | [.repository.nameWithOwner, (.number|tostring), .title] | @tsv' 2>/dev/null)
+           --jq '.[] | [.repository.nameWithOwner, "#\(.number)", .title] | @tsv' 2>/dev/null)
   if [[ -z "$list" ]]; then
     echo "No open release-please PRs found in: ${(j:, :)owners}"
     return 0
   fi
 
   local selections
-  selections=$(print -r -- "$list" | column -t -s $'\t' | \
+  selections=$(print -r -- "$list" | column -t -s $'\t' | _gh_paint | \
       fzf --ansi --multi \
           --header 'Tab mark · ^a all · ⏎ confirm squash-merge · ^/ preview · ^d/u scroll' \
           --bind 'tab:toggle+down,btab:toggle+up' \
@@ -644,7 +717,7 @@ ghrp() {
   # columned selection → "repo<TAB>num<TAB>title" for the batch engine
   local tsv
   tsv=$(print -r -- "$selections" | \
-    awk '{repo=$1; num=$2; $1=$2=""; sub(/^ +/,""); printf "%s\t%s\t%s\n", repo, num, $0}')
+    awk '{repo=$1; num=$2; sub(/^#/,"",num); $1=$2=""; sub(/^ +/,""); printf "%s\t%s\t%s\n", repo, num, $0}')
   _gh_batch_merge "$tsv" --squash
 }
 


### PR DESCRIPTION
## Summary

Bring the `gh` PR/issue/run fzf picker functions in `dot_zshrc.tmpl` up to a consistent **colorized, column-aligned** standard for readability. Originally driven by a request to improve `ghsq`; extended to the adjacent pickers for consistency.

## Changes

- **`_gh_paint`** (new shared helper) — an `awk` colorizer applied *after* `column -t`, so padding is computed on plain text and the ANSI escapes (zero-width under `fzf --ansi`) never shift a column. Map: `✓…` green, `✗…` red, `⏳…` yellow, `#num` cyan, dates dim.
- **`ghsq` / `ghrb`** (`_gh_pr_multi_select`) — replaced the raw `gh pr list` dump with a `--json`/`--jq` table (`#num · state · CI · review · branch · title`) mirroring `ghpc`; rewrote the number/title extraction `awk` for the `#`-prefixed column.
- **`_gh_pr_pick`** (`ghv`/`ghd`/`ghco`/`ghck`) — same rich PR table.
- **`_gh_issue_pick`** (`ghiv`) — `#num · labels · updated · title` table.
- **`_gh_run_pick`** (`ghr`/`ghw`) — aligned with `column -t`; added a status glyph (`✓ok`/`✗fail`/`⏳…`) the colorizer paints.
- **`ghi` / `ghpc`** — added `_gh_paint` so their existing tables render in color.
- **`ghrp`** — `#`-prefixed PR numbers (cyan) with matching `#`-strip in extraction.

## Verification

- Rendered template (`chezmoi execute-template`) passes `zsh -n`.
- All four data pipelines tested live against `cli/cli`: aligned columns, correct ANSI, and correct number extraction — including run IDs surviving spaced workflow names and PR titles containing backticks.
- Confirmed `gh pr view '#N'` / `gh pr diff '#N'` accept the `#`-prefixed previews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)