### PR TITLE
chore(claude): ignore Claude Code daemon and job runtime files

### DIFF
--- a/exact_dot_claude/.chezmoiignore
+++ b/exact_dot_claude/.chezmoiignore
@@ -16,6 +16,15 @@ teams/
 chrome/
 scheduled-tasks/
 sessions/
+.last-cleanup
+.last-update
+daemon/
+daemon.lock
+daemon.log
+daemon.status.json
+gh-pr-status-cache.json
+jobs/
+.last-update-result.json
 
 # Runtime files created by Claude Code
 .update.lock


### PR DESCRIPTION
## What

Add Claude Code runtime artifacts to `exact_dot_claude/.chezmoiignore`:

- `daemon/`, `daemon.lock`, `daemon.log`, `daemon.status.json`
- `jobs/`
- `gh-pr-status-cache.json`
- `.last-cleanup`, `.last-update`, `.last-update-result.json`

## Why

Claude Code writes these into `~/.claude` at runtime (daemon state, the job queue, PR-status/update caches, last-run markers). They are per-machine ephemeral state and should never enter the chezmoi-managed tree, where they'd show up as perpetual drift on `chezmoi diff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)