### PR TITLE
docs(claude): add public-repo banner + fix broken security rule links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 Chezmoi dotfiles repository with cross-platform development environment configuration.
 
+## ⚠️ Public Repository
+
+This repo is **public** (`github.com/laurigates/dotfiles`). Never commit private information: secrets/API tokens (use `~/.api_tokens`, sourced by mise), personal hostnames/IPs, internal-only org facts, or machine-specific identifiers. Secret-adjacent files use the chezmoi `private_` prefix and stay out of templates that render to tracked output. When in doubt, leave it out — assume anything committed is world-readable and indexed.
+
 ## Chezmoi Quick Reference
 
 - **Source directory**: `~/.local/share/chezmoi/` (always edit here)
@@ -97,4 +101,4 @@ Blueprint v3.3.0 manages project documentation and rules.
 
 ## Security & Release
 
-See `.claude/rules/security.md` and `.claude/rules/release-please.md`. Quick: API tokens in `~/.api_tokens`, private files use `private_` prefix, never manually edit `CHANGELOG.md`.
+See `exact_dot_claude/rules/security.md` and `exact_dot_claude/rules/release-please.md`. Quick: API tokens in `~/.api_tokens`, private files use `private_` prefix, never manually edit `CHANGELOG.md`. Remember this repo is public — see [⚠️ Public Repository](#️-public-repository) above.


### PR DESCRIPTION
## Summary

Make the **public-repo / no-private-data** constraint explicit at the top of the project `CLAUDE.md` — today it's only implied, and the one existing pointer to it is broken.

- **Add a `## ⚠️ Public Repository` banner** immediately under the one-line description (before "Chezmoi Quick Reference"). States the single load-bearing fact — this repo is public (`github.com/laurigates/dotfiles`) — and the rule it implies: never commit secrets/tokens, personal hostnames/IPs, internal-only org facts, or machine-specific identifiers.
- **Fix the broken pointer** in "Security & Release": `.claude/rules/security.md` / `.claude/rules/release-please.md` do not exist at the repo root. Repointed to the real source files `exact_dot_claude/rules/security.md` and `exact_dot_claude/rules/release-please.md`, and added a cross-reference back to the new banner (link, don't duplicate).

## Scope notes

- Edits the **project** `CLAUDE.md` only. No repo-root `.claude/rules/` directory is created — it isn't wired into anything today, so the banner in `CLAUDE.md` is the discoverable home.
- The global `exact_dot_claude/rules/security.md` is intentionally untouched — "this specific repo is public" belongs in this repo's `CLAUDE.md`, not the global rule.

## Verification

- Banner renders above "Chezmoi Quick Reference".
- `ls exact_dot_claude/rules/{security,release-please}.md` — both link targets exist.
- pre-commit (markdown/secret hooks) green on the commit.
- No `chezmoi apply` needed — repo-root `CLAUDE.md` is a tracked project doc, not a chezmoi-managed target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)