### PR TITLE
feat(claude): manage portfolio repos CLAUDE.md and rules

### DIFF
--- a/private_repos/private_CLAUDE.md
+++ b/private_repos/private_CLAUDE.md
@@ -1,0 +1,22 @@
+# repos/ - Project Portfolio Overview
+
+This directory contains project repositories organized by owner/origin. Running Claude Code from here provides visibility across all projects for portfolio-level operations.
+
+## Directory Structure
+
+| Directory | Contents |
+|-----------|----------|
+| `ForumViriumHelsinki/` | Forum Virium Helsinki organization repos ([GitHub](https://github.com/ForumViriumHelsinki)) |
+| `laurigates/` | Personal repos ([GitHub](https://github.com/laurigates)) |
+| `external/` | Third-party clones and forks (bevy, esp-idf, llama.cpp, moodle, etc.) |
+| `archive/` | Inactive/deprecated projects |
+
+## Key Workflows
+
+### Repository Activity
+
+Run `/repo-activity` (user-global skill) to scan all repos and see recent activity: last commit info, active projects, uncommitted changes, and current branches.
+
+### Podio Ticket Management
+
+See `ForumViriumHelsinki/CLAUDE.md` for Podio Kanban workflows; `/podio-ticket-updates` is an FVH-scoped skill (`ForumViriumHelsinki/.claude/skills/`).

--- a/private_repos/private_dot_claude/rules/ci-cd-multirepo.md
+++ b/private_repos/private_dot_claude/rules/ci-cd-multirepo.md
@@ -1,0 +1,96 @@
+# Multi-Repo CI/CD Discipline
+
+Org-agnostic lessons for working across a portfolio of repos that share
+reusable workflows. Applies under both ForumViriumHelsinki/ and laurigates/.
+The org-specific workflow catalogs live in the child rules
+(`*/.claude/rules/ci-cd-workflows.md`).
+
+## Diagnosing a CI Failure — Fetch First
+
+Before investigating why a workflow failed, `git fetch` and compare local
+`HEAD` against `origin/main`. In a multi-repo portfolio, local checkouts go
+stale, and **the failing workflow file (or its config —
+`release-please-config.json`, the manifest, a new `.yml`) may have been added
+in commits you haven't pulled.** It won't exist in your local tree, so you'll
+search for a "missing" file that CI is actively running. One `git fetch` +
+`git log --oneline HEAD..origin/main` shows the gap; `git pull --ff-only`
+syncs it. Diagnose against what CI actually ran, not a stale snapshot.
+
+## Rolling a Workflow Out to a Repo Class
+
+When promoting a self-contained workflow into a shared `reusable-*.yml` and
+adding a thin caller to every repo of a class, three things bite if missed:
+
+1. **IaC feature flags are the source of truth for the repo set.** Don't
+   hand-list repos — derive the class from the gitops/Terraform definitions
+   (e.g. `release_please = true` entries in `repositories.tf` *are* the
+   membership list). Extract them rather than guessing which repos qualify:
+   ```
+   awk '/^    "[^"]+" = \{/ { match($0, /"[^"]+"/); name=substr($0, RSTART+1, RLENGTH-2) } /release_please[ ]*=[ ]*true/ { print name }' repositories.tf
+   ```
+2. **Land the reusable workflow on the `.github` repo's `main` first.**
+   Callers pin `uses: <owner>/.github/...@main`, which resolves at dispatch
+   time — a caller merged or dispatched before the reusable workflow exists on
+   `main` fails. Merge the `.github` PR before opening (or at least before
+   merging) the callers. `workflow_dispatch`-only callers are harmless until
+   triggered, so they can be opened in parallel, but the `.github` change is
+   the prerequisite.
+3. **Bulk-create callers via the GitHub API, not local clones.** The caller
+   body is identical across repos, and some repos may not be checked out
+   locally. Creating the branch + file + PR through the API is uniform and
+   immune to local working-tree state (stale checkouts, wrong branch,
+   uncommitted changes):
+   ```
+   sha=$(gh api repos/<owner>/$r/git/ref/heads/main --jq .object.sha)
+   gh api -X POST repos/<owner>/$r/git/refs -f ref=refs/heads/$BRANCH -f sha=$sha
+   gh api -X PUT repos/<owner>/$r/contents/$PATH -f message=$MSG -f content=$B64 -f branch=$BRANCH
+   gh pr create -R <owner>/$r --base main --head $BRANCH -a laurigates --title "$MSG" --body "$BODY"
+   ```
+   Loop sequentially (not a parallel batch — siblings cancel on the first
+   non-zero exit), and skip a repo if the file already exists on `main`. Title
+   the caller PR `ci:` so release-please does not cut a version bump for a
+   CI-only change. When the running gh user is the repo owner, omit
+   `--add-reviewer` (self-review is rejected 422).
+
+## Landing a `@main` Reusable-Workflow Fix on an Existing PR — Re-Trigger, Don't Re-Run
+
+After you merge a fix to a `reusable-*.yml` on the `.github` repo's `main`,
+the open PRs whose callers pin `@main` do **not** pick it up by re-running the
+failed check. **A GitHub re-run replays the original run against the workflow
+resolution it was first dispatched with** — including the exact commit the
+`@main` reusable workflow resolved to at that time. So `gh run rerun` /
+"Re-run failed jobs" / the `rerun-failed-jobs` API all replay the *stale*
+reusable workflow and fail identically, even though `main` is now fixed.
+
+The tell: you read the re-run's log and it shows the *old* behaviour (the
+command you just replaced still running), not your fix.
+
+**Fix: force a fresh `pull_request` event**, which re-resolves `@main` at
+dispatch time and picks up the merged fix. Cheapest first:
+
+```
+gh pr update-branch <n> -R <owner>/<repo>   # fires `synchronize`; no-op-safe if already current
+```
+
+If the branch is already current (update-branch reports "already up to date"),
+close-then-reopen fires `reopened` instead:
+
+```
+gh pr close <n> -R <owner>/<repo> && gh pr reopen <n> -R <owner>/<repo>
+```
+
+For a **release-please** PR, prefer `update-branch` — closing the release PR is
+safe (release-please acts on push-to-`main`/schedule, not PR-close events) but
+reopening is noisier than a branch update. Avoid pushing to a release-please
+branch by hand.
+
+There is a second replay trap with the same shape: a `pull_request` re-run also
+replays the original event payload, so its `sender` is whoever opened the PR —
+a **bot** for Renovate/release-please PRs. Actions with a human-actor guard
+(e.g. `anthropics/claude-code-action` without `allowed_bots`) therefore fail
+with "Workflow initiated by non-human actor" on re-run **regardless of who
+clicked re-run**. A fresh event doesn't change the sender (still the bot), so
+the real fix is `allowed_bots` on the action, not re-triggering — but the same
+"re-run replays the original payload" mechanic is why clicking re-run yourself
+doesn't help. Both traps are the same root cause: a re-run is a replay, not a
+new dispatch.

--- a/private_repos/private_dot_claude/rules/github-metadata-hygiene.md
+++ b/private_repos/private_dot_claude/rules/github-metadata-hygiene.md
@@ -1,0 +1,65 @@
+# GitHub Metadata Hygiene
+
+Shared baseline for every repo under this portfolio (ForumViriumHelsinki/ and
+laurigates/). Scope-specific deltas live in the child rules:
+- FVH org project routing + Terraform-managed labels:
+  `ForumViriumHelsinki/.claude/rules/github-metadata-hygiene.md`
+- laurigates gitops-managed labels: `laurigates/.claude/rules/github-metadata-hygiene.md`
+
+## Rule: Every issue and PR must have complete metadata — enforce on every GitHub interaction
+
+### Trigger Points
+
+Apply these checks when:
+1. **Creating** issues or PRs — set all metadata at creation time
+2. **Commenting or reviewing** existing issues/PRs — check for gaps and backfill
+3. **Before opening a PR** — verify the target issue has proper metadata
+
+### Issue Metadata Checklist
+
+| Field | Required | How to Set | Default |
+|-------|----------|-----------|---------|
+| Assignee | Always | `-a @laurigates` | `laurigates` unless told otherwise |
+| Labels | Always | `-l <name>` | At minimum a type label: `bug`, `enhancement`, `chore`, `docs` |
+| Milestone | If exists | `--milestone <name>` | Set if a relevant milestone exists for the repo |
+| Issue type | If supported | MCP `issue_write` with `type` param | Check `list_issue_types` first |
+| Linked PR | When applicable | PR body `Closes #N` or `gh issue develop` | Link when creating PRs that address the issue |
+
+### PR Metadata Checklist
+
+| Field | Required | How to Set | Default |
+|-------|----------|-----------|---------|
+| Reviewer | If not author | `-r <user>` | **Skip if the requested reviewer is the PR author** (GitHub API rejects self-review requests with HTTP 422) |
+| Assignee | Always | `-a @laurigates` | `laurigates` unless told otherwise |
+| Labels | Always | `-l <name>` | Match linked issue labels; add type label if missing |
+| Linked issue | When applicable | PR body with `Closes #N` / `Fixes #N` | Reference the issue being addressed |
+
+**Self-review guard:** Before requesting a reviewer, check the PR author. If the
+requested reviewer matches the PR author, skip the `--add-reviewer` / `-r` flag
+entirely. Use separate `gh` commands for reviewer vs. other metadata so a single
+422 doesn't fail the whole update.
+
+### Backfill on Existing Issues/PRs
+
+When interacting with an issue or PR that has missing metadata:
+
+1. Add missing assignee (and reviewer for PRs — skip if author matches reviewer)
+2. Add missing type labels — infer from title and content
+3. Inform the user what was added (do not silently modify)
+
+### Label Conventions
+
+Use these standard type labels consistently:
+
+| Label | When |
+|-------|------|
+| `bug` | Defect or broken behavior |
+| `enhancement` | New feature or improvement to existing feature |
+| `chore` | Maintenance, dependency updates, refactoring |
+| `docs` | Documentation changes |
+| `security` | Security-related fixes or improvements |
+
+Check available labels with `gh label list -R <owner>/<repo>` before applying —
+do not create labels that don't exist without asking. Both scopes manage their
+standard label sets via IaC (see the child rules above); ad-hoc `gh label create`
+is only for genuinely repo-specific labels.

--- a/private_repos/private_dot_claude/rules/justfile.md
+++ b/private_repos/private_dot_claude/rules/justfile.md
@@ -1,0 +1,55 @@
+---
+paths:
+  - "**/justfile"
+  - "**/*.just"
+---
+# Justfile Standards — Portfolio Conventions
+
+Generic justfile authoring (structure, attributes, shebang recipes, parameters,
+naming) is covered by the `tools-plugin:justfile-expert` skill and audited by
+`configure-plugin:configure-justfile` — consult those rather than restating
+syntax here. This rule holds only the conventions specific to this repos/
+portfolio layout.
+
+## Portfolio-Level Conventions
+
+The root `repos/justfile` operates across all repositories using dynamic
+discovery (`find . -maxdepth 3 -name .git`). Subdirectory justfiles handle
+org/personal-specific recipes (`ForumViriumHelsinki/justfile`,
+`laurigates/justfile`).
+
+### Module Integration
+
+When a subdirectory has its own justfile, register it as a module in the
+parent — at every level, not just the root:
+
+```just
+mod name 'subdirectory'
+# Invoke: just name::recipe
+```
+
+The root registers `fvh`, `laurigates`, and `dotgithub`; org/personal justfiles
+register their own children (e.g. `infrastructure/`, `claude-plugins/`).
+
+### Bash 5 Prerequisite
+
+macOS ships bash 3.2 which lacks `declare -A`, `readarray`/`mapfile`, and other
+modern features used by the portfolio recipes. Install bash 5+ via
+`brew install bash` and ensure `/opt/homebrew/bin` is in PATH before `/bin`.
+Document this in each justfile's header comment.
+
+### Repo-Iteration Recipe Patterns
+
+Recipes that sweep many repos follow the `pull-clean` house style:
+
+- **Counters survive the loop** — `declare -i` + process substitution
+  (`done < <(…)`), never `find | while` (subshell discards counters)
+- **No silent skips** — every skipped repo prints a reason
+  (`skip: dirty`, `skip: detached HEAD`, `skip: no upstream`)
+- **Guard git substitutions** — `$(git … || echo "?")` so one broken repo
+  (unborn HEAD, corrupt worktree) cannot abort the sweep under
+  `set -euo pipefail`
+- **Summary line** at the end with tallies
+- **`[confirm]`** on bulk-mutating sweeps (pull/checkout/fetch across repos)
+- Aligned `printf "%-NNs"` output; report success/failure inline
+  (`ok` / `FAILED`)

--- a/private_repos/private_dot_claude/rules/tool-migration-cutover.md
+++ b/private_repos/private_dot_claude/rules/tool-migration-cutover.md
@@ -1,0 +1,91 @@
+# Tool-Migration Cutover: Verify the Replacement Is *Operational* Before Deprecating the Incumbent
+
+When migrating from one tool to another (Dependabot → Renovate, a PAT-based
+workflow → a GitHub App, one linter/CI/runner → another), **do not remove the
+incumbent until the replacement is observed actually doing the job** — not merely
+*configured* to. "Config exists" and "config works" are different claims, and the
+gap between them is where coverage silently drops to zero.
+
+## The failure mode
+
+The incumbent is removed on the strength of the replacement's *presence*:
+
+1. The replacement's config is committed and looks correct.
+2. Someone reasons "Renovate is set up, so Dependabot is redundant — remove it."
+3. The replacement was never actually running (broken credentials, missing
+   step, unprovisioned secret, quota), so **neither** tool is now doing the work.
+4. The gap is invisible: no error fires for "nothing is updating dependencies."
+
+Config presence is not evidence of operation. A scheduled runner can fail every
+single run and leave no trace in the place you're looking (the repo's PR list
+stays empty, which reads identically to "no updates needed").
+
+## The rule
+
+**Removal of the incumbent is gated on a positive operational signal from the
+replacement**, observed on the *actual* target repos:
+
+| Replacement | Positive signal to require before deprecating incumbent |
+|---|---|
+| Renovate | A successful runner execution **and** a Dependency Dashboard issue / `renovate/*` branch / PR on the target repo |
+| A CI/lint tool | A green run of the new check on a real PR, not just the workflow file merged |
+| A GitHub App replacing a PAT | A workflow run that successfully mints **and uses** the App token |
+| A new deploy path | One real deploy through the new path that reaches the target |
+
+Until that signal exists, **stage the deprecation as a draft** (draft PRs, an
+un-merged branch, a feature-flag off) so the work is ready the instant the signal
+lands — but cannot be merged prematurely by you or anyone else.
+
+## How to check operation (don't trust config presence)
+
+- **Runner actually ran and succeeded** — `gh run list --workflow=<f> -L 5`
+  (all `failure` = it has never worked). Read the failed log; an ~8s failure at
+  step 1 is usually a credential/token problem, a ~2s zero-step failure is
+  usually quota.
+- **Side effects appeared on the target** — the dashboard issue, the branch, the
+  PR. `gh issue list --search "Dependency Dashboard in:title"`,
+  `gh api repos/<o>/<r>/branches --jq '.[].name|select(startswith("renovate/"))'`.
+- **Credentials/secrets are present where consumed** — the secret/variable on the
+  consuming repo, not just "set upstream" (in Scalr/CI/a vault). The push from
+  upstream to the repo is a separate step that can itself be blocked.
+
+## Worked example — Dependabot → Renovate (Bun), 2026-06
+
+The premise "Renovate already manages these repos, overlapping with Dependabot"
+was false: the centralized autodiscover runner **failed every run** (unprovisioned
+GitHub App → empty `app-id` → token mint failed), so Dependabot was the *only*
+working dependency automation. Deprecating it then would have left 9 repos with
+no updates. Correct sequence: fix the latent runner bug, **stage the 9
+`dependabot.yml` deletions as draft PRs**, hand off the (manual, user-only) App
+provisioning, and gate the draft merges on a verified Renovate run.
+
+Two Renovate/Bun facts that fell out of the same investigation, worth not
+re-deriving:
+
+- **There is no bun `postUpdateOptions` value** (`bunDedupe` does not exist;
+  allowed values are npm/pnpm/yarn/bundler/go/nuget only). An invented value
+  fails Renovate's `allowedValues` validation and breaks the **whole config** —
+  for the *global* self-hosted config, that breaks every repo. Verify enum values
+  against the Renovate docs before adding them.
+- Renovate updates and commits `bun.lock` **natively** when it patches
+  `package.json` (it runs the package manager and commits both). No option is
+  needed for "generate a matching lockfile"; `lockFileMaintenance` is the
+  separate periodic full-refresh.
+
+## When it bites
+
+- Dependency-bot swaps (Dependabot ↔ Renovate), where "no PRs" looks the same
+  whether the tool is off or just has nothing to do.
+- Credential/secret migrations where the value is set in the orchestrator
+  (Scalr, a vault, org secrets) but the *push to the consuming repo* hasn't run.
+- CI tool replacements merged as a workflow file but never exercised on a PR.
+
+## Rationale
+
+Removing a working tool is cheap to do and expensive to discover undone — the
+loss is a *non-event* (updates that silently stop happening), so nothing alarms.
+Gating on a positive operational signal, and staging the removal as a draft in
+the meantime, costs one extra "is it actually running?" check and converts a
+silent multi-week coverage gap into a no-op wait. This is the migration-time
+sibling of `verify-upstream-before-patching.md` (check reality before acting) and
+`ci-cd-multirepo.md` (fetch-first before diagnosing CI).


### PR DESCRIPTION
## Summary

Brings the portfolio repos' `CLAUDE.md` and `.claude/rules` under chezmoi management via the `private_repos/` source tree.

## Changes

- `private_repos/private_CLAUDE.md` — portfolio repos CLAUDE.md.
- `private_repos/private_dot_claude/rules/ci-cd-multirepo.md` — multi-repo CI/CD rule (with re-trigger note).
- `private_repos/private_dot_claude/rules/github-metadata-hygiene.md`
- `private_repos/private_dot_claude/rules/justfile.md`
- `private_repos/private_dot_claude/rules/tool-migration-cutover.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)