### PR TITLE
docs(claude): batch global rule updates (agent fan-out, autonomous PR, task config)

### DIFF
--- a/exact_dot_claude/rules/decision-defaults.md
+++ b/exact_dot_claude/rules/decision-defaults.md
@@ -41,10 +41,10 @@ Commit proactively when a coherent unit of work is done — no need to pause and
 
 - **Commit at natural checkpoints** — tests green, feature tracker updated, working tree contains exactly one theme of change
 - **Conventional-commit subject** — `type(scope): short imperative summary`; body explains the why, not the what
-- **Still do not push** — pushes remain explicit-ask only (shared state, visible to others)
-- **Still do not amend or rebase** others' commits — always a new commit
+- **Push a feature branch and open a PR autonomously** — a normal `git push` of a feature branch and `gh pr create` are part of the same wrap-up checkpoint as the commit; no separate ask needed
+- **Still ask before force-push, push to `main`/default, and rebase/amend of others' commits** — these touch shared state destructively; confirm first. Always a new commit, never amend/rebase someone else's
 - **Split when concerns diverge** — two themes → two commits; don't bundle drift-audit bookkeeping with a feature slice just because both are in the tree
-- Rationale: the default "ask before every commit" is needless friction when a wave of work wraps cleanly. Push / force-push / rebase / destructive ops still need confirmation — only the commit itself is autonomous.
+- Rationale: the default "ask before every commit/push" is needless friction when a wave of work wraps cleanly. A feature-branch push + PR is reversible (close PR, delete branch) and is the natural end of a work unit. Force-push / push-to-main / rebase / destructive ops are not reversible and still need confirmation.
 
 ## Adding New Defaults
 

--- a/exact_dot_claude/rules/taskwarrior-bulk-operations.md
+++ b/exact_dot_claude/rules/taskwarrior-bulk-operations.md
@@ -80,6 +80,34 @@ echo "$UUIDS" | xargs -I {} sh -c 'task rc.confirmation=no {} done'
 
 Without it, taskwarrior may prompt "this task is blocked by N other tasks, complete anyway? (yes/no)" per task, hanging the loop. `rc.confirmation=no` makes batch closes deterministic.
 
+## `task config` also needs `rc.confirmation=no` — or it silently no-ops
+
+The confirmation hazard is not limited to `task done`. **`task config <name> <value>` prompts to confirm by default**, and in a non-interactive context (a script, an agent's Bash tool, a hook, `chezmoi`) the un-answered prompt makes the command **exit 0 without writing the value**. The config change silently does not persist — no error, exit status 0, looks like success.
+
+The bite is worst when **declaring UDAs**. A setup script that runs:
+
+```sh
+# WRONG — exits 0 but the UDA is NOT written non-interactively
+task config uda.ghid.type numeric
+```
+
+reports success, yet `task _udas` still lacks `ghid`. The next `task add foo ghid:1417` then treats `ghid:` as an unknown attribute and **appends the literal `ghid:1417` to the description** instead of setting the UDA — so every downstream `task ghid:1417 export` / reconcile query finds nothing. The failure is invisible until you notice the field landed in the description text.
+
+```sh
+# Right — rc.confirmation=no makes the write actually happen; </dev/null
+# guards against any residual prompt eating the caller's stdin
+task rc.confirmation=no config uda.ghid.type numeric </dev/null
+task rc.confirmation=no config uda.ghid.label "GH Issue" </dev/null
+```
+
+Verify the write took effect rather than trusting the exit code:
+
+```sh
+task _udas | grep -qx ghid && echo "declared" || echo "MISSING — config did not persist"
+```
+
+The same applies to any scripted `task config` (urgency coefficients, report definitions, `data.location`): pass `rc.confirmation=no` and confirm the value landed. (Discovered 2026-06 building taskwarrior-plugin's `ensure-udas.sh`: the inline `task config` install blocks worked interactively — the agent answered the prompt — but silently no-op'd in a fresh non-interactive store.)
+
 ## Filter caveats when finding tasks
 
 - `task project: status:pending list` (empty `project:` value as first filter) errors with `Unable to find report`. Use `task status:pending project: list` or sidestep the CLI filter by exporting and filtering with `jq`:

--- a/exact_dot_claude/rules/tool-use-patterns.md
+++ b/exact_dot_claude/rules/tool-use-patterns.md
@@ -109,6 +109,30 @@ Pattern: when a batch's siblings depend on existence, do a single
 existence-check call first (`Glob`, `ls -1`), then issue the parallel
 batch over confirmed-present paths.
 
+### Don't launch a large agent fan-out in one burst — serialize or wave it
+
+Spawning many agents simultaneously — a `Workflow` `parallel()`/`pipeline()`
+of N agents, or N `Agent` calls in one message — can trip a **server-side
+burst rate limit** (`API Error: Server is temporarily limiting requests (not
+your usage limit) · Rate limited`), distinct from your usage quota. When it
+fires, the agents die after their retries and `parallel()` returns them as
+`null` — **every agent's startup tokens wasted** (observed: 7 Opus auditors,
+628 k tokens, all killed at 18 s).
+
+Mitigations, in order of preference:
+
+- **For deterministic / mechanical work** (parsing, counting, audits, link
+  resolution, frontmatter scans), prefer a **single inline pass** — one
+  `python3`/`rg` script — over an agent fan-out. It's cheaper, reproducible,
+  and rate-limit-immune. Reserve agents for genuinely independent
+  *reasoning-heavy* work (judgment, synthesis, review).
+- **When you do fan out, serialize or small-wave it.** Run agents in a
+  `for…await` loop (one at a time) or in waves of 2–3, not all N at once.
+  Sequential execution keeps the request rate low and dodges the burst limit;
+  the wall-clock cost is usually acceptable for non-latency-critical work.
+- **Don't blind-retry the same wide fan-out** after a burst-limit kill — it
+  re-trips. Re-issue serialized, or fall back to the inline pass.
+
 ## WebFetch — do not retry the same failing URL
 
 | Failure | Try |


### PR DESCRIPTION
Batches three global `~/.claude` rule/doc updates that had accumulated locally and weren't yet on origin.

## Commits

- `docs(claude): don't launch a large agent fan-out in one burst` — adds the serialize/small-wave guidance to `tool-use-patterns.md` after a server-side burst rate-limit killed a 7-agent fan-out.
- `docs(claude): make feature-branch push + PR an autonomous default` — promotes feature-branch push + `gh pr create` to part of the wrap-up checkpoint in `decision-defaults.md`.
- `docs(claude): warn that task config silently no-ops without rc.confirmation=no` — documents that non-interactive `task config` exits 0 without writing the value (worst when declaring UDAs), with the `rc.confirmation=no` + `</dev/null` fix and a verify-the-write step.

All three are documentation/rule edits under `exact_dot_claude/rules/` (the chezmoi source for `~/.claude/`). No code or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)