### PR TITLE
docs(chezmoi): teach source-path navigation and add chattr/doctor

### DIFF
--- a/.claude/skills/chezmoi-expert/REFERENCE.md
+++ b/.claude/skills/chezmoi-expert/REFERENCE.md
@@ -32,6 +32,26 @@ chezmoi state dump
 chezmoi state reset
 ```
 
+### Changing Source Attributes (`chattr`)
+
+Change a managed file's attributes — template, private, executable, etc. —
+**without manually renaming the source file**. `chattr` renames the source
+entry for you to encode the new prefix/suffix, and it takes **target** paths.
+
+```bash
+chezmoi chattr +template ~/.bashrc      # plain source → add .tmpl suffix
+chezmoi chattr +private,+template ~/.netrc  # add private_ prefix AND .tmpl
+chezmoi chattr +encrypted ~/.ssh/id_ed25519 # mark for encryption
+chezmoi chattr +executable ~/bin/foo.sh # add executable_ prefix (mode 0755)
+chezmoi chattr -- -executable ~/bin/foo.sh  # remove it (-- guards the leading -)
+chezmoi chattr +exact ~/.config/app     # exact_ on a directory (prune orphans)
+```
+
+Attribute words: `template`, `private`, `readonly`, `executable`, `empty`,
+`encrypted`, `exact`, `remove`. Prefix with `+`/`-` (or `no` form). Manually
+renaming `foo` → `private_dot_foo.tmpl` works too, but `chattr` won't
+fat-finger the prefix order (`private_` before `dot_`, `.tmpl` last).
+
 ### External Files
 
 ```toml
@@ -290,6 +310,14 @@ sh -c "$(curl -fsLS get.chezmoi.io)" -- -b ~/.local/bin
 ```
 
 ## Debugging Checklist
+
+0. **Environment / setup broken?**
+   - Run `chezmoi doctor` first — checks chezmoi version, the source dir,
+     git, `$EDITOR`, the configured diff/merge/pager commands, and any
+     encryption tool (age/gpg) or password manager referenced by templates.
+   - Each row is `ok` / `warning` / `error`; fix `error` rows before
+     chasing apply/template symptoms below — a missing `age` or unset
+     recipient surfaces here, not in `apply` output.
 
 1. **File not updating?**
    - Check if managed: `chezmoi managed | grep <file>`

--- a/.claude/skills/chezmoi-expert/SKILL.md
+++ b/.claude/skills/chezmoi-expert/SKILL.md
@@ -31,9 +31,33 @@ Expert knowledge for managing dotfiles with chezmoi, including templates, cross-
 3. `chezmoi apply -v <path>` - Apply specific paths first
 4. Let user review before full `chezmoi apply`
 
+## Finding the Source File — Don't Translate Prefixes by Hand
+
+When you know a **target** path and need the **source**, ask chezmoi instead
+of mentally translating `dot_`/`private_`/`exact_`/`.tmpl`/`encrypted_`.
+Stacked prefixes make manual guessing error-prone, and a wrong guess points
+at a nonexistent path.
+
+```bash
+chezmoi source-path ~/.zshrc                 # → .../dot_zshrc.tmpl
+chezmoi source-path ~/.config/mise/config.toml  # → .../private_dot_config/mise/config.toml.tmpl
+chezmoi target-path <source-file>            # inverse: source → target
+```
+
+Canonical edit loop: **`chezmoi source-path <target>` → `Read` it → `Edit`
+it → `chezmoi apply`**. `source-path` exits non-zero when the target is not
+managed — check the exit code; if it errors, use `chezmoi unmanaged <path>`
+or `chezmoi managed <path>` to confirm whether the file is unmanaged vs.
+ignored (`chezmoi ignored`).
+
 ## Essential Commands
 
 ```bash
+# Find the source / target for a path (let chezmoi compute prefixes)
+chezmoi source-path ~/.zshrc    # Target → source (exits non-zero if unmanaged)
+chezmoi target-path <src-file>  # Source → target (inverse)
+chezmoi unmanaged ~/.config     # Home-dir files NOT managed by chezmoi
+
 # Check differences
 chezmoi diff                    # All pending changes
 chezmoi status                  # Quick status overview
@@ -48,11 +72,11 @@ chezmoi apply -v                # Apply all after review
 chezmoi add ~/.bashrc           # Start managing file
 chezmoi re-add ~/.bashrc        # Update from modified target
 chezmoi managed                 # List managed files
-chezmoi verify                  # Verify target matches source
+chezmoi verify                  # Verify target matches source (exit 0 = clean)
 
 # Templates
 chezmoi data                    # Show template variables
-chezmoi dump ~/.config/file     # Preview rendered output
+chezmoi cat ~/.config/file      # Preview rendered target content (renders .tmpl, decrypts)
 chezmoi execute-template < file # Test template
 ```
 

--- a/exact_dot_claude/rules/chezmoi-conventions.md
+++ b/exact_dot_claude/rules/chezmoi-conventions.md
@@ -31,6 +31,41 @@ Derived from git history patterns (1404 commits, 2018–2026).
 - After modifying `exact_dot_claude/rules/`, run `chezmoi apply --force ~/.claude`
 - Use `chezmoi diff` to preview changes before applying
 
+## Finding the Source File — Ask Chezmoi, Don't Translate
+
+When you know a **target** path and need to read or edit its **source**, do
+not hand-translate the `dot_` / `private_` / `exact_` / `.tmpl` /
+`encrypted_` prefixes — let chezmoi compute it. Stacked prefixes
+(`private_dot_config/private_fish/...`) make manual translation error-prone,
+and a wrong guess silently points at a path that doesn't exist.
+
+```
+chezmoi source-path ~/.zshrc
+# → ~/.local/share/chezmoi/dot_zshrc.tmpl
+
+chezmoi source-path ~/.claude/rules/security.md
+# → ~/.local/share/chezmoi/exact_dot_claude/rules/security.md
+
+chezmoi source-path ~/.config/mise/config.toml
+# → ~/.local/share/chezmoi/private_dot_config/mise/config.toml.tmpl
+```
+
+The canonical edit workflow becomes: **`chezmoi source-path <target>` →
+`Read` that path → `Edit` it → `chezmoi apply`**. This is the same in any
+chezmoi-managed repo, so it works regardless of the project's specific
+naming layout.
+
+| Need | Command | Notes |
+|---|---|---|
+| Source path for a target | `chezmoi source-path <target>` | Exits non-zero if the target is **not managed** — check the exit code before reading the result |
+| Target path for a source file | `chezmoi target-path <source>` | Inverse direction; useful when browsing the source tree |
+| Is this home-dir file managed at all? | `chezmoi unmanaged <path>` / `chezmoi managed <path>` | When `source-path` errors, confirm whether the file is unmanaged vs. ignored (`chezmoi ignored`) |
+| Preview rendered target content | `chezmoi cat <target>` | Renders `.tmpl` and decrypts `encrypted_` in memory — reading the raw source shows template syntax, not the result |
+
+`--source-path` is also a global flag: `chezmoi diff --source-path
+<source-file>` lets commands take source paths directly when you already
+have one.
+
 ## Runtime Drift (Claude Code's `settings.json`)
 
 Some target files are mutated by the application at runtime, not just by `chezmoi apply`. Claude Code writes to `~/.claude/settings.json` when the user toggles plugins, dismisses surveys, changes editor mode, enables features, or modifies anything via `/config` or `/plugin`. The chezmoi source has no idea those mutations happened.


### PR DESCRIPTION
## Summary

Teaches the "ask chezmoi for the source path, don't hand-translate the prefixes" workflow, so the resolve→Read→Edit→apply loop works regardless of a repo's `dot_`/`private_`/`exact_`/`.tmpl` layout.

## Changes

- **`exact_dot_claude/rules/chezmoi-conventions.md`**: new "Finding the Source File — Ask Chezmoi, Don't Translate" section with `chezmoi source-path` examples and a lookup table (`source-path`/`target-path`/`managed`/`unmanaged`/`cat`).
- **`.claude/skills/chezmoi-expert/SKILL.md`**: adds the source-path workflow to Essential Commands; fixes the rendered-preview command (`chezmoi dump` → `chezmoi cat`).
- **`.claude/skills/chezmoi-expert/REFERENCE.md`**: adds `chattr` (Advanced Commands) and `doctor` (Debugging Checklist step 0).

Doc-only; no functional/config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)