### PR TITLE
chore(claude): drop removed MultiEdit tool from permission and hook configs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,7 +27,7 @@
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "Edit|Write|MultiEdit|NotebookEdit",
+        "matcher": "Edit|Write|NotebookEdit",
         "hooks": [
           {
             "type": "command",

--- a/.github/claude-tools-config.json
+++ b/.github/claude-tools-config.json
@@ -5,7 +5,6 @@
   "categories": {
     "core": [
       "Edit",
-      "MultiEdit",
       "Write",
       "Read",
       "Glob",

--- a/exact_dot_claude/modify_settings.json
+++ b/exact_dot_claude/modify_settings.json
@@ -165,7 +165,6 @@ read -r -d '' overlay <<'OVERLAY' || true
       "Bash(git push -f *)",
       "Bash(kubectl config use-context *)",
       "Edit(**/CHANGELOG.md)",
-      "MultiEdit(**/CHANGELOG.md)",
       "Write(**/CHANGELOG.md)"
     ],
     "ask": [],


### PR DESCRIPTION
## Summary

`MultiEdit` was removed from Claude Code (folded into `Edit` with the `replace_all` parameter). The leftover `MultiEdit(**/CHANGELOG.md)` deny rule referenced a tool the harness no longer knows about, producing a `matches no known tool — check for typos` warning on **every launch**.

This drops the three stale `MultiEdit` references:

- `exact_dot_claude/modify_settings.json` — removed the `MultiEdit(**/CHANGELOG.md)` deny rule (source of the launch warning). `Edit`/`Write` deny rules still fully cover CHANGELOG protection, and `Edit` is now the only edit tool.
- `.github/claude-tools-config.json` — removed `MultiEdit` from the GH Actions allowed-tools `core` list.
- `.claude/settings.json` — removed `MultiEdit` from the PostToolUse hook matcher alternation.

## Verification

- `chezmoi apply --force ~/.claude/settings.json` applied cleanly; `~/.claude/settings.json` now has zero `MultiEdit` references.
- Pre-commit hooks (JSON checks, secret scan, conventional-commit) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)