### PR TITLE
feat(claude): keep claude-plugins marketplace fresh + reconcile plugin pins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,6 +25,18 @@
   "enableAllProjectMcpServers": true,
   "enabledMcpjsonServers": [],
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/claude-plugins-refresh.sh",
+            "timeout": 20
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write|NotebookEdit",

--- a/exact_dot_claude/hooks/executable_claude-plugins-audit.sh
+++ b/exact_dot_claude/hooks/executable_claude-plugins-audit.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# claude-plugins-audit.sh — surface UNDECIDED plugins and MISSING opt-in env flags.
+#
+# Compares the live laurigates/claude-plugins marketplace plugin set against the
+# enabledPlugins map in ~/.claude/settings.json (the RENDERED source of truth,
+# pinned by the chezmoi overlay exact_dot_claude/modify_settings.json), plus a
+# curated list of recommended opt-in env flags against the live env block.
+# Prints a short nudge so a new plugin or a freshly-recommended flag gets a
+# true/false decision instead of silently defaulting off.
+#
+# ALWAYS exits 0 — it is advisory and must never break a session when invoked
+# from the SessionStart refresh hook.
+#
+#   Standalone:  bash ~/.claude/hooks/claude-plugins-audit.sh
+#   Called by:   claude-plugins-refresh.sh (when the debounce window elapses)
+set -uo pipefail
+
+SETTINGS="${HOME}/.claude/settings.json"
+MARKETPLACE="laurigates-claude-plugins"
+MARKETPLACE_JSON_URL="https://raw.githubusercontent.com/laurigates/claude-plugins/refs/heads/main/.claude-plugin/marketplace.json"
+
+# Curated recommended opt-in env flags. KEEP IN SYNC with the overlay env block
+# in exact_dot_claude/modify_settings.json. Add a new flag here ONLY after
+# verifying its exact name against current Claude Code docs (code.claude.com/docs)
+# — an unverified flag name produces noisy false "missing" nudges every session.
+RECOMMENDED_ENV_FLAGS=(
+  CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS
+  CLAUDE_CODE_DISABLE_AUTO_MEMORY
+  ENABLE_TOOL_SEARCH
+  CLAUDE_HOOKS_ENABLE_BASH_ANTIPATTERNS_TEACH
+  CLAUDE_HOOKS_ENABLE_CALENDAR_ESTIMATES
+)
+
+command -v jq >/dev/null 2>&1 || exit 0
+[ -f "$SETTINGS" ] || exit 0
+
+# --- marketplace plugin set ---------------------------------------------------
+# Prefer authenticated `gh api` (no rate limit, works offline-of-raw-CDN); fall
+# back to the raw marketplace.json. Both resolve the same canonical list.
+marketplace_names() {
+  local out=""
+  if command -v gh >/dev/null 2>&1; then
+    out="$(gh api repos/laurigates/claude-plugins/contents/.claude-plugin/marketplace.json \
+            --jq '.content' 2>/dev/null | base64 -d 2>/dev/null \
+            | jq -r '.plugins[].name' 2>/dev/null | sort -u)"
+  fi
+  if [ -z "$out" ]; then
+    out="$(curl -fsSL --max-time 8 "$MARKETPLACE_JSON_URL" 2>/dev/null \
+            | jq -r '.plugins[].name' 2>/dev/null | sort -u)"
+  fi
+  printf '%s\n' "$out"
+}
+
+mkt="$(marketplace_names)"
+# No network / no list -> nothing actionable; stay silent.
+[ -z "$mkt" ] && exit 0
+
+# Plugin keys already DECIDED in the overlay (present with true OR false), for
+# this marketplace, with the "@marketplace" suffix stripped.
+decided="$(jq -r --arg m "$MARKETPLACE" '
+  (.enabledPlugins // {}) | keys[]
+  | select(endswith("@" + $m)) | sub("@" + $m + "$"; "")' "$SETTINGS" 2>/dev/null | sort -u)"
+
+undecided_list="$(comm -23 <(printf '%s\n' "$mkt") <(printf '%s\n' "$decided"))"
+stale_list="$(comm -13 <(printf '%s\n' "$mkt") <(printf '%s\n' "$decided"))"
+
+# --- recommended env flags ----------------------------------------------------
+missing_flags=()
+for f in "${RECOMMENDED_ENV_FLAGS[@]}"; do
+  v="$(jq -r --arg k "$f" '.env[$k] // empty' "$SETTINGS" 2>/dev/null)"
+  [ -z "$v" ] && missing_flags+=("$f")
+done
+
+# --- nudge --------------------------------------------------------------------
+have_news=0
+[ -n "$undecided_list" ] && have_news=1
+[ -n "$stale_list" ] && have_news=1
+[ "${#missing_flags[@]}" -gt 0 ] && have_news=1
+[ "$have_news" -eq 0 ] && exit 0
+
+echo "── claude-plugins audit ─────────────────────────────────────"
+if [ -n "$undecided_list" ]; then
+  echo "New plugin(s) not yet decided in the overlay enabledPlugins (defaulting OFF):"
+  printf '%s\n' "$undecided_list" | sed 's/^/  • /'
+  echo "  → decide each true/false in exact_dot_claude/modify_settings.json,"
+  echo "    or run /pin-plugins / /configure:claude-plugins --exhaustive."
+fi
+if [ -n "$stale_list" ]; then
+  echo "Pinned plugin(s) no longer in the marketplace (safe to drop from overlay):"
+  printf '%s\n' "$stale_list" | sed 's/^/  • /'
+fi
+if [ "${#missing_flags[@]}" -gt 0 ]; then
+  echo "Recommended opt-in env flag(s) absent from settings.env:"
+  printf '  • %s\n' "${missing_flags[@]}"
+fi
+echo "─────────────────────────────────────────────────────────────"
+exit 0

--- a/exact_dot_claude/hooks/executable_claude-plugins-refresh.sh
+++ b/exact_dot_claude/hooks/executable_claude-plugins-refresh.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# claude-plugins-refresh.sh — debounced, NON-BLOCKING marketplace freshness.
+#
+# Registered as a user-level SessionStart hook (via the chezmoi overlay
+# exact_dot_claude/modify_settings.json and the repo-root .claude/settings.json).
+# Claude Code's plugin auto-update is startup-only with no time interval, so
+# long-lived sessions never refresh — the root cause of the manual
+# `claude plugin marketplace update` habit. This hook closes that gap WITHOUT
+# slowing startup:
+#
+#   * Debounced by a stamp file — acts at most once per refresh interval
+#     (default 4h), so it costs nothing on the many session starts in between.
+#   * The marketplace update runs BACKGROUNDED + detached (nohup) — startup is
+#     never blocked, and the child survives the hook process exiting.
+#   * When the window elapses it also prints the plugin / env-flag audit nudge.
+#
+# Updates take effect on the NEXT session (or /reload-plugins) — the same model
+# as Claude Code's own startup auto-update. Plugin-provided SessionStart hooks
+# (e.g. session-plugin's spinup nudge) are a separate source and fire alongside
+# this one; this hook does not replace them.
+#
+#   --force   ignore the debounce stamp (manual runs / verification)
+#
+# Env knobs:
+#   CLAUDE_PLUGINS_REFRESH_INTERVAL_HOURS  debounce window in hours (default 4)
+#   CLAUDE_PLUGINS_REFRESH_SELF_UPDATE=1   also run `claude update` in the bg job
+set -uo pipefail
+
+INTERVAL_HOURS="${CLAUDE_PLUGINS_REFRESH_INTERVAL_HOURS:-4}"
+STAMP="${HOME}/.cache/claude-plugins-refresh.stamp"
+LOG="${TMPDIR:-/tmp}/claude-plugins-refresh.log"
+MARKETPLACE="laurigates-claude-plugins"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+force=0
+[ "${1:-}" = "--force" ] && force=1
+
+# --- debounce -----------------------------------------------------------------
+now=$(date +%s)
+interval_s=$(( INTERVAL_HOURS * 3600 ))
+if [ "$force" -eq 0 ] && [ -f "$STAMP" ]; then
+  last="$(cat "$STAMP" 2>/dev/null || echo 0)"
+  case "$last" in ''|*[!0-9]*) last=0 ;; esac
+  if [ $(( now - last )) -lt "$interval_s" ]; then
+    exit 0   # within debounce window — silent no-op
+  fi
+fi
+
+# Stamp FIRST so rapid/concurrent session starts don't all fire the refresh.
+mkdir -p "$(dirname "$STAMP")"
+printf '%s\n' "$now" > "$STAMP"
+
+# --- background marketplace refresh (never blocks startup) --------------------
+# nohup + redirected stdio + disown detaches the child so it keeps running after
+# this hook process exits at the end of SessionStart.
+if command -v claude >/dev/null 2>&1; then
+  # The bash -c body is single-quoted ON PURPOSE: $REFRESH_* must expand in the
+  # detached child (from the exported env below), not in this parent shell.
+  # shellcheck disable=SC2016
+  REFRESH_MARKETPLACE="$MARKETPLACE" \
+  REFRESH_LOG="$LOG" \
+  REFRESH_SELF_UPDATE="${CLAUDE_PLUGINS_REFRESH_SELF_UPDATE:-0}" \
+  nohup bash -c '
+    {
+      echo "=== $(date "+%Y-%m-%d %H:%M:%S") refresh start ==="
+      CLAUDECODE= claude plugin marketplace update "$REFRESH_MARKETPLACE" 2>&1
+      if [ "$REFRESH_SELF_UPDATE" = "1" ]; then
+        echo "--- claude update ---"
+        CLAUDECODE= claude update 2>&1
+      fi
+      echo "=== $(date "+%Y-%m-%d %H:%M:%S") refresh done ==="
+    } >>"$REFRESH_LOG" 2>&1
+  ' >/dev/null 2>&1 &
+  disown 2>/dev/null || true
+fi
+
+# --- audit nudge (fast; foreground) -------------------------------------------
+audit="${HERE}/claude-plugins-audit.sh"
+if [ -x "$audit" ]; then
+  bash "$audit" || true
+fi
+
+exit 0

--- a/exact_dot_claude/modify_settings.json
+++ b/exact_dot_claude/modify_settings.json
@@ -18,13 +18,21 @@
 # unless it is promoted into the overlay below. That keeps project-specific
 # permission noise out of the global config by design.
 #
-# hooks.SessionStart / hooks.Stop are pinned to empty arrays on purpose:
-# session spinup/end nudges now come from session-plugin (auto-registered via
-# its plugin.json hooks). Because the overlay REPLACES arrays on merge, the
-# empty arrays force-clear the retired user-level nudge hooks from the live
-# target. (Do not re-add a "//" comment key inside the JSON hooks object —
-# Claude Code's settings schema has no comment support and /doctor flags it
-# as an unknown hook event.)
+# hooks.Stop is pinned to an empty array on purpose: the end-of-session nudge
+# now comes from session-plugin (registered via its plugin.json hooks).
+#
+# hooks.SessionStart carries ONE user-level hook — claude-plugins-refresh.sh
+# (debounced marketplace freshness + plugin/env audit nudge). Plugin-provided
+# hooks are a SEPARATE source that Claude Code UNIONS with user/project
+# settings hooks (per code.claude.com/docs/en/hooks: "its hooks merge with your
+# user and project hooks; all matching hooks run in parallel; identical
+# handlers are deduplicated"). So session-plugin's own SessionStart spinup nudge
+# still fires alongside this one — listing the refresh hook here does NOT clobber
+# it. Because the overlay REPLACES arrays on merge, this array is authoritative
+# for USER-LEVEL SessionStart hooks only: a retired user nudge is force-cleared,
+# but plugin hooks are untouched. (Do not re-add a "//" comment key inside the
+# JSON hooks object — Claude Code's settings schema has no comment support and
+# /doctor flags it as an unknown hook event.)
 set -euo pipefail
 
 current="$(cat)"
@@ -195,7 +203,18 @@ read -r -d '' overlay <<'OVERLAY' || true
     ]
   },
   "hooks": {
-    "SessionStart": [],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/claude-plugins-refresh.sh",
+            "timeout": 20
+          }
+        ]
+      }
+    ],
     "Stop": [],
     "PreToolUse": [
       {
@@ -269,7 +288,8 @@ read -r -d '' overlay <<'OVERLAY' || true
       "source": {
         "source": "github",
         "repo": "laurigates/claude-plugins"
-      }
+      },
+      "autoUpdate": true
     }
   },
   "alwaysThinkingEnabled": true,

--- a/exact_dot_claude/rules/claude-plugins-freshness.md
+++ b/exact_dot_claude/rules/claude-plugins-freshness.md
@@ -1,0 +1,66 @@
+# Keeping `laurigates/claude-plugins` Fresh + Plugin Enablement
+
+**Scope**: managing the `laurigates-claude-plugins` marketplace and the
+`enabledPlugins` map across the global chezmoi overlay and committed project
+configs. The marketplace updates very often (automated upkeep + agent feedback
+loops), so freshness and drift are recurring concerns.
+
+## Two independent mechanisms — neither replaces the other
+
+| Concern | Global / local upkeep | Web / remote / CI portability |
+|---|---|---|
+| **Plugin enablement** | overlay `enabledPlugins` in `exact_dot_claude/modify_settings.json` (the single source of truth) | committed `.claude/settings.json` `enabledPlugins` — the ONLY place plugins get enabled where `~/.claude` is unavailable |
+| **Binary tools** (helm, terraform, gitleaks, just…) | installed locally via mise / Brewfile | `scripts/install_pkgs.sh` + a SessionStart hook (see `configure-plugin:configure-web-session`) |
+
+Claude Code web/remote/CI has **no access** to the global `~/.claude` overlay,
+so a committed `.claude/settings.json` is the only way to enable *plugins*
+there, and `install_pkgs.sh` is the only way to get *binary tools*. Both are
+needed for full web parity. There is no imperative substitute for plugin
+enablement — committed settings stay canonical for that.
+
+## `enabledPlugins` merge semantics: whole-map replacement
+
+Verified against `code.claude.com/docs/en/settings.md` (the docs call out
+per-key merging **only** for permission rules; everything else overrides):
+
+> When `enabledPlugins` appears in both user-global and project settings, the
+> **highest-precedence scope wins entirely** — the project map REPLACES the
+> global map. A plugin enabled globally but absent from the project map is
+> **disabled** in that project.
+
+Consequence: a committed project pin that is meant to be exhaustive **must list
+the full set**. An exhaustive pin that omits a newly-added marketplace plugin
+silently disables it in web/remote. Deliberate *narrow* subsets are fine — a
+new plugin defaulting off is the intended behavior for an intentionally narrow
+repo. (Hooks, by contrast, are **unioned** across sources — see
+`code.claude.com/docs/en/hooks.md`.)
+
+## Freshness automation (global)
+
+- `~/.claude/hooks/claude-plugins-refresh.sh` — a debounced, backgrounded
+  SessionStart hook. Claude Code's plugin auto-update is startup-only with no
+  time interval, so long-lived sessions go stale; this refreshes the
+  marketplace at most once per `CLAUDE_PLUGINS_REFRESH_INTERVAL_HOURS` (4h
+  default) without blocking startup. Set
+  `CLAUDE_PLUGINS_REFRESH_SELF_UPDATE=1` to also run `claude update`.
+  `--force` bypasses the debounce. Log: `$TMPDIR/claude-plugins-refresh.log`.
+- `~/.claude/hooks/claude-plugins-audit.sh` — prints a nudge for marketplace
+  plugins not yet decided in the overlay `enabledPlugins` (so a new plugin gets
+  an explicit true/false rather than silently defaulting off), stale pins no
+  longer in the marketplace, and recommended opt-in env flags missing from
+  `settings.env`. Runnable standalone; invoked by the refresh hook when due.
+  Its `RECOMMENDED_ENV_FLAGS` list must stay in sync with the overlay `env`
+  block, and a flag is added only after verifying its exact name in the docs.
+- The overlay pins `extraKnownMarketplaces.laurigates-claude-plugins.autoUpdate
+  = true` so the freshness intent is durable, not just runtime state.
+
+## Reconciling committed project pins (drift)
+
+- `just plugins-audit` — read-only; flags repos whose committed *exhaustive*
+  pin (≥ 90% of canonical keys) has drifted from the canonical global set
+  (missing / extra / state-diff). Narrow subsets are ignored.
+- `just plugins-sync-repo <repo>` — rewrites one repo's committed
+  `enabledPlugins` from canonical, showing the diff first. Reversible via git.
+
+After editing the overlay, sync with `chezmoi apply -v ~/.claude` and confirm
+`chezmoi diff ~/.claude` is empty (the overlay is idempotent).

--- a/justfile
+++ b/justfile
@@ -355,6 +355,73 @@ plugins-check-repo:
     @echo "{{BLUE}}Checking Claude plugin configuration for repository at $(pwd)...{{NORMAL}}"
     CLAUDECODE= claude -p "/configure:claude-plugins --check-only"
 
+# Audit committed project plugin pins for drift vs canonical (read-only)
+plugins-audit:
+    #!/usr/bin/env bash
+    # Canonical = the @laurigates-claude-plugins keys in ~/.claude/settings.json.
+    # Compares ONLY that marketplace's keys (official LSPs and other-marketplace
+    # aliases vary in naming and are out of scope). Flags only "exhaustive" pins
+    # — an ABSOLUTE floor of laurigates keys separates them (>= 41 in practice)
+    # from deliberate narrow subsets (<= 21); the floor is canonical-growth-proof,
+    # unlike a %-of-canonical threshold which reclassifies drifted-behind pins as
+    # subsets. enabledPlugins uses whole-map replacement, so an exhaustive pin
+    # omitting a new plugin silently disables it in web/remote — exactly this drift.
+    set -uo pipefail
+    canonical="$HOME/.claude/settings.json"
+    mp="laurigates-claude-plugins"
+    floor=30
+    if [ ! -f "$canonical" ]; then echo "{{YELLOW}}No $canonical — apply the chezmoi overlay first.{{NORMAL}}"; exit 1; fi
+    lauri_keys() { jq -r --arg m "$mp" '(.enabledPlugins // {}) | keys[] | select(endswith("@"+$m)) | sub("@"+$m+"$";"")' "$1" 2>/dev/null | sort -u; }
+    canon_keys="$(lauri_keys "$canonical")"
+    canon_n="$(printf '%s\n' "$canon_keys" | grep -c . || true)"
+    if [ "$canon_n" -eq 0 ]; then echo "{{YELLOW}}Canonical has no @$mp plugins.{{NORMAL}}"; exit 1; fi
+    echo "{{BLUE}}Canonical: $canon_n @$mp plugins (~/.claude/settings.json). Exhaustive floor: $floor keys.{{NORMAL}}"
+    found=0; drifted=0
+    while IFS= read -r f; do
+      case "$f" in *"/worktrees/"*|*"/.git/"*) continue ;; esac
+      jq -e '.enabledPlugins' "$f" >/dev/null 2>&1 || continue
+      keys="$(lauri_keys "$f")"
+      n="$(printf '%s\n' "$keys" | grep -c . || true)"
+      [ "$n" -lt "$floor" ] && continue   # deliberate subset / different marketplace — not in scope
+      found=$((found + 1))
+      missing="$(comm -23 <(printf '%s\n' "$canon_keys") <(printf '%s\n' "$keys"))"
+      extra="$(comm -13 <(printf '%s\n' "$canon_keys") <(printf '%s\n' "$keys"))"
+      valdiff="$(jq -rn --arg m "$mp" --slurpfile a "$canonical" --slurpfile b "$f" '
+        ($a[0].enabledPlugins // {}) as $A | ($b[0].enabledPlugins // {}) as $B
+        | [ $A | to_entries[] | select(.key | endswith("@"+$m))
+            | select(($B[.key] != null) and ($B[.key] != .value)) | (.key | sub("@"+$m+"$";"")) ] | .[]' 2>/dev/null)"
+      if [ -z "$missing" ] && [ -z "$extra" ] && [ -z "$valdiff" ]; then continue; fi
+      drifted=$((drifted + 1))
+      echo ""
+      echo "{{YELLOW}}DRIFT:{{NORMAL}} $f ($n @$mp plugins)"
+      [ -n "$missing" ] && { echo "  missing (canonical, not pinned):"; printf '    - %s\n' $missing; }
+      [ -n "$extra" ]   && { echo "  extra (pinned, not in canonical):"; printf '    + %s\n' $extra; }
+      [ -n "$valdiff" ] && { echo "  state drift (enabled differs from canonical):"; printf '    ~ %s\n' $valdiff; }
+    done < <(find "$HOME/repos" -type f -path "*/.claude/settings.json" 2>/dev/null)
+    echo ""
+    echo "{{GREEN}}Scanned $found exhaustive-pinned repo(s); $drifted drifted.{{NORMAL}}"
+    [ "$drifted" -gt 0 ] && echo "Bring one to canonical: just plugins-sync-repo <repo-path>"
+
+# Rewrite one repo's committed enabledPlugins from canonical (shows diff first)
+plugins-sync-repo repo:
+    #!/usr/bin/env bash
+    # Canonical = ~/.claude/settings.json. Shows the enabledPlugins diff, then
+    # writes in place (jq normalizes JSON formatting). Reversible — review with
+    # `git -C <repo> diff`.
+    set -uo pipefail
+    canonical="$HOME/.claude/settings.json"
+    target="{{repo}}"
+    case "$target" in */.claude/settings.json) : ;; *) target="${target%/}/.claude/settings.json" ;; esac
+    if [ ! -f "$canonical" ]; then echo "{{YELLOW}}No $canonical{{NORMAL}}"; exit 1; fi
+    if [ ! -f "$target" ]; then echo "{{YELLOW}}No $target{{NORMAL}}"; exit 1; fi
+    canon_ep="$(jq '.enabledPlugins // {}' "$canonical")"
+    new="$(jq --argjson ep "$canon_ep" '.enabledPlugins = $ep' "$target")"
+    if [ "$new" = "$(cat "$target")" ]; then echo "{{GREEN}}Already canonical: $target{{NORMAL}}"; exit 0; fi
+    echo "{{BLUE}}enabledPlugins changes for $target:{{NORMAL}}"
+    diff <(jq -S '.enabledPlugins // {}' "$target") <(printf '%s' "$canon_ep" | jq -S '.') || true
+    printf '%s\n' "$new" > "$target"
+    echo "{{GREEN}}Wrote $target — review with: git -C \"$(dirname "$(dirname "$target")")\" diff{{NORMAL}}"
+
 # ─────────────────────────────────────────────────────────────────────────────
 # CI/CD Integration
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Why

Claude Code's plugin auto-update is **startup-only** with no time interval, so long-lived local sessions never refresh — the root cause of the manual `claude plugin marketplace update` habit. The `laurigates/claude-plugins` marketplace updates very often, so this closes the freshness gap and adds tooling to keep both the global overlay and committed project pins honest.

## What

**Freshness (global, automated):**
- `claude-plugins-refresh.sh` — debounced (4h default), **backgrounded + detached** SessionStart hook so startup is never blocked. Opt-in `claude update` via `CLAUDE_PLUGINS_REFRESH_SELF_UPDATE=1`; `--force` bypasses the debounce. Log at `$TMPDIR/claude-plugins-refresh.log`.
- `claude-plugins-audit.sh` — nudges for marketplace plugins **not yet decided** in the overlay (so a new plugin gets an explicit true/false instead of silently defaulting off), stale pins, and missing recommended opt-in env flags. Runnable standalone; invoked by the refresh hook when due.
- Overlay pins `extraKnownMarketplaces.autoUpdate = true` (durable intent, not just runtime state).

**Hook coexistence:** the refresh hook is registered in both the overlay and the repo-root `.claude/settings.json`. Per the docs, hooks from different sources are **unioned** (and identical handlers deduped), so this fires *alongside* session-plugin's plugin-provided SessionStart nudge — it does not clobber it.

**Project-pin drift (web/remote portability):**
- `just plugins-audit` — read-only drift report for **exhaustive** laurigates-marketplace pins vs the canonical global set. Uses an absolute key floor (growth-proof) and compares only `@laurigates-claude-plugins` keys (no cross-marketplace / LSP-naming noise). Found 5 drifted exhaustive repos on first run.
- `just plugins-sync-repo <repo>` — rewrites one repo's `enabledPlugins` from canonical, diff first.

**Docs:** `rules/claude-plugins-freshness.md` records the verified `enabledPlugins` merge semantics and the web-portability split.

## Merge-semantics verdict (the blocking question)

Resolved against `code.claude.com/docs`: `enabledPlugins` is **whole-map replacement** — the highest-precedence scope wins entirely, NOT a per-key merge. So a committed exhaustive project pin **must list the full set**, or it silently disables globally-enabled plugins in web/remote. That is exactly what `plugins-audit` checks. (Hooks, by contrast, are unioned across sources.)

## Verification

- `chezmoi apply -v ~/.claude` → idempotent (`chezmoi diff` empty after).
- `--force` run: backgrounds the update, writes the stamp + audit nudge; immediate re-run is a silent no-op (debounce works).
- `shellcheck` clean on both hooks; `pre-commit` green (incl. `check json` confirming the `modify_settings.json` exclusion).
- `just plugins-audit` flags the 5 drifted exhaustive repos with clean per-plugin output.

## Follow-up (out of scope)

The dead `update-ai-tools.sh` references (README, `cleanup-mcp-servers.sh.tmpl`, `dependency-management.md`) are an **MCP** concern, not plugins — filed as taskwarrior task 238 rather than mixing unrelated doc edits into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)