### PR TITLE
feat(kitty): prefix OS window title with cwd basename

### DIFF
--- a/private_dot_config/private_kitty/kitty.conf.tmpl
+++ b/private_dot_config/private_kitty/kitty.conf.tmpl
@@ -338,6 +338,14 @@ tab_title_max_length 50
 #: Hard cap on rendered tab title cells. The cwd prefix sits at the
 #: front so it survives truncation when {title} is long.
 
+watcher os_window_title.py
+
+#: Mirror the tab's "{cwd} · {title}" format into the macOS titlebar.
+#: kitty has no os_window_title_template, so a watcher reasserts a
+#: cwd-prefixed OS window title on focus/title/cmd events. The tab title
+#: stays pull-based (tab.active_oldest_wd) for live cwd; this enriches
+#: only the titlebar. See os_window_title.py.
+
 #: # endregion
 
 #: Color scheme # region

--- a/private_dot_config/private_kitty/os_window_title.py
+++ b/private_dot_config/private_kitty/os_window_title.py
@@ -1,0 +1,64 @@
+"""Prefix the macOS titlebar (OS window title) with the active tab's cwd
+basename, mirroring tab_title_template's "{cwd} · {title}" format.
+
+kitty has tab_title_template but no equivalent for the OS window title, which
+otherwise just shows the active window's process title with no cwd context.
+This watcher reasserts a cwd-prefixed title on the events that drive the
+titlebar.
+
+Push-based by necessity (there is no per-render hook for the OS title), so it
+fires on:
+  - on_focus_change  — switching tabs swaps which window drives the titlebar
+  - on_title_change  — an OSC-emitting program (vim/ssh) changed its title
+  - on_cmd_startstop — a shell command started/stopped; cwd may have changed
+
+Only the globally-active window is allowed to write the titlebar, so a
+background tab emitting a title never clobbers what you're looking at.
+
+See: kitty.conf `watcher os_window_title.py`.
+"""
+
+import os
+
+from kitty.fast_data_types import set_os_window_title
+
+
+def _cwd_base(window):
+    try:
+        cwd = window.cwd_of_child or ""
+    except Exception:
+        cwd = ""
+    return os.path.basename(cwd.rstrip("/")) or "~"
+
+
+def _is_active(boss, window):
+    """True when this window currently drives the OS titlebar."""
+    try:
+        return boss.active_window is window
+    except Exception:
+        return True
+
+
+def _apply(window, title):
+    base = _cwd_base(window)
+    title = (title or "").strip()
+    label = f"{base} · {title}" if title and title != base else base
+    try:
+        set_os_window_title(window.os_window_id, label)
+    except Exception:
+        pass
+
+
+def on_focus_change(boss, window, data):
+    if data.get("focused"):
+        _apply(window, window.title)
+
+
+def on_title_change(boss, window, data):
+    if _is_active(boss, window):
+        _apply(window, data.get("title") or window.title)
+
+
+def on_cmd_startstop(boss, window, data):
+    if _is_active(boss, window):
+        _apply(window, window.title)


### PR DESCRIPTION
## Summary

Adds a kitty OS-window-title watcher that prefixes the window title with the basename of the current working directory.

## Changes

- `private_dot_config/private_kitty/os_window_title.py` — watcher script that derives the title prefix from cwd.
- `private_dot_config/private_kitty/kitty.conf.tmpl` — wires the watcher into kitty config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)