### PR TITLE
feat(kitty): tmux-aware ctrl+arrow pane navigation

### DIFF
--- a/macos-settings.toml
+++ b/macos-settings.toml
@@ -7,11 +7,14 @@ config_version = "1.0.0"
 last_updated = "2024-08-30"
 
 [keyboard_shortcuts]
-# Mission Control space navigation shortcuts (disabled for terminal use)
-disable_ctrl_left_arrow = true      # ID 79: Ctrl+Left Arrow
-disable_ctrl_right_arrow = true     # ID 81: Ctrl+Right Arrow
-disable_ctrl_shift_left = true      # ID 80: Ctrl+Shift+Left Arrow
-disable_ctrl_shift_right = true     # ID 82: Ctrl+Shift+Right Arrow
+# Mission Control shortcuts disabled so ctrl+arrow reaches the terminal
+# (kitty neighboring_window / tmux pane navigation) instead of macOS.
+disable_ctrl_left_arrow = true      # ID 79: Ctrl+Left Arrow (Move left a space)
+disable_ctrl_right_arrow = true     # ID 81: Ctrl+Right Arrow (Move right a space)
+disable_ctrl_shift_left = true      # ID 80: Ctrl+Shift+Left Arrow (Move window left a space)
+disable_ctrl_shift_right = true     # ID 82: Ctrl+Shift+Right Arrow (Move window right a space)
+disable_ctrl_up_arrow = true        # ID 32: Ctrl+Up Arrow (Mission Control)
+disable_ctrl_down_arrow = true      # ID 33: Ctrl+Down Arrow (Application windows / App Exposé)
 
 [finder]
 show_hidden_files = true

--- a/private_dot_config/private_kitty/kitty.conf.tmpl
+++ b/private_dot_config/private_kitty/kitty.conf.tmpl
@@ -789,11 +789,16 @@ map shift+down move_window down
 # map ctrl+shift+right layout_action move_to_screen_edge right
 # map ctrl+shift+down layout_action move_to_screen_edge bottom
 
-# Switch focus to the neighboring window in the indicated direction
-map ctrl+left neighboring_window left
-map ctrl+right neighboring_window right
-map ctrl+up neighboring_window up
-map ctrl+down neighboring_window down
+# Switch focus to the neighboring window in the indicated direction.
+# Routed through the custom kitten (the `kitten` keyword + .py file) rather
+# than kitty's built-in `neighboring_window` action, so it can be tmux-aware:
+# arg1 is the direction (used for kitty windows); arg2 is the key forwarded
+# into the child when it's tmux, so the same ctrl+arrow keypress moves tmux
+# panes (via tmux's `bind -n M-* select-pane` in ~/.tmux.conf).
+map ctrl+left kitten neighboring_window.py left alt+left
+map ctrl+right kitten neighboring_window.py right alt+right
+map ctrl+up kitten neighboring_window.py up alt+up
+map ctrl+down kitten neighboring_window.py down alt+down
 #: You can also create shortcuts to switch to specific layouts::
 
 #:     map ctrl+alt+t goto_layout tall

--- a/private_dot_config/private_kitty/neighboring_window.py
+++ b/private_dot_config/private_kitty/neighboring_window.py
@@ -1,0 +1,35 @@
+from kitty.key_encoding import KeyEvent, parse_shortcut
+from kittens.tui.handler import result_handler
+
+
+def main():
+    pass
+
+
+def encode_key_mapping(window, key_mapping):
+    mods, key = parse_shortcut(key_mapping)
+    event = KeyEvent(
+        mods=mods,
+        key=key,
+        shift=bool(mods & 1),
+        alt=bool(mods & 2),
+        ctrl=bool(mods & 4),
+        super=bool(mods & 8),
+        hyper=bool(mods & 16),
+        meta=bool(mods & 32),
+    ).as_window_system_event()
+
+    return window.encoded_key(event)
+
+
+@result_handler(no_ui=True)
+def handle_result(args, result, target_window_id, boss):
+    window = boss.window_id_map.get(target_window_id)
+
+    cmd = window.child.foreground_cmdline[0]
+    if cmd == 'tmux':
+        keymap = args[2]
+        encoded = encode_key_mapping(window, keymap)
+        window.write_to_child(encoded)
+    else:
+        boss.active_tab.neighboring_window(args[1])

--- a/run_onchange_macos-settings.sh.tmpl
+++ b/run_onchange_macos-settings.sh.tmpl
@@ -16,11 +16,14 @@ echo "🍎 Configuring macOS settings..."
 echo "⌨️  Configuring keyboard shortcuts..."
 
 # Disable Mission Control shortcuts that interfere with development tools
-echo "  Disabling Mission Control space navigation shortcuts..."
+# (ctrl+arrow must reach the terminal for kitty/tmux pane navigation).
+echo "  Disabling Mission Control shortcuts that clash with ctrl+arrow..."
 defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 79 "{enabled = 0; value = { parameters = (65535, 123, 8650752); type = standard;};}" || echo "    ⚠️  Failed to disable Ctrl+Left shortcut"
 defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 80 "{enabled = 0; value = { parameters = (65535, 123, 8781824); type = standard;};}" || echo "    ⚠️  Failed to disable Ctrl+Shift+Left shortcut"
 defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 81 "{enabled = 0; value = { parameters = (65535, 124, 8650752); type = standard;};}" || echo "    ⚠️  Failed to disable Ctrl+Right shortcut"
 defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 82 "{enabled = 0; value = { parameters = (65535, 124, 8781824); type = standard;};}" || echo "    ⚠️  Failed to disable Ctrl+Shift+Right shortcut"
+defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 32 "{enabled = 0; value = { parameters = (65535, 126, 8650752); type = standard;};}" || echo "    ⚠️  Failed to disable Ctrl+Up shortcut (Mission Control)"
+defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 33 "{enabled = 0; value = { parameters = (65535, 125, 8650752); type = standard;};}" || echo "    ⚠️  Failed to disable Ctrl+Down shortcut (Application windows)"
 
 # =============================================================================
 # FINDER SETTINGS


### PR DESCRIPTION
## What

Make a single `ctrl+arrow` keypress move focus seamlessly across **both** kitty windows and tmux panes.

- Route `ctrl+{left,right,up,down}` through a custom `neighboring_window.py` kitten instead of kitty's built-in `neighboring_window` action.
- The kitten checks the window's foreground process: if it's `tmux`, it forwards the corresponding `alt+arrow` keypress into the child (driving tmux's `bind -n M-* select-pane`); otherwise it falls back to `boss.active_tab.neighboring_window(direction)`.
- Disable the macOS `Ctrl+Up` (Mission Control, ID 32) and `Ctrl+Down` (App Exposé, ID 33) symbolic hotkeys so `ctrl+up`/`ctrl+down` reach the terminal — completing the set with the already-disabled left/right space-navigation shortcuts.

## Why

`ctrl+arrow` previously only moved between kitty windows, and macOS swallowed `ctrl+up`/`ctrl+down` for Mission Control / App Exposé. This unifies pane navigation under one ergonomic chord regardless of whether the active window is running tmux.

## Note on the kitten

`neighboring_window.py` was already installed in the target (`~/.config/kitty/`) but was **untracked by chezmoi** — the prior config edits referencing it would have shipped a broken config to a fresh `chezmoi apply`. This PR brings the kitten into the source (`private_dot_config/private_kitty/neighboring_window.py`) so the config and its dependency ship together.

The sibling kittens `relative_resize.py` and `split_window.py` also exist untracked in the target but are not referenced by the current config, so they are intentionally left out of this PR.

## Files

- `private_dot_config/private_kitty/kitty.conf.tmpl` — ctrl+arrow → kitten mappings
- `private_dot_config/private_kitty/neighboring_window.py` — **new**, the tmux-aware kitten
- `macos-settings.toml` — declare ctrl+up/down disabled
- `run_onchange_macos-settings.sh.tmpl` — `defaults write` for hotkey IDs 32 & 33

🤖 Generated with [Claude Code](https://claude.com/claude-code)