### PR TITLE
docs(claude): add global rules — mise stale copies, stacked-PR order, rustfmt gate

### DIFF
--- a/exact_dot_claude/.chezmoiignore
+++ b/exact_dot_claude/.chezmoiignore
@@ -13,6 +13,7 @@ skills/notebooklm/
 
 # Runtime directories created by Claude Code - don't manage or remove these
 cache/
+downloads/
 file-history/
 paste-cache/
 plans/

--- a/exact_dot_claude/rules/mise-stale-tool-copies.md
+++ b/exact_dot_claude/rules/mise-stale-tool-copies.md
@@ -1,0 +1,83 @@
+# A CLI Tool "Keeps Coming Back" in a mise Node Path
+
+When a globally-installed CLI tool (notably `claude`, but any
+`npm install -g` binary) reappears in a mise-managed runtime path even
+after you "removed" it, the cause is almost never an active reinstall.
+It is **stale per-version copies** scattered across the runtime versions
+mise has installed. mise keeps a separate `node_modules` tree per node
+version, so a global package installed under one version lives only
+there — and every *other* installed version may carry its own old copy.
+
+Removing the tool from the *active* version makes it look gone, until
+mise activates a different version (a project pins `node@22`, a
+`mise exec node@24 -- …`, an `.mise.toml` switch) and that version's
+leftover shim resurfaces. The tool "comes back" without anything
+reinstalling it.
+
+## The trap
+
+```sh
+# Looks installed once…
+which -a claude            # → ~/.local/bin/claude   (native, fine)
+# …but the running process is a DIFFERENT copy:
+#   "npm-global at .../mise/installs/node/22.21.1/bin/claude"
+```
+
+A single `npm uninstall -g` (or deleting one symlink) only touches the
+active version. The copies under the other ~10 node version dirs stay.
+
+## Check all three locations, not just the active one
+
+```sh
+# 1. Per-version global node_modules — the real footprint
+ls -d ~/.local/share/mise/installs/node/*/lib/node_modules/@anthropic-ai/claude-code
+
+# 2. Per-version bin symlinks
+ls -la ~/.local/share/mise/installs/node/*/bin/claude
+
+# 3. The mise shim (points back at the mise binary; survives uninstall)
+ls -la ~/.local/share/mise/shims/claude
+
+# 4. The auto-reinstall trigger: mise installs these into EVERY new
+#    node version. If the tool is listed here, it genuinely will return.
+cat ~/.default-npm-packages    # chezmoi source: dot_default-npm-packages
+```
+
+## Remove from every version + the shim
+
+```sh
+for d in ~/.local/share/mise/installs/node/*/lib/node_modules/@anthropic-ai; do [ -d "$d" ] && rm -rf "$d"; done
+for s in ~/.local/share/mise/installs/node/*/bin/claude;  do rm -f "$s"; done
+rm -f ~/.local/share/mise/shims/claude
+```
+
+Note: deleting files of the *currently running* process is safe on
+macOS — the open inode persists until the process exits; the live
+session keeps working and the next fresh-shell launch resolves to the
+native binary.
+
+## Make sure it stays gone
+
+- **`~/.default-npm-packages` must NOT list the tool.** This file (mise
+  reads it on every node install, like asdf/nvm) is the only mechanism
+  that auto-reinstalls a global into new versions. If the tool is here,
+  removing the copies is pointless — it returns on the next
+  `node = "latest"` bump. Source it in chezmoi: `dot_default-npm-packages`.
+- **PATH precedence**: `~/.local/bin` (native install) should resolve
+  before any mise node `bin`/shim dir. `which -a claude` returning *only*
+  the native path confirms it.
+- For `claude` specifically, the native installer is canonical:
+  `~/.claude.json` should show `"installMethod": "native"` and
+  `"autoUpdates": false` so `claude update` targets the native copy, not
+  an npm one.
+
+## Rationale
+
+The mise "global package per runtime version" model means *uninstall*
+has a per-version blast radius, but *PATH activation* roams across
+versions — so a one-version uninstall produces a tool that intermittently
+reappears with no visible installer. The fix is to sweep every version
+dir plus the shim, and to confirm `~/.default-npm-packages` isn't quietly
+re-seeding it. Same pattern applies to any mise-provided runtime
+(Python `pipx:` globals, bun globals): check all installed versions, not
+just the active one.

--- a/exact_dot_claude/rules/rustfmt-gate-onboarding.md
+++ b/exact_dot_claude/rules/rustfmt-gate-onboarding.md
@@ -1,0 +1,52 @@
+# Onboarding a `cargo fmt --check` Gate Onto a Never-Formatted Rust Repo
+
+When you add a CI `fmt` job (`cargo fmt --all -- --check`) to a Rust repo
+that was **never run through rustfmt**, the first `cargo fmt --all` reflows the
+*entire* tree — often hundreds of lines across dozens of files — because the
+code was hand-formatted denser than rustfmt's defaults. Default rustfmt's
+`fn_call_width = 60` (60% of `max_width`) explodes multi-arg calls one-per-line,
+so a tidy `foo(a, b, c, d)` becomes a four-line block. The gate is worth having,
+but the blast radius fights the author's style and balloons the diff.
+
+## The rule
+
+Before applying `cargo fmt --all`, add a `rustfmt.toml` with:
+
+```toml
+use_small_heuristics = "Max"
+```
+
+This sets `fn_call_width`/`array_width`/`chain_width`/etc. to `max_width` (100),
+so any call/array/chain under 100 cols stays on one line — preserving the dense
+single-line style and collapsing churn to the genuinely-non-compliant spots
+instead of a tree-wide explosion. In one real onboarding this turned a default
++803/−193 reflow into a net **−553** (denser) diff that mostly matched the
+existing code.
+
+## Sequence
+
+1. Add `rustfmt.toml` (`use_small_heuristics = "Max"`) **first**.
+2. `cargo fmt --all` — now a minimal reflow.
+3. Commit the reformat as an **isolated `style:` commit** (separate from the CI
+   commit), so it's reviewable and revertable on its own. It is a *prerequisite*
+   for the fmt gate to pass, so it must land in the same PR as (or before) the
+   CI `fmt` job — don't ship the gate against an unformatted tree (red CI on
+   merge).
+4. Verify the tree is clean: `cargo fmt --all -- --check` exits 0, tests green
+   (the reflow is mechanical — tests are the proof semantics are unchanged).
+
+## When this bites
+
+- Any Rust repo gaining its first `fmt` CI gate or pre-commit hook.
+- Inherited/ported repos where `cargo fmt` was never enforced.
+
+If the author genuinely wants default rustfmt style, skip the toml — but that's
+a deliberate style change to surface, not a silent side effect of "add CI".
+
+## Rationale
+
+The fmt gate is a real local↔CI-parity win (`local-ci-parity.md`), but bolting
+it onto an unformatted repo silently imposes a formatting standard. `Max`
+heuristics keeps the existing dense style compliant, so the gate enforces
+consistency *going forward* without rewriting the past — minimal diff, no style
+fight, and the `style:` commit stays a clean mechanical artifact.

--- a/exact_dot_claude/rules/stacked-pr-merge-order.md
+++ b/exact_dot_claude/rules/stacked-pr-merge-order.md
@@ -1,0 +1,92 @@
+# Stacked PR Merge Order
+
+When PR B is based on PR A's branch (a *stack*), the merge order and the
+base-branch deletion interact in a way that silently destroys PR B. Merge
+the base, delete its branch, and GitHub **auto-closes** the stacked child —
+it does **not** retarget it to `main`. Worse, a closed PR whose base branch
+no longer exists **cannot be reopened** (`reopenPullRequest` fails, and
+`updatePullRequest` refuses to change the base of a closed PR). The child's
+work isn't lost (the head branch survives), but the PR, its review thread,
+and its comments are stranded.
+
+## The trap
+
+```
+PR A: feature-a   → base main
+PR B: feature-b   → base feature-a      (stacked on A)
+
+# squash-merge A, delete feature-a branch
+gh pr merge A --squash --delete-branch
+#   → GitHub auto-CLOSES PR B (does not retarget to main)
+#   → gh pr edit B --base main      → "Cannot change the base branch of a closed pull request"
+#   → gh pr reopen B                → "Could not open the pull request" (base branch gone)
+```
+
+This bit a real two-PR docs stack (FVH infrastructure #2031 → #2032, 2026-06):
+#2032 auto-closed on #2031's merge and had to be reopened as a fresh PR
+#2033.
+
+## The rule
+
+**Retarget the child PR to `main` *before* merging and deleting the base
+PR's branch.** A child whose base is already `main` survives the base
+branch's deletion untouched.
+
+Clean sequence for a two-PR stack (squash-merge, the common org default):
+
+```
+# 1. Retarget the child to main FIRST (while the base PR is still open)
+gh pr edit <child> --base main
+
+# 2. Merge the base PR and delete its branch
+gh pr merge <base> --squash --delete-branch
+
+# 3. Rebase the child's head onto the new main, dropping the now-merged
+#    base commits (squash put them on main as one commit, so the child's
+#    copies are redundant). --onto <old-base-tip> replays only the child's
+#    own commits:
+git fetch origin
+git rebase --onto origin/main <old-base-branch-tip-sha> <child-branch>
+git push --force-with-lease origin <child-branch>
+
+# 4. Merge the child
+gh pr merge <child> --squash --delete-branch
+```
+
+Step 3 matters specifically for **squash** merges: squashing the base
+collapses its commits into one new commit on `main` with a different SHA, so
+the child still carries the originals in its history. Rebasing `--onto
+origin/main <old-base-tip>` replays *only* the child's own commits and drops
+the duplicates cleanly. (With a **rebase**-merge of the base instead, the
+base commits keep their patch-ids and a plain `git rebase origin/main` on the
+child auto-skips them — but squash is the more common default, so assume the
+`--onto` form.)
+
+## If the child already got auto-closed
+
+The head branch still exists, so recover by re-creating the PR rather than
+fighting the closed one:
+
+```
+git fetch origin
+git rebase --onto origin/main <old-base-tip> <child-branch>   # drop merged base commits
+git push --force-with-lease origin <child-branch>
+gh pr create --base main --head <child-branch> ...            # fresh PR
+gh pr comment <closed-child> --body "Superseded by #<new> (auto-closed when the stacked base branch was deleted)."
+```
+
+## When this bites
+
+- Any two-or-more-deep PR stack where the base merges first — the default
+  flow.
+- Especially with **squash** or **rebase** merges plus branch
+  auto-deletion (`delete_branch_on_merge` on the repo, or
+  `--delete-branch`), which is the norm on release-please / conventional-commit
+  repos.
+
+## Rationale
+
+The failure is invisible at merge time — `gh pr merge` reports success, and
+the stacked PR's closure is a side effect you only notice when you go to
+merge it. One pre-merge `gh pr edit <child> --base main` removes the whole
+class of problem; everything after is a normal rebase.


### PR DESCRIPTION
## Summary

Three new global rules under `exact_dot_claude/rules/` (synced to `~/.claude/rules/`), plus a `.chezmoiignore` entry for `downloads/`.

## Changes

- `exact_dot_claude/rules/mise-stale-tool-copies.md` — diagnosing a CLI tool that "keeps coming back" via stale per-node-version mise copies; sweep every version dir + shim.
- `exact_dot_claude/rules/stacked-pr-merge-order.md` — retarget a child PR to `main` before merging/deleting a stacked base branch, to avoid silent auto-close.
- `exact_dot_claude/rules/rustfmt-gate-onboarding.md` — add `rustfmt.toml` (`use_small_heuristics = "Max"`) before the first `cargo fmt` when onboarding a fmt CI gate, to keep the reflow diff minimal.
- `exact_dot_claude/.chezmoiignore` — ignore `downloads/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)