### PR TITLE
feat(claude): rules consolidation — exact-dir safety, scaffold-backport rule, glab CLI

### DIFF
--- a/exact_dot_claude/.chezmoiignore
+++ b/exact_dot_claude/.chezmoiignore
@@ -1,3 +1,16 @@
+# Friction-learner weekly baseline reports (written by the reduce-friction
+# scheduled task; moved out of rules/ so they don't load into every session).
+# MUST stay ignored: ~/.claude is an exact_ dir, so an unlisted top-level
+# entry is DELETED on chezmoi apply.
+friction-reports/
+
+# Vendored third-party skill, installed and updated by `notebooklm skill
+# install` (ships with the notebooklm-py package). Not chezmoi-managed so
+# tool updates don't fight chezmoi apply. Re-run the install after every
+# `uv tool upgrade notebooklm-py` — upgrading the package alone does not
+# refresh the skill file.
+skills/notebooklm/
+
 # Runtime directories created by Claude Code - don't manage or remove these
 cache/
 file-history/

--- a/exact_dot_claude/hooks/executable_chezmoi-exact-guard.sh
+++ b/exact_dot_claude/hooks/executable_chezmoi-exact-guard.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) — block `chezmoi apply` when it would DELETE target files.
+#
+# exact_ source dirs (exact_dot_claude/ → ~/.claude/) remove every target
+# entry that is in neither the source nor a .chezmoiignore, and --force makes
+# the removal silent. Path-scoped `chezmoi diff <target>` does NOT surface
+# pending deletions; only `chezmoi status` D-lines do. This guard runs that
+# status check so an apply can never silently delete unmanaged files.
+# Incident reference: ~/.claude/rules/chezmoi-conventions.md
+# ("exact_ Dirs DELETE Unmanaged Files").
+#
+# Registered user-globally (modify_settings.json) so it fires regardless of
+# the session's cwd — applies are often run far from the dotfiles repo.
+set -euo pipefail
+
+input=$(cat)
+
+tool=$(jq -r '.tool_name // empty' <<<"$input" 2>/dev/null || echo "")
+[ "$tool" = "Bash" ] || exit 0
+
+cmd=$(jq -r '.tool_input.command // empty' <<<"$input" 2>/dev/null || echo "")
+[ -z "$cmd" ] && exit 0
+
+# Fast bail: only inspect commands that invoke `chezmoi ... apply`
+case "$cmd" in
+    *chezmoi*apply*) ;;
+    *) exit 0 ;;
+esac
+
+# Dry runs and verbose previews are safe
+case "$cmd" in
+    *--dry-run*|*" -n "*) exit 0 ;;
+esac
+
+command -v chezmoi >/dev/null 2>&1 || exit 0
+
+# Pending deletions: `chezmoi status` lines whose second column is D.
+# Paths are reported relative to ~. Keep paths bare here; indent at print time.
+deletions=$(chezmoi status 2>/dev/null | awk '$1 == "D" || substr($0,2,1) == "D" { print "~/" $NF }' || true)
+[ -z "$deletions" ] && exit 0
+
+# If the apply is path-scoped, only block when a pending deletion falls
+# under one of the given paths. Extract non-flag args after `apply`.
+scoped_paths=$(awk '{
+    seen=0
+    for (i=1; i<=NF; i++) {
+        if ($i == "apply") { seen=1; continue }
+        if (seen && $i !~ /^-/) print $i
+    }
+}' <<<"$cmd")
+
+if [ -n "$scoped_paths" ]; then
+    relevant=""
+    while IFS= read -r del; do
+        del_abs="${del/#\~/$HOME}"
+        while IFS= read -r p; do
+            p_abs="${p/#\~/$HOME}"
+            case "$del_abs" in
+                "$p_abs"|"$p_abs"/*) relevant+="$del"$'\n' ;;
+            esac
+        done <<<"$scoped_paths"
+    done <<<"$deletions"
+    deletions="${relevant%$'\n'}"
+    [ -z "$deletions" ] && exit 0
+fi
+
+cat >&2 <<EOF
+BLOCKED: this 'chezmoi apply' would DELETE the following target file(s)
+(unmanaged entries inside an exact_-managed tree are removed on apply,
+silently under --force):
+
+$(sed 's/^/  /' <<<"$deletions")
+
+Before re-running, register or resolve each one:
+  - keep + manage:     chezmoi add <target>
+  - keep, unmanaged:   add a commented entry to the exact_ dir's .chezmoiignore
+  - deletion intended: rm the target file yourself, then apply
+
+See ~/.claude/rules/chezmoi-conventions.md ("exact_ Dirs DELETE Unmanaged
+Files") for the full guard rationale.
+EOF
+exit 2

--- a/exact_dot_claude/modify_settings.json
+++ b/exact_dot_claude/modify_settings.json
@@ -17,6 +17,14 @@
 # "always allow" grant made in a session is wiped on the next `chezmoi apply`
 # unless it is promoted into the overlay below. That keeps project-specific
 # permission noise out of the global config by design.
+#
+# hooks.SessionStart / hooks.Stop are pinned to empty arrays on purpose:
+# session spinup/end nudges now come from session-plugin (auto-registered via
+# its plugin.json hooks). Because the overlay REPLACES arrays on merge, the
+# empty arrays force-clear the retired user-level nudge hooks from the live
+# target. (Do not re-add a "//" comment key inside the JSON hooks object —
+# Claude Code's settings schema has no comment support and /doctor flags it
+# as an unknown hook event.)
 set -euo pipefail
 
 current="$(cat)"
@@ -188,9 +196,19 @@ read -r -d '' overlay <<'OVERLAY' || true
     ]
   },
   "hooks": {
-    "//": "Session spinup/end nudges are provided by session-plugin (auto-registered via its plugin.json SessionStart/Stop hooks). These arrays are kept empty to force-clear the retired user-level nudge hooks from the live target, since the modify_ overlay replaces arrays on merge.",
     "SessionStart": [],
-    "Stop": []
+    "Stop": [],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/chezmoi-exact-guard.sh"
+          }
+        ]
+      }
+    ]
   },
   "statusLine": {
     "type": "command",

--- a/exact_dot_claude/rules/agent-and-tool-selection.md
+++ b/exact_dot_claude/rules/agent-and-tool-selection.md
@@ -44,3 +44,15 @@ Rationale: a subagent's output feeds back into the main loop as a tool result,
 so a weaker delegate quietly degrades everything downstream. Opus-low is both
 better and cheaper than Sonnet-high, which makes "save tokens with Sonnet" a
 false economy.
+
+### Sanctioned exception: cold-read gates run on Haiku
+
+The `agent-patterns-plugin:cold-read-gate` pattern deliberately uses
+`model: "haiku"` for its isolated fresh-reader critics. That agent is not a
+delegate producing work — it is the **measurement instrument**: the test is
+"can a low-context, low-capability reader act on this text alone?", and a
+stronger model would answer a different, easier question. Do not "fix" haiku
+cold readers to Opus. The exception applies only to readers whose entire job
+is to report what confuses them about a single artifact; any agent that
+edits, verifies facts, or returns analysis the main loop builds on stays on
+Opus.

--- a/exact_dot_claude/rules/chezmoi-conventions.md
+++ b/exact_dot_claude/rules/chezmoi-conventions.md
@@ -31,6 +31,46 @@ Derived from git history patterns (1404 commits, 2018–2026).
 - After modifying `exact_dot_claude/rules/`, run `chezmoi apply --force ~/.claude`
 - Use `chezmoi diff` to preview changes before applying
 
+## exact_ Dirs DELETE Unmanaged Files — Check `chezmoi status` Before Apply
+
+An `exact_` source dir (notably `exact_dot_claude/` → `~/.claude/`) makes
+apply **remove every target entry** that is in neither the source nor a
+`.chezmoiignore`. With `--force` (required in headless sessions) the removal
+is **silent** — no prompt, no warning. This deleted a freshly created
+`~/.claude/friction-reports/` (10 files, ~150 KB) on 2026-06-10; it was
+recovered only because the contents happened to survive in session
+transcripts and context.
+
+Two traps stack here:
+
+1. **Path-scoped `chezmoi diff <target>` does NOT show pending deletions of
+   unmanaged files** (verified: a canary file in `~/.claude` produced empty
+   `chezmoi diff ~/.claude` output). The "diff before apply" habit alone
+   cannot catch this. Only `chezmoi status` (` D <path>` lines) or the
+   *unrestricted* `chezmoi diff` (`deleted file mode` hunks) reveal them.
+2. **`--force` only suppresses the prompt; it adds no safety.** The check
+   has to happen before the apply, not be delegated to the prompt.
+
+**The rule:**
+
+- **Before any `chezmoi apply` that touches an exact_ tree**, run
+  `chezmoi status <target-tree>` and treat every ` D` line as a stop
+  signal: either it's an intended removal, or the file must first be
+  registered (below). Never apply over an unexplained ` D`.
+- **Creating or moving files INTO a chezmoi-managed target tree requires
+  registering them in the same change** — `chezmoi add <target>` if it
+  should be managed, or a `.chezmoiignore` entry (with a comment saying
+  who owns it) if intentionally unmanaged. A new top-level entry in an
+  exact_ dir that is neither is one apply away from deletion.
+- `.chezmoiignore` placement: the file inside the exact_ source dir
+  (`exact_dot_claude/.chezmoiignore`) with patterns relative to that
+  target (`friction-reports/`, `skills/notebooklm/`).
+- exact_ semantics apply **per directory level**: only the dir carrying the
+  `exact_` prefix purges unmanaged entries; its non-`exact_` subdirs (e.g.
+  `rules/`, `skills/` under `exact_dot_claude/`) tolerate unmanaged files.
+  That asymmetry is why damage can look partial — and why "it survived last
+  time" proves nothing about a sibling path.
+
 ## Finding the Source File — Ask Chezmoi, Don't Translate
 
 When you know a **target** path and need to read or edit its **source**, do

--- a/exact_dot_claude/rules/development-process.md
+++ b/exact_dot_claude/rules/development-process.md
@@ -1,0 +1,80 @@
+# Development Process
+
+## Documentation-First
+
+**ALWAYS check documentation before implementing changes or features.**
+
+Before implementing any changes or features, complete this checklist:
+
+1. **Read relevant documentation sections thoroughly**
+2. **Verify syntax and parameters** in official documentation before coding
+3. **Check for breaking changes** and version compatibility requirements
+4. **Review best practices** and recommended patterns in the tool's documentation
+5. **Validate configuration options** against current documentation versions
+6. **Check for deprecated features** that should be avoided
+7. **Confirm implementation details match current best practices**
+
+### Critical Documentation Sources
+
+- Tool-specific documentation (mise, Fish, Neovim, Homebrew, chezmoi)
+- GitHub Actions documentation for workflow modifications
+- Platform-specific guides for cross-platform compatibility
+- Security documentation for secrets handling and API token management
+
+### Research Tools
+
+- **context7** - Research documentation before implementation
+- **WebFetch** - Fetch and analyze web documentation
+- **WebSearch** - Search for current documentation and best practices
+
+### Complex Task Handling
+
+- Use `sequential-thinking` MCP tool for multi-step reasoning
+- Break down complex problems systematically
+- Document decision-making process
+
+## PRD-First Development
+
+- Every new feature or significant change MUST have a Product Requirements Document (PRD)
+- PRDs must be created before any implementation begins
+- Use the requirements-documentation agent for comprehensive PRDs
+
+## Test-Driven Development (TDD)
+
+Follow strict RED → GREEN → REFACTOR workflow:
+
+1. **RED**: Write a failing test that defines desired behavior
+2. **GREEN**: Implement minimal code to make the test pass
+3. **REFACTOR**: Improve code quality while keeping tests green
+4. Run full test suite to verify no regressions
+
+### Tiered Test Execution
+
+| Tier | When to Run | Command | Duration |
+|------|-------------|---------|----------|
+| Unit | After every change | `/test:quick` | < 30s |
+| Integration | After feature completion | `/test:full` | < 5min |
+| E2E | Before commit/PR | `/test:full` | < 30min |
+
+### Testing Agent Consultation
+
+| Scenario | Agent |
+|----------|-------|
+| Run tests, analyze failures | `test-runner` |
+| New feature test strategy | `test-architecture` |
+| Complex test failures | `system-debugging` |
+| Test code quality review | `code-review` |
+
+## Version Control
+
+- Commit early and often to track incremental changes
+- Use conventional commits for clear history and automation
+- Always pull before creating a branch
+- Run security checks before staging files
+
+## Development Practices
+
+- Use `tmp/` directory in the project root for temporary test outputs and command results
+- Ensure `tmp/` is added to `.git/info/exclude` to prevent tracking
+- Prefer to stay in the repository root directory
+- Specify paths as command arguments to maintain clarity and avoid directory context switching

--- a/exact_dot_claude/rules/path-scoped-rules.md
+++ b/exact_dot_claude/rules/path-scoped-rules.md
@@ -1,0 +1,47 @@
+---
+paths:
+  - ".claude/rules/**"
+---
+
+# Path-Scoped Rules
+
+Rules in `.claude/rules/` load on every session by default. Use the `paths` frontmatter field to scope rules to specific file types so they only load when Claude reads matching files — reducing context noise for unrelated work.
+
+## When to Scope
+
+Add `paths` when a rule is only relevant for specific workflows or file types:
+
+| Rule type | Example paths |
+|-----------|--------------|
+| Skill authoring | `"**/skills/**"`, `"**/SKILL.md"` |
+| Agent authoring | `"**/agents/**"` |
+| Test files | `"**/*.{test,spec}.{ts,tsx,js}"`, `"**/*.test.py"` |
+| CI/CD | `".github/workflows/**"` |
+| Shell scripts | `"**/*.sh"`, `"scripts/**"` |
+| Changelogs/versions | `"**/CHANGELOG.md"`, `"**/package.json"` |
+| Plugin manifests | `"**/.claude-plugin/**"` |
+| Hooks config | `".claude/hooks/**"`, `".claude/settings*.json"` |
+| Chezmoi templates | `"**/.chezmoidata.toml"`, `"**/*.sh.tmpl"` |
+
+## When NOT to Scope
+
+Keep unconditional when the rule applies to any file or context:
+- Commit message conventions (needed for any git operation)
+- Code quality and design principles
+- Communication style
+- Security principles
+- Delegation and tool selection strategy
+
+## Syntax
+
+```yaml
+---
+paths:
+  - "**/skills/**"
+  - "**/SKILL.md"
+---
+```
+
+Multiple patterns are OR-combined. Rules without `paths` load at session start. Path-scoped rules trigger when Claude reads a file matching any pattern.
+
+Scope the rule file itself when it's only relevant for specific workflows — including this one.

--- a/exact_dot_claude/rules/release-please.md
+++ b/exact_dot_claude/rules/release-please.md
@@ -1,0 +1,91 @@
+---
+paths:
+  - "**/CHANGELOG.md"
+  - "**/package.json"
+  - "release-please-config.json"
+  - ".release-please-manifest.json"
+  - "**/pyproject.toml"
+  - "**/Cargo.toml"
+---
+
+# Release-Please Automation
+
+**CRITICAL RULE:** Never manually edit files managed by release-please automation.
+
+## Protected Files
+
+### Hard Protection (Permission System Blocks)
+
+- `plugins/**/CHANGELOG.md` - Auto-generated from conventional commits
+- **Any** `CHANGELOG.md` file across all projects
+
+These files are **blocked** via Claude Code's permission system. Attempts to edit them will fail.
+
+### Soft Protection (Skill Detection & Warning)
+
+- `plugins/**/.claude-plugin/plugin.json` - Version field only
+- `.claude-plugin/marketplace.json` - Version references
+- `package.json` - Version field in Node.js projects
+- `pyproject.toml` - Version field in Python projects
+- `Cargo.toml` - Version field in Rust projects
+
+## Why This Matters
+
+Manual edits to these files cause:
+- **Merge conflicts** with automated release PRs
+- **Version inconsistencies** across packages
+- **Duplicate or lost** CHANGELOG entries
+- **Broken release workflows** requiring manual intervention
+
+## Proper Workflow
+
+Instead of manually editing version or changelog files:
+
+### 1. Use Conventional Commit Messages
+
+```bash
+# For new features (minor version bump)
+git commit -m "feat(auth): add OAuth2 support"
+
+# For bug fixes (patch version bump)
+git commit -m "fix(api): handle timeout edge case"
+
+# For breaking changes (major version bump)
+git commit -m "feat(api)!: redesign authentication
+
+BREAKING CHANGE: Auth endpoint now requires OAuth2."
+```
+
+### 2. Release-Please Automatically
+
+- Analyzes conventional commits
+- Determines semantic version bump
+- Updates CHANGELOG.md with grouped entries
+- Updates version fields in all manifests
+- Creates a release PR for review
+
+### 3. Review and Merge the Release PR
+
+- Verify version bump is correct
+- Check CHANGELOG entries are accurate
+- Merge to trigger tagged release
+
+## Conventional Commit Types
+
+| Type | Version Bump | Description |
+|------|--------------|-------------|
+| `feat:` | Minor | New features |
+| `fix:` | Patch | Bug fixes |
+| `feat!:` or `BREAKING CHANGE:` | Major | Breaking changes |
+| `chore:`, `docs:`, `style:`, `refactor:` | None | No version bump |
+
+## Emergency Override
+
+If you **absolutely must** manually edit protected files:
+
+1. Temporarily disable protection in `~/.claude/settings.json`
+2. Make your edits
+3. Re-enable protection immediately
+4. Sync with chezmoi if needed
+
+**Use this only for emergencies** - the automation exists to prevent errors.

--- a/exact_dot_claude/rules/scaffold-fix-backport.md
+++ b/exact_dot_claude/rules/scaffold-fix-backport.md
@@ -1,0 +1,69 @@
+# Back-Port Instance Fixes Into Their Scaffold/Generator
+
+When fixing something that was *generated* — a site scaffolded by a
+justfile recipe, a repo from a cookiecutter template, a config from a
+`new-*` skill — check whether the bug came from the generator, and if
+so, fix the generator **in the same sweep**. A fix applied only to the
+deployed instance leaves every future generation broken in the same
+way, and the gap is invisible until the next person scaffolds.
+
+## The failure mode
+
+Canonical case (FVH `sites` monorepo, 2026-06): two PRs fixed the
+deployed `example-static` site — `service.targetPort: 8080` for the
+non-root nginx image, numeric `runAsUser` for Kyverno — but the
+`just new-site` template that had produced those broken values was
+never touched. Every subsequently scaffolded site would have shipped
+with chart-default port-80 probes against an 8080 listener: pod never
+Ready, stuck `Progressing`, no error anywhere. Found and back-ported
+only weeks later during a readiness audit (sites#11).
+
+The shape is always the same:
+
+1. An instance misbehaves; someone fixes the instance. PR merges, done.
+2. The generator still emits the pre-fix content.
+3. The next generation reproduces the bug — often for someone without
+   the context of fix #1.
+
+## The rule
+
+- **When fixing a generated artifact**, ask: "did the generator produce
+  this bug?" If yes, patch the generator template in the same PR (or an
+  immediately linked one) — not as a someday follow-up.
+- **When reviewing a fix to a known-scaffolded file** (e.g.
+  `deploy/values.yaml` in a monorepo with a `new-*` recipe, anything
+  under a directory a cookiecutter emits), check the template for the
+  same defect before approving.
+- **When auditing a scaffold for readiness**, diff the template's output
+  against the oldest working instance — accumulated instance-only fixes
+  show up as the delta.
+
+## Where generators hide
+
+- justfile `new-*` recipes with heredoc templates
+- `cookiecutter/` directories and copier templates
+- Claude skills that scaffold (`*-scaffold`, `configure-*`)
+- "Copy the example app" docs — the example *is* the generator; fixes to
+  forks of it don't propagate back
+
+## Verify
+
+After back-porting, generate a throwaway instance and diff it against
+the fixed real instance — the relevant blocks should match:
+
+```
+just new-site zz-smoke-test
+diff <(yq ... sites/zz-smoke-test/deploy/values.yaml) <(yq ... sites/example-static/deploy/values.yaml)
+```
+
+Clean up the throwaway (including any registry/config files the recipe
+mutated) before committing.
+
+## Rationale
+
+This is DRY applied to provenance: the template is the source of truth
+for new instances, so a fix that skips it creates a silently diverging
+copy. The cost asymmetry is stark — back-porting at fix time is one
+extra edit with full context in hand; discovering it later costs a
+broken deploy, a re-diagnosis from scratch, and usually a different
+person's afternoon.

--- a/exact_dot_claude/rules/taskwarrior-bulk-operations.md
+++ b/exact_dot_claude/rules/taskwarrior-bulk-operations.md
@@ -1,0 +1,105 @@
+# Taskwarrior Bulk Operations
+
+When triaging or closing many tasks in one pass (queue cleanup, PR sweep, project wrap-up), the obvious CLI shape — `for id in 1 2 3; do task $id done; done` — silently breaks in two ways. This rule documents the two foot-guns and the patterns that avoid them.
+
+Companion to `taskwarrior-cross-session.md` (which covers **when** to add tasks). This rule covers **how** to operate on tasks at scale.
+
+## Foot-gun 1: numeric IDs renumber after every `task done`
+
+Taskwarrior numeric IDs are a display index over **pending** tasks. The moment you complete one task, every higher ID shifts down by one. A loop like:
+
+```sh
+# WRONG — IDs shift mid-loop, you close the wrong tasks
+for id in 35 36 37 38 39; do
+  task "$id" done
+done
+```
+
+closes task 35 correctly, then "36" now points at what was originally 37, and so on. After the first close you are targeting the wrong tasks.
+
+**Fix: always use UUIDs for loops over multiple tasks.** UUIDs are immutable.
+
+```sh
+# Correct — UUIDs don't shift
+UUIDS=$(task status:pending project:foo export | jq -r '.[] | .uuid')
+for u in $UUIDS; do
+  task "$u" done </dev/null    # (see foot-gun 2 below)
+done
+```
+
+The same applies to `task <id> annotate`, `task <id> modify`, `task <id> delete` — any state-changing op iterated over a set must reference UUIDs.
+
+### The loop is the obvious case — the gap is the subtle one
+
+The renumbering hazard is **not** loop-specific. A numeric ID is a display index over the *current* pending set, so it is stale across **any** gap between reading it and acting on it — a later conversation turn, a new session, or just elapsed time during which *anything* (an agent in another session, a `task done` you ran for an unrelated task) mutated the pending set. The IDs shift even though you never ran a loop.
+
+```sh
+# WRONG — read IDs now, act on them later
+# turn 1: `task export` shows promote-task = 169, cleanup-task = 167
+# ...several turns later, an unrelated `task done` has shifted the set...
+task 169 done          # 169 now points at a DIFFERENT task — closes the wrong one
+```
+
+This is exactly how a wrap-up session closed an unrelated note-taking task instead of the intended one: the numeric IDs were read from an early `export`, then used two turns later after the pending set had changed underneath them.
+
+**Fix: resolve to the UUID at read time, the moment you know you'll act later.** Never carry a numeric ID across a turn, a tool-call gap, or a session boundary.
+
+```sh
+# Capture the immutable UUID up front, use it for every later op
+PROMOTE=$(task _get 169.uuid)        # 169 is valid *right now*, at read time
+CLEANUP=$(task _get 167.uuid)
+# ...any number of turns / unrelated task closes later...
+task "$PROMOTE" done </dev/null      # still the right task
+task "$CLEANUP" annotate "..." </dev/null
+```
+
+If you only have a numeric ID and a gap has passed, **re-derive it** (re-run the `export`/`list` and re-match on description) before acting — do not trust the cached number.
+
+## Foot-gun 2: `task done` consumes loop stdin
+
+`task done` reads from stdin (for confirmation prompts and similar). In a shell `for` loop, the loop's input is *also* stdin. When `task done` runs inside the loop body, it eats subsequent iterations from stdin and the loop exits early — usually after one or two iterations — with no error.
+
+Symptom: you set up a loop over 15 UUIDs, the script reports "processed 15" but only 1 task actually closed.
+
+**Two fixes:**
+
+```sh
+# Fix A — redirect stdin per inner command
+for u in $UUIDS; do
+  task "$u" annotate "..." </dev/null
+  task "$u" rc.confirmation=no done </dev/null
+done
+
+# Fix B — use xargs instead of a for loop (preferred for one-liners)
+echo "$UUIDS" | xargs -I {} sh -c 'task rc.confirmation=no {} done'
+```
+
+`xargs -I {}` runs each command in its own subshell with no stdin link to the source — cleaner and harder to misuse.
+
+## Always pass `rc.confirmation=no` for batch `task done`
+
+Without it, taskwarrior may prompt "this task is blocked by N other tasks, complete anyway? (yes/no)" per task, hanging the loop. `rc.confirmation=no` makes batch closes deterministic.
+
+## Filter caveats when finding tasks
+
+- `task project: status:pending list` (empty `project:` value as first filter) errors with `Unable to find report`. Use `task status:pending project: list` or sidestep the CLI filter by exporting and filtering with `jq`:
+
+  ```sh
+  task status:pending export | jq -r '.[] | select(.project == null) | .uuid'
+  ```
+
+- For tag-style markers that live in the **description text** (e.g. `+upstream-issue` as a literal substring, not a real tag), filter with `jq`'s `test()` and remember to escape the `+`:
+
+  ```sh
+  task status:pending export | jq -r '.[] | select(.description | test("\\+upstream-issue")) | .uuid'
+  ```
+
+- Real taskwarrior tags (set via `+tagname` at task creation, listed in `.tags`) should be filtered through the CLI: `task +upstream-issue status:pending export`.
+
+## Why annotate before `done`, not after
+
+Once a task is `completed`, its `id` becomes 0 and `task <id>` no longer addresses it (you must use the UUID). Adding annotations *before* closing keeps the UUID-or-ID workflow uniform and ensures the annotation lands in the pending-state task that still shows in `task <id> info`.
+
+## Rationale
+
+The default shape of "I'll just loop and close these" wastes 5–30 minutes the first time someone hits it: the loop runs, the count reports success, but the tasks are still pending and now scattered across unexpected IDs. The fix is mechanical — UUIDs + stdin discipline — but invisible until you've been burned. Codifying it removes the burn.

--- a/exact_dot_claude/rules/taskwarrior-cross-session.md
+++ b/exact_dot_claude/rules/taskwarrior-cross-session.md
@@ -1,0 +1,69 @@
+# Cross-Session Work Tracking via Taskwarrior
+
+The session-level `TaskCreate` / `TaskList` tools live and die with the conversation. When work emerges during a session that **won't complete in that session** — waiting on a PR to merge, a feature to land, a manual UI step, a verification against an external source, a future re-check — log it to **taskwarrior** so it survives the session boundary.
+
+## When to add a taskwarrior task
+
+Add one when **all** of these are true:
+
+- The work is concrete and actionable (not "think about X someday")
+- It can't be finished before the user ends the session
+- It isn't already tracked somewhere durable (existing GitHub issue, PR, calendar event)
+
+Don't add tasks for:
+
+- Work the agent completed during the session (the in-session `TaskCreate` tool already captured that)
+- Vague aspirations or "maybe someday" ideas — those rot in the queue
+- Items that are *already* a GitHub issue / PR — annotate the existing one or link to it from a parent task, but don't duplicate
+
+## Project naming convention
+
+Always set `project:<descriptive-name>`. Use a single, consistent label per long-running area of work so `task project:<name>` filters cleanly.
+
+| Context | `project:` |
+|---|---|
+| D&D campaign vault (Immeral) | `immeral` |
+| Other long-running personal projects | match the repo / directory name |
+| Cross-project chores (dotfiles, infra) | `dotfiles`, `infra`, etc. |
+
+When unsure what to use for a new context, ask the user once and then stick to it.
+
+## Annotate with references
+
+Every task that links to something durable should carry an annotation pointing at it:
+
+```sh
+task <id> annotate "Doc: Pages/Immeral 2024 Migration Notes.md"
+task <id> annotate "See: https://github.com/owner/repo/issues/123"
+```
+
+This lets a future agent (or the user) pick up the task with full context without scrolling the conversation history.
+
+## Priority and tags
+
+- `priority:H` — affects gameplay / blocks downstream work
+- `priority:M` — improves quality but not blocking
+- `priority:L` — nice-to-have, monitoring, follow-up
+- Tags scope the work area: `+foundry`, `+dnd`, `+migration`, `+chezmoi`, etc.
+
+Default to `priority:M` if unsure; the user can re-rank with `task <id> modify priority:H`.
+
+## Workflow at session end
+
+When wrapping up a session that produced ongoing work:
+
+1. List the items that survived the session (manual sheet edits, audit follow-ups, blocked-on-tool tasks)
+2. Add each to taskwarrior with the right project, tags, priority, and annotations
+3. Briefly tell the user what got logged so they can adjust before context closes
+
+Do this proactively when the work clearly outlives the session — don't wait for the user to ask. But also don't over-log: 3-6 well-chosen tasks beats 20 noisy ones.
+
+## What this is *not*
+
+- **Not** a replacement for GitHub issues. Issues belong to the project; taskwarrior is the user's personal cross-project queue.
+- **Not** a replacement for in-session `TaskCreate`. That tool tracks active work *during* the conversation; taskwarrior tracks work *between* conversations.
+- **Not** a calendar. Use `due:` only when there's an actual deadline.
+
+## Rationale
+
+The default failure mode without this rule: useful follow-up work — "fix the spell-slot consumption on the sheet", "verify the audit items against the PHB", "check if issue #142 has landed" — gets surfaced in conversation, agreed in principle, and then vanishes the moment the session ends. Taskwarrior is the personal queue that bridges sessions. Logging there at the natural checkpoint (end of a piece of work that generated follow-ups) keeps the queue honest and the user out of the "wait, what was I supposed to do next?" trap.

--- a/exact_dot_claude/skills/repo-activity/SKILL.md
+++ b/exact_dot_claude/skills/repo-activity/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: repo-activity
+description: Scan all git repositories under ~/repos and report recent activity — last commit age, branch, uncommitted changes — in age-bucketed tables. Use when the user asks for a repo activity overview, "what have I been working on", portfolio status, or which repos are active/dormant.
+allowed-tools: Bash(fd *), Bash(git -C *), Glob, Read
+---
+
+# Repository Activity Overview
+
+Scan all repositories in ~/repos/ and report recent activity.
+
+## Workflow
+
+### 1. Find All Git Repositories
+
+```bash
+fd -t d -H '^\.git$' ~/repos --max-depth 3 -x dirname {} | sort -u
+```
+
+### 2. Get Activity for Each Repo
+
+For each repository, gather:
+
+```bash
+# Last commit date and message
+git -C {repo} log -1 --format='%ar|%s' 2>/dev/null
+
+# Uncommitted changes count
+git -C {repo} status --porcelain | wc -l
+
+# Current branch
+git -C {repo} branch --show-current
+```
+
+Guard every substitution (`|| echo "?"`) — freshly-cloned repos with an
+unborn HEAD exit 128 on `log`/`rev-parse` and must not abort the sweep.
+
+### 3. Generate Activity Report
+
+Create a sorted table showing:
+
+| Repository | Last Commit | Age | Branch | Uncommitted |
+|------------|-------------|-----|--------|-------------|
+| repo-name  | commit msg  | 2d  | main   | 3 files     |
+
+Sort by most recent activity first.
+
+### 4. Highlight Active Projects
+
+Flag repositories with:
+- Commits in the last 7 days
+- Uncommitted changes
+- Non-main/master branches (active development)
+
+## Output Format
+
+```
+## Active Repositories (last 7 days)
+
+| Repository | Last Activity | Branch | Status |
+|------------|---------------|--------|--------|
+
+## Recently Active (7-30 days)
+
+| Repository | Last Activity | Branch | Status |
+|------------|---------------|--------|--------|
+
+## Dormant (>30 days)
+
+| Repository | Last Activity |
+|------------|---------------|
+
+## Summary
+- X repositories scanned
+- Y active in last 7 days
+- Z with uncommitted changes
+```
+
+## Options
+
+When invoking this skill, the user may specify:
+- `--days N` - Change the "active" threshold (default: 7)
+- `--uncommitted` - Only show repos with uncommitted changes
+
+## Related
+
+For cross-referencing active repos against Podio Kanban tickets (FVH org
+work), chain into the `podio-ticket-updates` skill — it owns the ticket
+matching workflow.

--- a/private_dot_config/mise/config.toml.tmpl
+++ b/private_dot_config/mise/config.toml.tmpl
@@ -113,6 +113,7 @@ rust = "latest"
 
 # Development Tools
 "aqua:cli/cli" = "latest"                     # gh (GitHub CLI)
+glab = "latest"                               # GitLab CLI (upstream interactions on code.europa.eu)
 neovim = "nightly"
 just = "latest"
 opentofu = "1.11.2"


### PR DESCRIPTION
## What

Consolidation branch for user-global Claude Code configuration, accumulated over recent sessions:

- **Adopt unmanaged target-only rules into chezmoi source** (`ac1b155`) — rules that existed only in `~/.claude/rules/` are now managed, closing the exact_-dir deletion gap for them
- **exact_-dir deletion safety** (`e11b7bb`, `aa332ff`, `70b0897`) — `.chezmoiignore` entries for `friction-reports/` and `skills/notebooklm`, the deletion-guard documentation in `chezmoi-conventions.md`, and a PreToolUse hook blocking `chezmoi apply` while `chezmoi status` shows pending ` D` lines
- **Promote `repo-activity` to a user-global skill** (`7239c93`)
- **Add `glab` CLI via mise** (`193ad0d`) — for code.europa.eu (EU GitLab) upstream interactions in SIMPL work
- **New rule: `scaffold-fix-backport.md`** (`fa05d3a`) — back-port instance fixes into their scaffold/generator in the same sweep; distilled from the FVH sites monorepo session where the example-static port/securityContext fixes never reached the `just new-site` template (ForumViriumHelsinki/sites#11)

## Verification

`chezmoi status ~/.claude` showed only the expected `A` line before apply (no pending deletions); `chezmoi apply --force ~/.claude` applied cleanly and the rule is live at `~/.claude/rules/scaffold-fix-backport.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)