### PR TITLE
chore(zsh): pin HOMEBREW_GIT_PATH to system git and redirect TMPDIR

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -141,6 +141,14 @@ export BAT_STYLE=plain
 export OLLAMA_ORIGINS="app://obsidian.md*"
 export HOMEBREW_BUNDLE_FILE="~/Brewfile"
 
+# Use system git for Homebrew's own operations. The Linuxbrew git bottle on
+# TrueNAS is built against a newer glibc than the host provides, so it fails
+# with "GLIBC_2.38 not found". System git (>= 2.7.0) satisfies brew's minimum.
+export HOMEBREW_GIT_PATH=/usr/bin/git
+
+# Redirect TMPDIR to a home-pool location (host /tmp is small/noexec on TrueNAS).
+export TMPDIR="$HOME/tmp/"
+
 # Remove "/" from WORDCHARS so that Ctrl+W doesn't kill directory paths.
 WORDCHARS="${WORDCHARS//[\/]}"
 


### PR DESCRIPTION
## What

- Add `export HOMEBREW_GIT_PATH=/usr/bin/git` to `dot_zshrc.tmpl`.
- Add `export TMPDIR="$HOME/tmp/"`.

## Why

The Linuxbrew `git` bottle on the TrueNAS host (git 2.54.0) is built against glibc 2.38, newer than the host provides, so it fails at startup with `GLIBC_2.38 not found`. Because brew's bin is ahead of `/usr/bin` on PATH, this broke the Claude Code plugin marketplace clone (and any other brew/git path).

Immediate fix this session was `brew unlink git` (falls through to the working `/usr/bin/git` 2.39.5). `HOMEBREW_GIT_PATH` makes it durable: Homebrew's own operations use system git even if a future `brew upgrade` relinks the broken bottle. `/usr/bin/git` exceeds brew's 2.7.0 minimum and exists on macOS too, so the line is cross-platform safe.

`TMPDIR` → `$HOME/tmp/` keeps temp work on the `/mnt/main` ZFS pool (exec-capable) instead of the small/noexec host `/tmp`.

## Notes

- Applied and verified this session; `~/tmp` confirmed not `noexec`.
- New shells only — existing sessions keep their env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)