### PR TITLE
docs(claude): distill modify_ drift pattern + auto-mode permission rule

### DIFF
--- a/.claude/skills/chezmoi-expert/REFERENCE.md
+++ b/.claude/skills/chezmoi-expert/REFERENCE.md
@@ -66,6 +66,40 @@ fat-finger the prefix order (`private_` before `dot_`, `.tmpl` last).
   url = "https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim"
 ```
 
+### Scripted Targets (`run_*` and `modify_`)
+
+| Prefix | When it runs | stdin | stdout |
+|---|---|---|---|
+| `run_once_<name>` | first apply only (hash tracked) | — | — |
+| `run_onchange_<name>` | when the script's contents/hash change | — | — |
+| `modify_<target>` | every apply/diff | **current target contents** | **becomes the new target** |
+
+A `modify_` script is the tool for a **partially-managed file** — one the
+application rewrites at runtime, where a static source perpetually drifts.
+chezmoi feeds the current target on stdin; the script emits the desired
+contents. The idiomatic pattern is a `jq` deep-merge of a managed overlay over
+the live file, so named keys are pinned and everything else passes through:
+
+```bash
+#!/usr/bin/env bash
+# modify_settings.json  -> ~/.claude/settings.json   (chmod +x)
+set -euo pipefail
+current="$(cat)"; [ -z "$current" ] && current='{}'
+read -r -d '' overlay <<'OVERLAY' || true
+{ "permissions": { "defaultMode": "auto" } }
+OVERLAY
+jq -n --argjson cur "$current" --argjson ov "$overlay" '$cur * $ov'
+```
+
+- `jq` `*` merges objects recursively but **replaces arrays** — overlay arrays
+  win wholesale (authoritative allow/deny lists, etc.).
+- The script must be **executable**. A `modify_*.json` source is a script, not
+  JSON — exclude it from any `check-json` pre-commit hook:
+  `exclude: '(^|/)modify_.*\.json$'`.
+- Confirm idempotency with an empty `chezmoi diff` after apply.
+- `modify_` and a static source for the same target conflict
+  (`inconsistent state`) — `git rm` the static file when converting.
+
 ## Template Functions
 
 ### Built-in Functions

--- a/exact_dot_claude/rules/chezmoi-conventions.md
+++ b/exact_dot_claude/rules/chezmoi-conventions.md
@@ -89,6 +89,26 @@ In headless environments (Claude Code agent sessions, CI), the TTY prompt errors
 
 Applies equally to any other tool that writes to its own chezmoi-managed config: `~/.config/gh/config.yml`, `~/.config/mise/config.toml` when mise mutates it, etc. Check `chezmoi diff` before applying.
 
+### Durable fix: manage the file with a `modify_` script
+
+The reconcile dance above is a per-apply chore. For a file the app rewrites *constantly* (Claude Code's `settings.json` is the worst offender — interactive toggles, schema changes across versions, auto-formatting), stop fighting it: convert the static source to a chezmoi **`modify_` script**. chezmoi pipes the *current* target to the script on stdin; the script's stdout becomes the new target. A `jq` deep-merge pins only the keys you manage and lets everything else pass through:
+
+```bash
+# exact_dot_claude/modify_settings.json  (must be executable)
+current="$(cat)"; [ -z "$current" ] && current='{}'
+read -r -d '' overlay <<'OVERLAY' || true
+{ "permissions": { "defaultMode": "auto" }, "teammateMode": "auto" }
+OVERLAY
+jq -n --argjson cur "$current" --argjson ov "$overlay" '$cur * $ov'
+```
+
+- Keys named in the overlay are **pinned**; keys you omit (`effortLevel`, `feedbackSurveyState`, any new key a future version adds) **pass through untouched** — drift stops being a problem.
+- `jq`'s `*` **replaces arrays**, so `permissions.allow`/`deny` become authoritative: an interactive grant is reverted on the next apply unless promoted into the overlay (good hygiene — keeps project-specific noise out).
+- The source is named `modify_<target>` (`modify_settings.json` → `~/.claude/settings.json`), must be **executable**, and — because it ends in `.json` but is a script — must be **excluded from the `check-json` pre-commit hook**: `exclude: '(^|/)modify_.*\.json$'`.
+- Verify idempotency: `chezmoi diff` is empty after `chezmoi apply`.
+
+See the `chezmoi-expert` skill REFERENCE for the general `modify_` mechanics. For the permission-key specifics of a Claude Code settings overlay, see `claude-code-auto-mode.md`.
+
 ## Script Conventions
 
 - `run_onchange_*` scripts execute when their template hash changes

--- a/exact_dot_claude/rules/claude-code-auto-mode.md
+++ b/exact_dot_claude/rules/claude-code-auto-mode.md
@@ -1,0 +1,92 @@
+# Claude Code Auto Mode & Permission Rules
+
+**Scope**: writing or editing `permissions` / `autoMode` in any Claude Code
+`settings.json` — user (`~/.claude/`), project (`.claude/`), or the chezmoi
+`modify_settings.json` overlay. Especially relevant when
+`permissions.defaultMode` is `"auto"`.
+
+## Two gates, evaluated in order
+
+Auto mode runs **two** independent checks:
+
+1. **Permission rules** (`permissions.allow` / `ask` / `deny`, tool-pattern
+   based) — resolve first.
+2. **The classifier** (a separate model, configured by the `autoMode` block,
+   prose based) — reviews whatever the rules didn't resolve.
+
+Decision order, first match wins: allow/deny rules → read-only and
+working-directory edits auto-approved → everything else to the classifier.
+Writes to protected paths always route to the classifier even when an allow
+rule matches.
+
+## Broad allow rules are DROPPED on entry to auto mode
+
+The easy mistake. On entering auto mode, allow rules that grant **arbitrary
+code execution are stripped**:
+
+- `Bash(*)`, `PowerShell(*)`
+- wildcarded interpreters like `Bash(python*)` / `Bash(python3:*)`
+- package-manager run commands (`npm run *`)
+- `Agent(*)`
+
+Narrow rules like `Bash(npm test)` or `Bash(git add *)` carry over and skip
+the classifier round-trip. **So prefer narrow, scoped allow rules**
+(`Bash(git add *)`, `Bash(gh pr *)`) over broad `Bash(git:*)`. The broad form
+gives no benefit under auto mode (it is stripped) and reduces classifier
+oversight in the non-auto modes. Under auto mode the allow-list's only job is
+skipping the classifier on safe, high-frequency commands — which wants narrow
+entries.
+
+## `deny` is a hard backstop
+
+`permissions.deny` resolves before the classifier and cannot be overridden in
+any mode except `bypassPermissions`. Keep dangerous ops in `deny`
+(`git push --force *`, `git add -A`, `kubectl config use-context *`,
+`Write(**/CHANGELOG.md)`).
+
+## The `autoMode` block is the real lever
+
+Separate from `permissions`; user-settable in `~/.claude/settings.json` (it is
+**not** read from project `.claude/settings.json`, so a repo can't grant itself
+trust). Four prose-list fields:
+
+| Field | Purpose |
+|---|---|
+| `environment` | Trusted infra (repos, buckets, domains). Default trusts only the working repo + its remotes; everything else is "external". |
+| `allow` | Exceptions that override `soft_deny`. |
+| `soft_deny` | Destructive actions; explicit user intent or a matching `allow` can clear them. |
+| `hard_deny` | Unconditional boundaries; nothing overrides, not even explicit intent. |
+
+Precedence inside the classifier: `hard_deny` > `soft_deny` > `allow`-exception
+> explicit-user-intent. A general request ("clean up the repo") is not explicit
+intent; naming the exact action ("force-push this branch") is.
+
+- **Always include the literal `"$defaults"`** in each list you set — omitting
+  it REPLACES the entire built-in list for that section. A `soft_deny` without
+  `$defaults` silently discards force-push / `curl|bash` / prod-deploy
+  protection; a `hard_deny` without it discards the data-exfiltration and
+  auto-mode-bypass rules.
+- Inspect with `claude auto-mode defaults` (built-ins), `claude auto-mode
+  config` (effective config, `$defaults` expanded), and `claude auto-mode
+  critique` (AI review of your custom prose — surfaces ambiguity and
+  over-block risk).
+- The classifier also reads CLAUDE.md, so behavioral boundaries there
+  ("never force push", "never deploy to prod without approval") steer it too.
+- Custom rules should name destinations relative to `environment`, default
+  ambiguous targets to the safe side (e.g. unknown namespace ⇒ production), and
+  not re-state "in-boundary" language so broadly that it reads as clearing the
+  default exfiltration / credential-leak / destruction rules.
+
+## `defaultMode: "auto"` placement & requirements
+
+`defaultMode: "auto"` is **ignored** in project/local `.claude/settings*.json`
+(v2.1.142+) so a repo cannot grant itself auto mode — set it in
+`~/.claude/settings.json`. Requires Opus 4.6+ / Sonnet 4.6+ on the Anthropic
+API (Opus 4.7+/4.8 on Bedrock/Vertex/Foundry, which also need
+`CLAUDE_CODE_ENABLE_AUTO_MODE=1`).
+
+## Ref
+
+- <https://code.claude.com/docs/en/permission-modes.md>
+- <https://code.claude.com/docs/en/permissions.md>
+- <https://code.claude.com/docs/en/auto-mode-config.md>


### PR DESCRIPTION
## Summary

Session distillation (`/project:distill`) of the `settings.json` drift work (#235) and the auto-mode permission work (#236), captured as reusable global rules + skill reference.

## Changes

- **`exact_dot_claude/rules/chezmoi-conventions.md`** — extends the existing "Runtime Drift" section with the durable fix: manage an app-rewritten config via a `modify_` script (jq deep-merge of a pinned overlay over the live target) instead of the per-apply manual reconcile dance.
- **`exact_dot_claude/rules/claude-code-auto-mode.md`** *(new)* — documents how `permissions.defaultMode: auto` works: the two-gate model (permission rules → classifier), the **broad-allow-rules-dropped-on-entry** gotcha (prefer narrow scoped rules), `deny` as a hard backstop, the separate `autoMode` block + `$defaults` sentinel, and the `claude auto-mode defaults/config/critique` subcommands.
- **`.claude/skills/chezmoi-expert/REFERENCE.md`** — adds a "Scripted Targets" section (`run_once_`/`run_onchange_`/`modify_`) with the `modify_` jq-merge pattern and the check-json / executable / inconsistent-state gotchas.

Doc-only. Both referenced features (#235 `modify_settings.json`, #236 `autoMode` block) are already merged to `main`, so the docs match the live config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)