### PR TITLE
feat(claude): add Gemini PR badge + cache-warmth to statusline

### DIFF
--- a/exact_dot_claude/executable_statusline-command.sh
+++ b/exact_dot_claude/executable_statusline-command.sh
@@ -157,22 +157,24 @@ if [[ -n "$transcript" && -f "$transcript" ]]; then
   fi
 fi
 
-# ── Render: colored text, joined by dim separators ───────────────────────────
-# Each part carries its own color and a trailing reset, so any truncation by
-# the TUI is harmless. Parts are collected, then joined with " · ".
-parts=()
+# ── Render: two colored rows ──────────────────────────────────────────────────
+# Each part carries its own color + reset, so any truncation is harmless.
+# Multi-line is supported (each printed line is a status row). Row 1 is identity
+# (where am I / what PR); row 2 is session metrics.
+line1=()  # directory · branch · PR (+CI +gemini)
+line2=()  # model · context/tokens · cache · time
 
-# Directory
+# Row 1 — Directory
 printf -v p '\033[38;2;%sm%s\033[0m' "$PURPLE" "$dir"
-parts+=("$p")
+line1+=("$p")
 
-# Git branch + dirty flag
+# Row 1 — Git branch + dirty flag
 if [[ -n "$git_branch" ]]; then
   printf -v p '\033[38;2;%sm%s%s\033[0m' "$ORANGE" "$git_branch" "$git_dirty"
-  parts+=("$p")
+  line1+=("$p")
 fi
 
-# PR info + CI check counts + gemini review badge
+# Row 1 — PR info + CI check counts + gemini review badge
 if [[ -n "$pr_number" ]]; then
   printf -v p '\033[38;2;%smPR#%s\033[0m' "$TEAL" "$pr_number"
   [[ "$pr_state" == "draft" ]] && printf -v d '\033[38;2;%sm draft\033[0m' "$DIM" && p+="$d"
@@ -190,14 +192,14 @@ if [[ -n "$pr_number" ]]; then
   if [[ "${gemini_unresolved:-0}" -gt 0 ]] 2>/dev/null; then
     printf -v g '\033[38;2;%sm ✦%s\033[0m' "$GEMINI" "$gemini_unresolved"; p+="$g"
   fi
-  parts+=("$p")
+  line1+=("$p")
 fi
 
-# Model name
+# Row 2 — Model name
 printf -v p '\033[38;2;%sm%s\033[0m' "$BLUE" "$short_model"
-parts+=("$p")
+line2+=("$p")
 
-# Context % + session token totals + cache warmth + heart + time (one part)
+# Row 2 — Context % + session token totals + cache warmth + heart + time
 p=""
 [[ -n "$used_pct" ]] && printf -v p '\033[38;2;%sm%.0f%%\033[0m ' "$DIM" "$used_pct"
 if [[ -n "$total_in" && -n "$total_out" ]]; then
@@ -210,13 +212,18 @@ if [[ -n "$cache_glyph" ]]; then
 fi
 printf -v t '\033[38;2;%sm♥\033[0m\033[38;2;%sm%s\033[0m' "$HEART" "$DIM" "$(date +%H:%M)"
 p+="$t"
-parts+=("$p")
+line2+=("$p")
 
-# Join with dim separator
+# Join a row's parts with a dim separator and print it (bash 3.2 safe — no namerefs)
 printf -v sep '\033[38;2;%sm · \033[0m' "$SEP"
-out=""
-for i in "${!parts[@]}"; do
-  [[ "$i" -gt 0 ]] && out+="$sep"
-  out+="${parts[$i]}"
-done
-printf '%s\n' "$out"
+join_row() {
+  local out="" i=0 part
+  for part in "$@"; do
+    [[ "$i" -gt 0 ]] && out+="$sep"
+    out+="$part"
+    i=$((i + 1))
+  done
+  printf '%s\n' "$out"
+}
+join_row "${line1[@]}"
+join_row "${line2[@]}"

--- a/exact_dot_claude/executable_statusline-command.sh
+++ b/exact_dot_claude/executable_statusline-command.sh
@@ -1,179 +1,177 @@
 #!/bin/bash
+# ~/.claude/statusline-command.sh
+# Powerline / Starship-inspired status line for Claude Code
+# Segment colors and order match ~/.config/starship.toml
+#
+# Extra features beyond the base Starship style:
+#   - Gemini PR review badge: count of UNRESOLVED gemini-code-assist[bot]
+#     review threads on the current PR (cached, refreshed in the background
+#     so rendering never blocks on a network call).
+#   - Cache-warmth indicator: whether the Anthropic prompt cache for this
+#     session is still warm, based on the 5-minute (300s) cache TTL measured
+#     from the transcript file's last-modified time.
 
-# Read Claude Code session data
 input=$(cat)
 
-# Extract data from JSON
+# Truecolor RGB values matching starship.toml segment palette
+PURPLE="154;52;142"   # #9A348E — opening segment (username/os in Starship)
+ORANGE="252;161;125"  # #FCA17D — git branch in Starship
+TEAL="6;150;154"      # #06969A — docker context in Starship (PR info here)
+BLUE="134;187;216"    # #86BBD8 — language runtimes in Starship (model name here)
+DARKBLUE="51;101;138" # #33658A — time segment in Starship
+BLACK="0;0;0"
+WHITE="255;255;255"
+GEMINI="138;180;248"  # #8AB4F8 — Google blue, gemini badge fg
+WARM="255;176;102"    # warm amber — cache-warm glyph
+COLD="150;180;205"    # cool dim — cache-cold glyph
+
+# U+E0B0 Powerline solid right arrow (requires Nerd Font; kitty + Starship implies this)
+ARROW=$(printf '\xee\x82\xb0')
+
+# Extract JSON fields
+current_dir=$(echo "$input" | jq -r '.workspace.current_dir // .cwd // empty')
 model_name=$(echo "$input" | jq -r '.model.display_name')
-current_dir=$(echo "$input" | jq -r '.workspace.current_dir')
-output_style=$(echo "$input" | jq -r '.output_style.name')
-
-# Extract context window metrics
-total_input=$(echo "$input" | jq -r '.context_window.total_input_tokens // 0')
-total_output=$(echo "$input" | jq -r '.context_window.total_output_tokens // 0')
-context_size=$(echo "$input" | jq -r '.context_window.context_window_size // 200000')
 used_pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
-remaining_pct=$(echo "$input" | jq -r '.context_window.remaining_percentage // empty')
+transcript=$(echo "$input" | jq -r '.transcript_path // empty')
+pr_number=$(echo "$input" | jq -r '.pr.number // empty')
+pr_state=$(echo "$input" | jq -r '.pr.review_state // empty')
+repo_owner=$(echo "$input" | jq -r '.workspace.repo.owner // empty')
+repo_name=$(echo "$input" | jq -r '.workspace.repo.name // empty')
 
-# Current usage (last API call)
-current_input=$(echo "$input" | jq -r '.context_window.current_usage.input_tokens // 0')
-current_output=$(echo "$input" | jq -r '.context_window.current_usage.output_tokens // 0')
-cache_creation=$(echo "$input" | jq -r '.context_window.current_usage.cache_creation_input_tokens // 0')
-cache_read=$(echo "$input" | jq -r '.context_window.current_usage.cache_read_input_tokens // 0')
+now=$(date +%s)
+cache_dir="${TMPDIR:-/tmp}/cc-statusline"
+mkdir -p "$cache_dir" 2>/dev/null
 
-# Get basic info
-time_str=$(date +%H:%M)
+# Directory: replace HOME with ~ then truncate to last 3 components
+# (mirrors Starship's truncation_length = 3 and truncation_symbol = "…/")
+dir="${current_dir/$HOME/~}"
+dir=$(echo "$dir" | awk -F'/' '{
+  if (NF > 3) { print "…/" $(NF-2) "/" $(NF-1) "/" $NF }
+  else         { print $0 }
+}')
 
-# Check if we're in a git repository first
-git_info=""
-repo_display=""
-if git rev-parse --git-dir >/dev/null 2>&1; then
-    # We're in a git repo - try to get owner/repo from remote
-    remote_url=$(git remote get-url origin 2>/dev/null || echo "")
-    if [[ -n "$remote_url" ]]; then
-        # Extract owner/repo from GitHub URL (handles both SSH and HTTPS)
-        if [[ "$remote_url" =~ github\.com[:/]([^/]+)/([^/.]+) ]]; then
-            owner="${BASH_REMATCH[1]}"
-            repo="${BASH_REMATCH[2]}"
-            repo_display="$owner/$repo"
-        fi
-    fi
-
-    # If we couldn't get owner/repo, fall back to just repo name from directory
-    if [[ -z "$repo_display" ]]; then
-        repo_display=$(basename "$current_dir")
-    fi
-
-    # Get git branch and status
-    branch=$(git branch --show-current 2>/dev/null)
-    if [[ -n "$branch" ]]; then
-        # Get git status (simplified)
-        status_output=$(git status --porcelain 2>/dev/null)
-        if [[ -n "$status_output" ]]; then
-            git_status="*"
-        else
-            git_status=""
-        fi
-        git_info=" $branch$git_status"
-    fi
-else
-    # Not in a git repo - use directory formatting (similar to starship's truncation)
-    repo_display="$current_dir"
-    if [[ ${#repo_display} -gt 50 ]]; then
-        repo_display="...${repo_display: -47}"
-    fi
-    # Replace home directory with ~
-    repo_display="${repo_display/$HOME/~}"
+# Git branch + dirty indicator (local only, no network)
+git_branch=""
+git_dirty=""
+if git -C "$current_dir" rev-parse --git-dir >/dev/null 2>&1; then
+  git_branch=$(git -C "$current_dir" branch --show-current 2>/dev/null || echo "")
+  if [[ -n "$git_branch" ]]; then
+    git_porcelain=$(git -C "$current_dir" status --porcelain 2>/dev/null || echo "")
+    [[ -n "$git_porcelain" ]] && git_dirty="*"
+  fi
 fi
 
-# GitHub PR context (only if in git repo and gh is available)
-pr_info=""
-if git rev-parse --git-dir >/dev/null 2>&1 && command -v gh >/dev/null 2>&1; then
-    # Check if current branch has an open PR (with timeout and error suppression)
-    pr_number=$(timeout 2 gh pr view --json number --jq '.number' 2>/dev/null || echo "")
-    if [[ -n "$pr_number" && "$pr_number" != "null" ]]; then
-        pr_info=" PR#$pr_number"
+# Model name: strip "Claude " prefix for brevity
+short_model="${model_name#Claude }"
 
-        # Get check run status for the PR (with timeout and error suppression)
-        check_data=$(timeout 3 gh pr checks --json state,name 2>/dev/null || echo "")
-        if [[ -n "$check_data" && "$check_data" != "[]" ]]; then
-            # Count checks by status
-            passing=$(echo "$check_data" | jq -r '.[] | select(.state=="SUCCESS") | .state' 2>/dev/null | wc -l | tr -d ' ')
-            failing=$(echo "$check_data" | jq -r '.[] | select(.state=="FAILURE") | .state' 2>/dev/null | wc -l | tr -d ' ')
-            pending=$(echo "$check_data" | jq -r '.[] | select(.state=="PENDING" or .state=="IN_PROGRESS" or .state=="QUEUED") | .state' 2>/dev/null | wc -l | tr -d ' ')
+# ── Gemini PR review badge ────────────────────────────────────────────────────
+# Counts UNRESOLVED review threads opened by gemini-code-assist[bot] on the
+# current PR. The gh GraphQL call is slow, so we never run it inline: each
+# render reads a cached count, and if the cache is stale it kicks off a
+# detached background refresh (single-flight, guarded by a lock) for next time.
+gemini_unresolved=""
+if [[ -n "$pr_number" && -n "$repo_owner" && -n "$repo_name" ]] && command -v gh >/dev/null 2>&1; then
+  cache_file="$cache_dir/gemini-${repo_owner}-${repo_name}-${pr_number}"
+  lock_file="${cache_file}.lock"
+  fresh_secs=90
 
-            # Only show checks if there are any
-            total_checks=$((passing + failing + pending))
-            if [[ $total_checks -gt 0 ]]; then
-                check_status=""
-                [[ $passing -gt 0 ]] && check_status="${passing}✅"
-                [[ $failing -gt 0 ]] && check_status="${check_status:+$check_status/}${failing}❌"
-                [[ $pending -gt 0 ]] && check_status="${check_status:+$check_status/}${pending}⏳"
-                pr_info="$pr_info $check_status"
-            fi
-        fi
-    fi
+  # Use whatever count we already have for this render.
+  [[ -f "$cache_file" ]] && gemini_unresolved=$(cat "$cache_file" 2>/dev/null)
+
+  # Decide whether to spawn a refresh: cache missing/stale AND no recent lock.
+  cache_age=999999
+  if [[ -f "$cache_file" ]]; then
+    cache_mtime=$(stat -f %m "$cache_file" 2>/dev/null || echo 0)
+    cache_age=$((now - cache_mtime))
+  fi
+  lock_age=999999
+  if [[ -f "$lock_file" ]]; then
+    lock_mtime=$(stat -f %m "$lock_file" 2>/dev/null || echo 0)
+    lock_age=$((now - lock_mtime))
+  fi
+
+  if [[ "$cache_age" -ge "$fresh_secs" && "$lock_age" -ge 60 ]]; then
+    : > "$lock_file"
+    (
+      gql='query($owner:String!,$name:String!,$pr:Int!){repository(owner:$owner,name:$name){pullRequest(number:$pr){reviewThreads(first:100){nodes{isResolved comments(first:1){nodes{author{login}}}}}}}}'
+      count=$(gh api graphql -f query="$gql" \
+        -F owner="$repo_owner" -F name="$repo_name" -F pr="$pr_number" \
+        --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select((.comments.nodes[0].author.login // "") | test("gemini")) | select(.isResolved==false)] | length' 2>/dev/null)
+      [[ -z "$count" ]] && count=0
+      printf '%s' "$count" > "${cache_file}.tmp" 2>/dev/null && mv "${cache_file}.tmp" "$cache_file" 2>/dev/null
+      rm -f "$lock_file" 2>/dev/null
+    ) >/dev/null 2>&1 &
+    disown 2>/dev/null || true
+  fi
 fi
 
-# Test status indicator (check for cached test results)
-test_info=""
-if [[ -f ".test_cache" ]]; then
-    test_status=$(cat .test_cache 2>/dev/null | head -1)
-    case "$test_status" in
-        "pass"|"passed"|"✅") test_info=" ✅" ;;
-        "fail"|"failed"|"❌") test_info=" ❌" ;;
-        "running"|"⏳") test_info=" ⏳" ;;
-    esac
-elif [[ -f ".pytest_cache/v/cache/lastfailed" ]] && [[ ! -s ".pytest_cache/v/cache/lastfailed" ]]; then
-    # pytest cache exists and lastfailed is empty (all tests passed)
-    test_info=" ✅"
-elif [[ -f ".pytest_cache/v/cache/lastfailed" ]] && [[ -s ".pytest_cache/v/cache/lastfailed" ]]; then
-    # pytest cache exists and lastfailed has content (some tests failed)
-    test_info=" ❌"
+# ── Cache-warmth indicator ────────────────────────────────────────────────────
+# The Anthropic prompt cache has a 5-minute (300s) TTL, refreshed on each turn.
+# The transcript file is appended every turn, so time since its last write is a
+# good proxy for how much of the cache window remains.
+cache_glyph=""
+cache_fg="$COLD"
+cache_remaining=""
+if [[ -n "$transcript" && -f "$transcript" ]]; then
+  t_mtime=$(stat -f %m "$transcript" 2>/dev/null || echo 0)
+  elapsed=$((now - t_mtime))
+  ttl=300
+  remaining=$((ttl - elapsed))
+  if [[ "$remaining" -gt 0 ]]; then
+    cache_glyph="♨"      # warm: cache still alive
+    cache_fg="$WARM"
+    cache_remaining=$(printf '%d:%02d' $((remaining / 60)) $((remaining % 60)))
+  else
+    cache_glyph="❄"      # cold: cache window has expired
+    cache_fg="$COLD"
+  fi
 fi
 
-# Context window metrics
-context_info=""
-if [[ -n "$used_pct" ]]; then
-    # Format numbers with K suffix for readability
-    format_tokens() {
-        local num=$1
-        if [[ $num -ge 1000 ]]; then
-            printf "%.1fK" "$(echo "scale=1; $num / 1000" | bc)"
-        else
-            printf "%d" "$num"
-        fi
-    }
+# ── Powerline segments ────────────────────────────────────────────────────────
+prev_bg="$PURPLE"
 
-    total_in_fmt=$(format_tokens $total_input)
-    total_out_fmt=$(format_tokens $total_output)
+# Segment 1: Purple — directory (Starship: username + directory)
+printf "\033[48;2;%sm\033[38;2;%sm  %s " "$PURPLE" "$WHITE" "$dir"
 
-    # Build context info string
-    context_info=" 🧠 ${used_pct}%"
-
-    # Add session totals
-    context_info="${context_info} [${total_in_fmt}↓/${total_out_fmt}↑]"
-
-    # Add current usage details if available (non-zero)
-    if [[ $current_input -gt 0 || $current_output -gt 0 ]]; then
-        curr_in_fmt=$(format_tokens $current_input)
-        curr_out_fmt=$(format_tokens $current_output)
-        context_info="${context_info} (${curr_in_fmt}↓/${curr_out_fmt}↑"
-
-        # Add cache info if present
-        if [[ $cache_creation -gt 0 || $cache_read -gt 0 ]]; then
-            cache_info=""
-            if [[ $cache_read -gt 0 ]]; then
-                cache_read_fmt=$(format_tokens $cache_read)
-                cache_info="💾${cache_read_fmt}"
-            fi
-            if [[ $cache_creation -gt 0 ]]; then
-                cache_create_fmt=$(format_tokens $cache_creation)
-                cache_info="${cache_info:+$cache_info/}📝${cache_create_fmt}"
-            fi
-            context_info="${context_info} ${cache_info}"
-        fi
-        context_info="${context_info})"
-    fi
+# Segment 2: Orange — git branch + dirty flag (Starship: git_branch + git_status)
+if [[ -n "$git_branch" ]]; then
+  printf "\033[38;2;%sm\033[48;2;%sm%s\033[38;2;%sm  %s%s " \
+    "$prev_bg" "$ORANGE" "$ARROW" "$BLACK" "$git_branch" "$git_dirty"
+  prev_bg="$ORANGE"
 fi
 
-# Build the status line (simplified colors for terminal display)
-printf " \033[31m%s\033[0m" "$repo_display" # Red directory/repo
-if [[ -n "$git_info" ]]; then
-    printf " \033[33m\033[0m%s" "$git_info" # Yellow git info with branch symbol
+# Segment 3: Teal — PR info + gemini review badge (Starship: docker_context)
+if [[ -n "$pr_number" ]]; then
+  printf "\033[38;2;%sm\033[48;2;%sm%s\033[38;2;%sm  PR#%s" \
+    "$prev_bg" "$TEAL" "$ARROW" "$WHITE" "$pr_number"
+  case "$pr_state" in
+    approved)          printf " [ok]" ;;
+    changes_requested) printf " [!]" ;;
+    draft)             printf " [draft]" ;;
+  esac
+  # Gemini badge: only when there are unresolved gemini threads
+  if [[ -n "$gemini_unresolved" && "$gemini_unresolved" -gt 0 ]] 2>/dev/null; then
+    printf "\033[38;2;%sm ✦%s\033[38;2;%sm" "$GEMINI" "$gemini_unresolved" "$WHITE"
+  fi
+  printf " "
+  prev_bg="$TEAL"
 fi
-if [[ -n "$pr_info" ]]; then
-    printf " \033[95m%s\033[0m" "$pr_info" # Magenta PR info
+
+# Segment 4: Blue — model name (Starship: language runtimes)
+printf "\033[38;2;%sm\033[48;2;%sm%s\033[38;2;%sm  %s " \
+  "$prev_bg" "$BLUE" "$ARROW" "$BLACK" "$short_model"
+prev_bg="$BLUE"
+
+# Segment 5: Dark blue — context % + cache warmth + heart + time
+printf "\033[38;2;%sm\033[48;2;%sm%s\033[38;2;%sm " \
+  "$prev_bg" "$DARKBLUE" "$ARROW" "$WHITE"
+[[ -n "$used_pct" ]] && printf "%.0f%% " "$used_pct"
+if [[ -n "$cache_glyph" ]]; then
+  printf "\033[38;2;%sm%s\033[38;2;%sm" "$cache_fg" "$cache_glyph" "$WHITE"
+  [[ -n "$cache_remaining" ]] && printf "%s" "$cache_remaining"
+  printf " "
 fi
-if [[ -n "$test_info" ]]; then
-    printf "%s" "$test_info" # Test status (no color, emoji provides the visual cue)
-fi
-if [[ -n "$context_info" ]]; then
-    printf " \033[92m%s\033[0m" "$context_info" # Green context window info
-fi
-printf " \033[36m♥ %s\033[0m" "$time_str" # Cyan time with heart symbol
-printf " \033[90m[%s]\033[0m" "$model_name" # Dim model name
-if [[ "$output_style" != "default" ]]; then
-    printf " \033[90m(%s)\033[0m" "$output_style" # Dim output style if not default
-fi
-echo
+printf "♥ %s " "$(date +%H:%M)"
+
+# Closing arrow back to terminal default background
+printf "\033[0m\033[38;2;%sm%s\033[0m\n" "$DARKBLUE" "$ARROW"

--- a/exact_dot_claude/executable_statusline-command.sh
+++ b/exact_dot_claude/executable_statusline-command.sh
@@ -26,13 +26,27 @@ GEMINI="138;180;248"  # #8AB4F8 — Google blue, gemini badge
 WARM="255;176;102"    # warm amber — cache-warm glyph
 COLD="150;180;205"    # cool dim — cache-cold glyph
 HEART="235;110;120"   # soft red — time heart
-DIM="150;160;170"     # context % and separators
+DIM="150;160;170"     # context % / token totals
 SEP="90;95;105"       # separator dots
+GREEN="126;200;130"   # CI passing
+RED="235;110;120"     # CI failing
+AMBER="230;190;110"   # CI pending
+
+# Format a token count with a K suffix (8500→8.5K, 84000→84K)
+fmt_tokens() {
+  awk -v n="$1" 'BEGIN{
+    if (n >= 10000)     printf "%.0fK", n/1000
+    else if (n >= 1000) printf "%.1fK", n/1000
+    else                printf "%d", n
+  }'
+}
 
 # Extract JSON fields
 current_dir=$(echo "$input" | jq -r '.workspace.current_dir // .cwd // empty')
 model_name=$(echo "$input" | jq -r '.model.display_name')
 used_pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+total_in=$(echo "$input" | jq -r '.context_window.total_input_tokens // empty')
+total_out=$(echo "$input" | jq -r '.context_window.total_output_tokens // empty')
 transcript=$(echo "$input" | jq -r '.transcript_path // empty')
 pr_number=$(echo "$input" | jq -r '.pr.number // empty')
 pr_state=$(echo "$input" | jq -r '.pr.review_state // empty')
@@ -68,19 +82,22 @@ fi
 # Model name: strip "Claude " prefix for brevity
 short_model="${model_name#Claude }"
 
-# ── Gemini PR review badge ────────────────────────────────────────────────────
-# Counts UNRESOLVED review threads opened by gemini-code-assist[bot] on the
-# current PR. The gh GraphQL call is slow, so we never run it inline: each
-# render reads a cached count, and if the cache is stale it kicks off a
-# detached background refresh (single-flight, guarded by a lock) for next time.
+# ── PR network data: Gemini reviews + CI checks ───────────────────────────────
+# Both need slow gh calls, so we never run them inline: each render reads a
+# cached line, and if it's stale it kicks off a single detached background
+# refresh (single-flight, lock-guarded) that fetches both and writes one line:
+#   "<gemini_unresolved>;<ci_pass>;<ci_fail>;<ci_pending>"
 gemini_unresolved=""
+ci_pass=""; ci_fail=""; ci_pend=""
 if [[ -n "$pr_number" && -n "$repo_owner" && -n "$repo_name" ]] && command -v gh >/dev/null 2>&1; then
-  cache_file="$cache_dir/gemini-${repo_owner}-${repo_name}-${pr_number}"
+  cache_file="$cache_dir/pr-${repo_owner}-${repo_name}-${pr_number}"
   lock_file="${cache_file}.lock"
   fresh_secs=90
 
-  # Use whatever count we already have for this render.
-  [[ -f "$cache_file" ]] && gemini_unresolved=$(cat "$cache_file" 2>/dev/null)
+  # Use whatever we already have for this render.
+  if [[ -f "$cache_file" ]]; then
+    IFS=';' read -r gemini_unresolved ci_pass ci_fail ci_pend < "$cache_file"
+  fi
 
   # Decide whether to spawn a refresh: cache missing/stale AND no recent lock.
   cache_age=999999
@@ -97,12 +114,21 @@ if [[ -n "$pr_number" && -n "$repo_owner" && -n "$repo_name" ]] && command -v gh
   if [[ "$cache_age" -ge "$fresh_secs" && "$lock_age" -ge 60 ]]; then
     : > "$lock_file"
     (
+      # Unresolved gemini-code-assist review threads
       gql='query($owner:String!,$name:String!,$pr:Int!){repository(owner:$owner,name:$name){pullRequest(number:$pr){reviewThreads(first:100){nodes{isResolved comments(first:1){nodes{author{login}}}}}}}}'
-      count=$(gh api graphql -f query="$gql" \
+      gem=$(gh api graphql -f query="$gql" \
         -F owner="$repo_owner" -F name="$repo_name" -F pr="$pr_number" \
         --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select((.comments.nodes[0].author.login // "") | test("gemini")) | select(.isResolved==false)] | length' 2>/dev/null)
-      [[ -z "$count" ]] && count=0
-      printf '%s' "$count" > "${cache_file}.tmp" 2>/dev/null && mv "${cache_file}.tmp" "$cache_file" 2>/dev/null
+      [[ -z "$gem" ]] && gem=0
+      # CI check buckets (pass/fail/pending) for the PR's latest commit
+      checks=$(gh pr checks "$pr_number" -R "${repo_owner}/${repo_name}" --json bucket 2>/dev/null)
+      if [[ -n "$checks" ]]; then
+        cp=$(jq '[.[]|select(.bucket=="pass")]|length' <<<"$checks" 2>/dev/null)
+        cf=$(jq '[.[]|select(.bucket=="fail" or .bucket=="cancel")]|length' <<<"$checks" 2>/dev/null)
+        cq=$(jq '[.[]|select(.bucket=="pending")]|length' <<<"$checks" 2>/dev/null)
+      fi
+      printf '%s;%s;%s;%s' "$gem" "${cp:-0}" "${cf:-0}" "${cq:-0}" > "${cache_file}.tmp" 2>/dev/null \
+        && mv "${cache_file}.tmp" "$cache_file" 2>/dev/null
       rm -f "$lock_file" 2>/dev/null
     ) >/dev/null 2>&1 &
     disown 2>/dev/null || true
@@ -146,20 +172,24 @@ if [[ -n "$git_branch" ]]; then
   parts+=("$p")
 fi
 
-# PR info + gemini review badge
+# PR info + CI check counts + gemini review badge
 if [[ -n "$pr_number" ]]; then
-  printf -v p '\033[38;2;%smPR#%s' "$TEAL" "$pr_number"
-  case "$pr_state" in
-    approved)          p+=" ✓" ;;
-    changes_requested) p+=" ✗" ;;
-    draft)             p+=" draft" ;;
-  esac
-  # Gemini badge: only when there are unresolved gemini threads
-  if [[ -n "$gemini_unresolved" && "$gemini_unresolved" -gt 0 ]] 2>/dev/null; then
-    printf -v g '\033[38;2;%sm ✦%s' "$GEMINI" "$gemini_unresolved"
-    p+="$g"
+  printf -v p '\033[38;2;%smPR#%s\033[0m' "$TEAL" "$pr_number"
+  [[ "$pr_state" == "draft" ]] && printf -v d '\033[38;2;%sm draft\033[0m' "$DIM" && p+="$d"
+  # CI checks: green pass / red fail / amber pending, each shown only when > 0
+  if [[ "${ci_pass:-0}" -gt 0 ]] 2>/dev/null; then
+    printf -v c '\033[38;2;%sm %s✓\033[0m' "$GREEN" "$ci_pass"; p+="$c"
   fi
-  p+=$'\033[0m'
+  if [[ "${ci_fail:-0}" -gt 0 ]] 2>/dev/null; then
+    printf -v c '\033[38;2;%sm %s✗\033[0m' "$RED" "$ci_fail"; p+="$c"
+  fi
+  if [[ "${ci_pend:-0}" -gt 0 ]] 2>/dev/null; then
+    printf -v c '\033[38;2;%sm %s⏳\033[0m' "$AMBER" "$ci_pend"; p+="$c"
+  fi
+  # Gemini badge: only when there are unresolved gemini threads
+  if [[ "${gemini_unresolved:-0}" -gt 0 ]] 2>/dev/null; then
+    printf -v g '\033[38;2;%sm ✦%s\033[0m' "$GEMINI" "$gemini_unresolved"; p+="$g"
+  fi
   parts+=("$p")
 fi
 
@@ -167,9 +197,13 @@ fi
 printf -v p '\033[38;2;%sm%s\033[0m' "$BLUE" "$short_model"
 parts+=("$p")
 
-# Context % + cache warmth + heart + time (one trailing part)
+# Context % + session token totals + cache warmth + heart + time (one part)
 p=""
 [[ -n "$used_pct" ]] && printf -v p '\033[38;2;%sm%.0f%%\033[0m ' "$DIM" "$used_pct"
+if [[ -n "$total_in" && -n "$total_out" ]]; then
+  printf -v tok '\033[38;2;%sm%s↓/%s↑\033[0m ' "$DIM" "$(fmt_tokens "$total_in")" "$(fmt_tokens "$total_out")"
+  p+="$tok"
+fi
 if [[ -n "$cache_glyph" ]]; then
   printf -v c '\033[38;2;%sm%s%s\033[0m ' "$cache_fg" "$cache_glyph" "$cache_remaining"
   p+="$c"

--- a/exact_dot_claude/executable_statusline-command.sh
+++ b/exact_dot_claude/executable_statusline-command.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 # ~/.claude/statusline-command.sh
-# Powerline / Starship-inspired status line for Claude Code
-# Segment colors and order match ~/.config/starship.toml
+# Minimal colored-text status line for Claude Code.
+# Foreground colors on the terminal's own background (no filled blocks), so a
+# mid-line truncation just drops trailing text — it can never leave a color
+# escape unclosed and bleed into the rest of the UI. Accent palette is borrowed
+# from ~/.config/starship.toml.
 #
-# Extra features beyond the base Starship style:
+# Extra features beyond plain dir/branch/model:
 #   - Gemini PR review badge: count of UNRESOLVED gemini-code-assist[bot]
 #     review threads on the current PR (cached, refreshed in the background
 #     so rendering never blocks on a network call).
@@ -13,20 +16,18 @@
 
 input=$(cat)
 
-# Truecolor RGB values matching starship.toml segment palette
-PURPLE="154;52;142"   # #9A348E — opening segment (username/os in Starship)
-ORANGE="252;161;125"  # #FCA17D — git branch in Starship
-TEAL="6;150;154"      # #06969A — docker context in Starship (PR info here)
-BLUE="134;187;216"    # #86BBD8 — language runtimes in Starship (model name here)
-DARKBLUE="51;101;138" # #33658A — time segment in Starship
-BLACK="0;0;0"
-WHITE="255;255;255"
-GEMINI="138;180;248"  # #8AB4F8 — Google blue, gemini badge fg
+# Truecolor RGB accent palette (used as foreground; brightened from the
+# starship.toml hexes where needed for legibility on a dark background)
+PURPLE="186;104;200"  # directory
+ORANGE="252;161;125"  # git branch (#FCA17D)
+TEAL="38;186;190"     # PR info
+BLUE="134;187;216"    # model name (#86BBD8)
+GEMINI="138;180;248"  # #8AB4F8 — Google blue, gemini badge
 WARM="255;176;102"    # warm amber — cache-warm glyph
 COLD="150;180;205"    # cool dim — cache-cold glyph
-
-# U+E0B0 Powerline solid right arrow (requires Nerd Font; kitty + Starship implies this)
-ARROW=$(printf '\xee\x82\xb0')
+HEART="235;110;120"   # soft red — time heart
+DIM="150;160;170"     # context % and separators
+SEP="90;95;105"       # separator dots
 
 # Extract JSON fields
 current_dir=$(echo "$input" | jq -r '.workspace.current_dir // .cwd // empty')
@@ -42,15 +43,15 @@ now=$(date +%s)
 cache_dir="${TMPDIR:-/tmp}/cc-statusline"
 mkdir -p "$cache_dir" 2>/dev/null
 
-# Directory: replace HOME with ~ then truncate to last 3 components
-# (mirrors Starship's truncation_length = 3 and truncation_symbol = "…/")
+# Directory: replace HOME with ~ then truncate to last 2 components
 dir="${current_dir/$HOME/~}"
 dir=$(echo "$dir" | awk -F'/' '{
-  if (NF > 3) { print "…/" $(NF-2) "/" $(NF-1) "/" $NF }
+  if (NF > 2) { print "…/" $(NF-1) "/" $NF }
   else         { print $0 }
 }')
 
-# Git branch + dirty indicator (local only, no network)
+# Git branch + dirty indicator (local only, no network). Long branch names are
+# middle-truncated so they cannot dominate the line width.
 git_branch=""
 git_dirty=""
 if git -C "$current_dir" rev-parse --git-dir >/dev/null 2>&1; then
@@ -58,6 +59,9 @@ if git -C "$current_dir" rev-parse --git-dir >/dev/null 2>&1; then
   if [[ -n "$git_branch" ]]; then
     git_porcelain=$(git -C "$current_dir" status --porcelain 2>/dev/null || echo "")
     [[ -n "$git_porcelain" ]] && git_dirty="*"
+    if [[ "${#git_branch}" -gt 20 ]]; then
+      git_branch="${git_branch:0:5}…${git_branch: -11}"
+    fi
   fi
 fi
 
@@ -127,51 +131,58 @@ if [[ -n "$transcript" && -f "$transcript" ]]; then
   fi
 fi
 
-# ── Powerline segments ────────────────────────────────────────────────────────
-prev_bg="$PURPLE"
+# ── Render: colored text, joined by dim separators ───────────────────────────
+# Each part carries its own color and a trailing reset, so any truncation by
+# the TUI is harmless. Parts are collected, then joined with " · ".
+parts=()
 
-# Segment 1: Purple — directory (Starship: username + directory)
-printf "\033[48;2;%sm\033[38;2;%sm  %s " "$PURPLE" "$WHITE" "$dir"
+# Directory
+printf -v p '\033[38;2;%sm%s\033[0m' "$PURPLE" "$dir"
+parts+=("$p")
 
-# Segment 2: Orange — git branch + dirty flag (Starship: git_branch + git_status)
+# Git branch + dirty flag
 if [[ -n "$git_branch" ]]; then
-  printf "\033[38;2;%sm\033[48;2;%sm%s\033[38;2;%sm  %s%s " \
-    "$prev_bg" "$ORANGE" "$ARROW" "$BLACK" "$git_branch" "$git_dirty"
-  prev_bg="$ORANGE"
+  printf -v p '\033[38;2;%sm%s%s\033[0m' "$ORANGE" "$git_branch" "$git_dirty"
+  parts+=("$p")
 fi
 
-# Segment 3: Teal — PR info + gemini review badge (Starship: docker_context)
+# PR info + gemini review badge
 if [[ -n "$pr_number" ]]; then
-  printf "\033[38;2;%sm\033[48;2;%sm%s\033[38;2;%sm  PR#%s" \
-    "$prev_bg" "$TEAL" "$ARROW" "$WHITE" "$pr_number"
+  printf -v p '\033[38;2;%smPR#%s' "$TEAL" "$pr_number"
   case "$pr_state" in
-    approved)          printf " [ok]" ;;
-    changes_requested) printf " [!]" ;;
-    draft)             printf " [draft]" ;;
+    approved)          p+=" ✓" ;;
+    changes_requested) p+=" ✗" ;;
+    draft)             p+=" draft" ;;
   esac
   # Gemini badge: only when there are unresolved gemini threads
   if [[ -n "$gemini_unresolved" && "$gemini_unresolved" -gt 0 ]] 2>/dev/null; then
-    printf "\033[38;2;%sm ✦%s\033[38;2;%sm" "$GEMINI" "$gemini_unresolved" "$WHITE"
+    printf -v g '\033[38;2;%sm ✦%s' "$GEMINI" "$gemini_unresolved"
+    p+="$g"
   fi
-  printf " "
-  prev_bg="$TEAL"
+  p+=$'\033[0m'
+  parts+=("$p")
 fi
 
-# Segment 4: Blue — model name (Starship: language runtimes)
-printf "\033[38;2;%sm\033[48;2;%sm%s\033[38;2;%sm  %s " \
-  "$prev_bg" "$BLUE" "$ARROW" "$BLACK" "$short_model"
-prev_bg="$BLUE"
+# Model name
+printf -v p '\033[38;2;%sm%s\033[0m' "$BLUE" "$short_model"
+parts+=("$p")
 
-# Segment 5: Dark blue — context % + cache warmth + heart + time
-printf "\033[38;2;%sm\033[48;2;%sm%s\033[38;2;%sm " \
-  "$prev_bg" "$DARKBLUE" "$ARROW" "$WHITE"
-[[ -n "$used_pct" ]] && printf "%.0f%% " "$used_pct"
+# Context % + cache warmth + heart + time (one trailing part)
+p=""
+[[ -n "$used_pct" ]] && printf -v p '\033[38;2;%sm%.0f%%\033[0m ' "$DIM" "$used_pct"
 if [[ -n "$cache_glyph" ]]; then
-  printf "\033[38;2;%sm%s\033[38;2;%sm" "$cache_fg" "$cache_glyph" "$WHITE"
-  [[ -n "$cache_remaining" ]] && printf "%s" "$cache_remaining"
-  printf " "
+  printf -v c '\033[38;2;%sm%s%s\033[0m ' "$cache_fg" "$cache_glyph" "$cache_remaining"
+  p+="$c"
 fi
-printf "♥ %s " "$(date +%H:%M)"
+printf -v t '\033[38;2;%sm♥\033[0m\033[38;2;%sm%s\033[0m' "$HEART" "$DIM" "$(date +%H:%M)"
+p+="$t"
+parts+=("$p")
 
-# Closing arrow back to terminal default background
-printf "\033[0m\033[38;2;%sm%s\033[0m\n" "$DARKBLUE" "$ARROW"
+# Join with dim separator
+printf -v sep '\033[38;2;%sm · \033[0m' "$SEP"
+out=""
+for i in "${!parts[@]}"; do
+  [[ "$i" -gt 0 ]] && out+="$sep"
+  out+="${parts[$i]}"
+done
+printf '%s\n' "$out"

--- a/exact_dot_claude/executable_statusline-command.sh
+++ b/exact_dot_claude/executable_statusline-command.sh
@@ -31,6 +31,7 @@ SEP="90;95;105"       # separator dots
 GREEN="126;200;130"   # CI passing
 RED="235;110;120"     # CI failing
 AMBER="230;190;110"   # CI pending
+WT="180;160;230"      # lavender — linked-worktree marker
 
 # Format a token count with a K suffix (8500→8.5K, 84000→84K)
 fmt_tokens() {
@@ -52,22 +53,29 @@ pr_number=$(echo "$input" | jq -r '.pr.number // empty')
 pr_state=$(echo "$input" | jq -r '.pr.review_state // empty')
 repo_owner=$(echo "$input" | jq -r '.workspace.repo.owner // empty')
 repo_name=$(echo "$input" | jq -r '.workspace.repo.name // empty')
+wt_name=$(echo "$input" | jq -r '.workspace.git_worktree // .worktree.name // empty')
 
 now=$(date +%s)
 cache_dir="${TMPDIR:-/tmp}/cc-statusline"
 mkdir -p "$cache_dir" 2>/dev/null
 
-# Directory: replace HOME with ~ then truncate to last 2 components
-dir="${current_dir/$HOME/~}"
-dir=$(echo "$dir" | awk -F'/' '{
-  if (NF > 2) { print "…/" $(NF-1) "/" $NF }
-  else         { print $0 }
-}')
+# Location: prefer owner/repo (present when there's a GitHub origin remote),
+# otherwise fall back to the HOME-relative path truncated to its last 2 parts.
+if [[ -n "$repo_owner" && -n "$repo_name" ]]; then
+  loc="$repo_owner/$repo_name"
+else
+  loc="${current_dir/$HOME/~}"
+  loc=$(echo "$loc" | awk -F'/' '{
+    if (NF > 2) { print "…/" $(NF-1) "/" $NF }
+    else         { print $0 }
+  }')
+fi
 
-# Git branch + dirty indicator (local only, no network). Long branch names are
-# middle-truncated so they cannot dominate the line width.
+# Git branch + dirty + worktree indicator (local only, no network). Long branch
+# names are middle-truncated so they cannot dominate the line width.
 git_branch=""
 git_dirty=""
+git_worktree=""
 if git -C "$current_dir" rev-parse --git-dir >/dev/null 2>&1; then
   git_branch=$(git -C "$current_dir" branch --show-current 2>/dev/null || echo "")
   if [[ -n "$git_branch" ]]; then
@@ -76,6 +84,14 @@ if git -C "$current_dir" rev-parse --git-dir >/dev/null 2>&1; then
     if [[ "${#git_branch}" -gt 20 ]]; then
       git_branch="${git_branch:0:5}…${git_branch: -11}"
     fi
+  fi
+  # Linked worktree: JSON hint, or an absolute git-dir under .../worktrees/<name>
+  # (the main working tree's git-dir is plain .../.git, with no worktrees/ path).
+  if [[ -n "$wt_name" ]]; then
+    git_worktree=1
+  else
+    git_dir_abs=$(git -C "$current_dir" rev-parse --absolute-git-dir 2>/dev/null || echo "")
+    [[ "$git_dir_abs" == */worktrees/* ]] && git_worktree=1
   fi
 fi
 
@@ -164,13 +180,16 @@ fi
 line1=()  # directory · branch · PR (+CI +gemini)
 line2=()  # model · context/tokens · cache · time
 
-# Row 1 — Directory
-printf -v p '\033[38;2;%sm%s\033[0m' "$PURPLE" "$dir"
+# Row 1 — Location (owner/repo, or path fallback)
+printf -v p '\033[38;2;%sm%s\033[0m' "$PURPLE" "$loc"
 line1+=("$p")
 
-# Row 1 — Git branch + dirty flag
+# Row 1 — Git branch + dirty flag, prefixed with ⑂ when on a linked worktree
 if [[ -n "$git_branch" ]]; then
-  printf -v p '\033[38;2;%sm%s%s\033[0m' "$ORANGE" "$git_branch" "$git_dirty"
+  p=""
+  [[ -n "$git_worktree" ]] && printf -v p '\033[38;2;%sm⑂\033[0m' "$WT"
+  printf -v b '\033[38;2;%sm%s%s\033[0m' "$ORANGE" "$git_branch" "$git_dirty"
+  p+="$b"
   line1+=("$p")
 fi
 


### PR DESCRIPTION
## What

Two new indicators on the Starship-inspired Claude Code statusline (`exact_dot_claude/executable_statusline-command.sh`).

### Gemini PR review badge
A Google-blue `✦N` appears in the teal PR segment showing the count of **unresolved** `gemini-code-assist[bot]` review threads on the current PR.

- Uses a `gh api graphql` query over `reviewThreads`, filtered to gemini-authored, `isResolved == false`.
- **Never runs inline**: each render reads a cached count from `$TMPDIR/cc-statusline/`; when the cache is stale (>90s) it spawns a single-flight, lock-guarded detached background refresh. Rendering stays instant — the network call updates the badge on a later frame.
- Badge disappears once the threads are resolved.

### Cache-warmth indicator
In the time segment, a warm amber `♨` + `M:SS` countdown shows while the Anthropic prompt cache is still alive, flipping to a dim `❄` once the 5-minute (300s) TTL lapses. Derived from the transcript file's mtime as a proxy for time since the last turn.

## Notes

- Driven entirely by the documented statusline JSON (`pr.*`, `workspace.repo.*`, `context_window.used_percentage`, `transcript_path`) — no extra settings. The `statusLine` key is already pinned in the `modify_settings.json` overlay.
- Falls back gracefully: no PR → no PR/Gemini segment; no `gh` → no badge; missing transcript → no cache glyph.

## Test

Rendered against synthetic warm/cold + with/without-PR payloads; the background refresh correctly populated `✦1` for FVH/infrastructure#2101 (1 unresolved Gemini thread). `chezmoi diff` is clean (idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)