### PR TITLE
feat(zsh): add skaffold aliases and scaffold zsh-abbr

### DIFF
--- a/.chezmoiexternal.toml
+++ b/.chezmoiexternal.toml
@@ -46,3 +46,13 @@
     exact = true
     stripComponents = 1
     refreshPeriod = "168h"
+
+# olets/zsh-abbr — fish-style abbreviations. Depends on the zsh-job-queue
+# submodule; fetch it at clone/pull time so the plugin loads without relying
+# on its (cwd-sensitive) runtime self-heal.
+["zsh/zsh-abbr"]
+    type = "git-repo"
+    url = "https://github.com/olets/zsh-abbr.git"
+    refreshPeriod = "168h"
+    clone.args = ["--recurse-submodules"]
+    pull.args = ["--ff-only", "--recurse-submodules"]

--- a/aliases.zsh
+++ b/aliases.zsh
@@ -40,8 +40,9 @@ alias s="kitty +kitten ssh"
   alias ll='lsd --long --almost-all'
 
 ### GitHub aliases
-alias prls='gh pr ls'
-alias ils='gh issue ls'
+# gh pr/issue ls live in zsh-abbr as gpls / gils
+# (see ~/.config/zsh-abbr/user-abbreviations) — they expand inline on Space so
+# the long form stays visible and the habit sticks.
 
 ### Git aliases
 # Mostly cherry-picked from the oh-my-zsh git plugin:
@@ -274,6 +275,13 @@ alias hssh='hcloud server ssh -u lgates'
 ### Terraform aliases
 
 alias tf='terraform'
+
+### Skaffold aliases
+alias sk='skaffold'
+alias skd='skaffold dev'
+alias skdp='skaffold dev --port-forward'
+alias skr='skaffold run'
+alias skdel='skaffold delete'
 
 ### Docker aliases
 alias dcls='docker compose ps --format "table {{.Service}}\t{{.Ports}}\t{{.Status}}"'

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -339,6 +339,15 @@ zle -N rationalise-dot
 [ -f ~/zsh/zsh-vi-mode/zsh-vi-mode.plugin.zsh ] && \
   source ~/zsh/zsh-vi-mode/zsh-vi-mode.plugin.zsh
 
+# zsh-abbr (olets) — fish-style abbreviations that expand inline as you type,
+# so the long form is visible every time (unlike a plain alias). Its default
+# Space/Enter bindings target the `main` keymap, which zsh-vi-mode rebuilds
+# after this file finishes — so disable them here and re-bind into `viins`
+# in zvm_after_init (per zsh-abbr issue #101). The `abbr` command, widgets,
+# and completions registered at source time survive the rebuild.
+ABBR_DEFAULT_BINDINGS=0
+[ -f ~/zsh/zsh-abbr/zsh-abbr.zsh ] && source ~/zsh/zsh-abbr/zsh-abbr.zsh
+
 
 #======================================================================
 # FZF Sourcing (keybindings & completions)
@@ -359,6 +368,15 @@ function zvm_after_init() {
 
   # PC-like bind for pipe on macOS (Command + <)
   bindkey -s "^[[60;9u" "|"
+
+  # zsh-abbr: Space expands the abbreviation, Ctrl+Space inserts a literal
+  # space (no expansion), Enter expands then accepts. Bound into viins here so
+  # they survive zsh-vi-mode's main-keymap rebuild (zsh-abbr issue #101).
+  if (( $+functions[abbr] )); then
+    bindkey -M viins " " abbr-expand-and-insert
+    bindkey -M viins "^ " magic-space
+    bindkey -M viins "^M" abbr-expand-and-accept
+  fi
 }
 
 

--- a/private_dot_config/zsh-abbr/user-abbreviations
+++ b/private_dot_config/zsh-abbr/user-abbreviations
@@ -1,0 +1,20 @@
+# zsh-abbr user abbreviations — fish-style inline expansions.
+#
+# Format: one `abbr <name>=<value>` per line. zsh-abbr keeps this file
+# alphabetized automatically when you mutate it with `abbr add/rename/erase`.
+#
+# Two ways to edit (this file is chezmoi-managed):
+#   1. Edit this source, then `chezmoi apply`.
+#   2. Run `abbr add foo='bar'` interactively, then capture the change with
+#      `chezmoi re-add ~/.config/zsh-abbr/user-abbreviations` (zsh-abbr writes
+#      to the target, so re-add it back into the chezmoi source — same drift
+#      pattern as settings.json).
+#
+# Seeded by migrating the two most-typed-in-full commands from aliases.zsh:
+# `gh pr ls` was typed in full 849 times and `gh issue ls` 102 times despite
+# the prls/ils aliases existing — because a plain alias never reveals itself.
+# As abbreviations they expand inline on Space, so the habit actually sticks.
+# Named gils/gpls (gh-`g` prefix, avoiding the gpl↔git-pull clash); rename
+# freely — the inline expansion makes the name matter less than for an alias.
+abbr gils='gh issue ls'
+abbr gpls='gh pr ls'


### PR DESCRIPTION
## Summary

Mined atuin history (`atuin history list --cmd-only | sort | uniq -c | sort -rn`) for frequently typed-in-full commands lacking a short form, then acted on the two biggest findings.

**Skaffold aliases** — ~960 invocations (`dev` 410, `run` 314, `dev --port-forward` 133, `delete` 101) with *zero* aliases. Added `sk` + `skd`/`skdp`/`skr`/`skdel`, following the existing base-alias convention (`k=kubectl`, `tf=terraform`, `h=hcloud`).

**zsh-abbr scaffold** — `gh pr ls` (849×) and `gh issue ls` (102×) were typed in full despite the `prls`/`ils` aliases existing, because a plain alias never reveals itself. olets/zsh-abbr gives fish-style abbreviations that expand inline on Space, so the habit actually sticks. Migrated them to `gpls`/`gils` (gh-`g` prefix, avoiding the `gpl`↔`git pull` clash).

## Changes

- **`.chezmoiexternal.toml`** — `zsh/zsh-abbr` git-repo external. `clone.args = ["--recurse-submodules"]` fetches the `zsh-job-queue` dependency at clone time rather than relying on zsh-abbr's cwd-sensitive runtime self-heal (which failed in testing).
- **`dot_zshrc.tmpl`** — source zsh-abbr with `ABBR_DEFAULT_BINDINGS=0`; bind Space/Enter into the `viins` keymap inside `zvm_after_init` so they survive zsh-vi-mode's `main`-keymap rebuild (per [zsh-abbr#101](https://github.com/olets/zsh-abbr/issues/101) and the repo's own `zshrc-keybindings` rule).
- **`private_dot_config/zsh-abbr/user-abbreviations`** — seeded abbreviations file (chezmoi-managed; header documents the `chezmoi re-add` workflow for runtime `abbr add` drift).
- **`aliases.zsh`** — added Skaffold block; removed `prls`/`ils` (now abbreviations).

## Verification

Validated under an interactive pty loading the real `~/.zshrc`: `abbr` loads, `gpls`/`gils` present, `abbr-expand-and-insert` widget registered, `zsh-job-queue` submodule fetched.

```
$ exec zsh; then type:  gpls<space>   ->   gh pr ls
```

## Follow-up

Further alias/abbreviation candidates from the same analysis (chezmoi apply, git status, npm run dev, cargo run, git stash, docker…) captured in #255 — not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)