### PR TITLE
docs(claude): Opus-only subagents + mise exec for pinned versions

### DIFF
--- a/exact_dot_claude/rules/agent-and-tool-selection.md
+++ b/exact_dot_claude/rules/agent-and-tool-selection.md
@@ -20,3 +20,27 @@ is only correct for agents defined at the user or project level
 When the agent list shows a `plugin:agent` form, always use that form. If the
 expected agent is missing from the current session's agent list, prefer a
 graceful fallback (different agent or direct tool use) over guessing a name.
+
+## Always Use Opus for Subagents and Agent Teams
+
+Every spawned subagent and every member of an agent team **must run on Opus**.
+Do not select Sonnet (or Haiku) for delegated work. Opus 4.8 on *low* effort
+already beats Sonnet 4.6 on *high* effort — on both quality and token
+efficiency — so there is no scenario where a smaller model is the right call
+for a subagent.
+
+- **Model**: always `opus`. Never pass `model: "sonnet"` / `"haiku"` to the
+  `Agent` / `Task` tools, to `agent()`/`opts.model` in `Workflow` scripts, or
+  to per-phase `model` overrides. When a teammate or workflow agent would
+  otherwise inherit a non-Opus session model, set `model: "opus"` explicitly.
+- **Effort**: free to dial down. `low` or `medium` effort is fine — and
+  preferred — for most delegated tasks; reserve `high` for genuinely hard
+  reasoning. The effort knob, not the model knob, is the lever for cost.
+- **Remove Sonnet suggestions on sight.** If an agent definition, workflow,
+  skill, or rule still recommends or hard-codes Sonnet for a subagent, change
+  it to Opus.
+
+Rationale: a subagent's output feeds back into the main loop as a tool result,
+so a weaker delegate quietly degrades everything downstream. Opus-low is both
+better and cheaper than Sonnet-high, which makes "save tokens with Sonnet" a
+false economy.

--- a/exact_dot_claude/rules/dependency-management.md
+++ b/exact_dot_claude/rules/dependency-management.md
@@ -13,6 +13,33 @@ Derived from git history patterns (tooling decisions across 1404 commits).
 4. **cargo install** / **go install** — When not available via aqua
 5. **brew install** — Last resort for CLI tools; primary for system packages and GUI apps
 
+## Running With a Specific Version — `mise exec`, Not `mise use`
+
+When a command needs a *specific* version of a mise-provided runtime (Python,
+Node, Go, Rust, Bun, or anything else mise installs) for one invocation, run it
+through `mise exec <tool>@<version> --` instead of switching the default with
+`mise use`.
+
+```
+mise exec python@3.14 -- uv run script.py
+mise exec node@22 -- npm ci
+mise exec go@1.23 -- go build ./...
+```
+
+Why `exec` over `use`:
+
+- **`mise use` clobbers the default.** It writes the version into the active
+  `mise.toml` / `.tool-versions`, so it persists and silently changes the
+  runtime for everything else relying on the current default. `mise exec`
+  scopes the version to the single command and leaves the default untouched.
+- **One streamlined line.** No "switch version → run → switch back" dance, and
+  no risk of forgetting the revert.
+- **Composes with `uv`/`npm`/etc.** Put `mise exec …@… --` in front of the
+  normal command; everything after `--` runs under the pinned runtime.
+
+Reach for `mise use` only when you genuinely want to *change* the project's or
+shell's default version going forward — not for a one-off run.
+
 ## Homebrew Package Profiles
 
 Packages are managed through `.chezmoidata/packages.toml` with profile activation in `.chezmoidata/profiles.toml`:


### PR DESCRIPTION
## Summary

Two global Claude rule updates.

### 1. Opus-only for delegated work (`agent-and-tool-selection.md`)
Every spawned subagent and agent-team member must run on Opus — never Sonnet/Haiku — including `Agent`/`Task` calls, Workflow `agent()`/per-phase `model` overrides. Opus 4.8 on low effort beats Sonnet 4.6 on high effort on both quality and token efficiency, and a weak delegate's output feeds the main loop, quietly degrading everything downstream. Effort (low/medium), not model, is the cost lever.

### 2. `mise exec @version` over `mise use` (`dependency-management.md`)
When a command needs a specific version of a mise-provided runtime for a one-off, run it via `mise exec <tool>@<ver> -- ...` (e.g. `mise exec python@3.14 -- uv run ...`) instead of `mise use`, which clobbers the default for everything else. `exec` scopes the version to a single command and composes cleanly with uv/npm/etc.

## Notes
- No existing Sonnet references existed in these user rules to remove; any Sonnet defaults in the `laurigates/claude-plugins` repo are out of scope here.
- After merge, `chezmoi apply -v ~/.claude` syncs the rules to the live config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)