### PR TITLE
docs(claude): global rules batch + auto-mode hook deferral, routines note

### DIFF
--- a/dot_zfunc/_claude
+++ b/dot_zfunc/_claude
@@ -166,6 +166,8 @@ _claude_mcp() {
         'get:<name> Get details about an MCP server.'
         'help:display help for command'
         'list:List configured MCP servers. Unapproved'
+        'login:<name> Authenticate with an MCP server (HTTP,'
+        'logout:<name> Clear stored OAuth credentials for an'
         'remove:<name> Remove an MCP server'
         'reset-project-choices:Reset all approved and rejected'
         'serve:Start the Claude Code MCP server'

--- a/exact_dot_claude/rules/claude-code-auto-mode.md
+++ b/exact_dot_claude/rules/claude-code-auto-mode.md
@@ -44,6 +44,34 @@ any mode except `bypassPermissions`. Keep dangerous ops in `deny`
 (`git push --force *`, `git add -A`, `kubectl config use-context *`,
 `Write(**/CHANGELOG.md)`).
 
+## Custom hooks vs. auto mode — don't double-gate
+
+A custom PreToolUse/UserPromptSubmit hook that re-implements a safety check
+auto mode already does (push-to-protected-branch, force-push, prod-deploy)
+**double-gates** under auto mode — and usually more bluntly, because the hook
+lacks the classifier's environment context. Auto mode classifies the **actual
+tool call** with full context (CLAUDE.md, trusted repos, `soft_deny`), and its
+denials surface in `/permissions → Recently denied`, **never** as "Operation
+stopped by hook" — that phrasing is always a *hook*, not auto mode.
+
+When a hook overlaps auto mode, make it **defer**:
+
+- **`command` hooks receive `permission_mode`** (a common hook-input field;
+  value `"auto"` among `default`/`plan`/`acceptEdits`/`dontAsk`/
+  `bypassPermissions`). Have the hook `exit 0` when
+  `permission_mode == "auto"` and enforce otherwise. This stops the
+  double-gate while keeping the deterministic hook as a fallback exactly where
+  auto mode can't reach — web/remote/CI and non-Opus sessions where auto mode
+  is gated off. `PERMISSION_MODE=$(jq -r '.permission_mode // empty'); [ "$PERMISSION_MODE" = "auto" ] && exit 0`.
+- **`type:"prompt"` hooks can't self-gate** — they get only `$ARGUMENTS` (the
+  raw prompt text), not `permission_mode`, and they judge text with zero exec
+  context. They false-positive on benign phrasings (e.g. the bare token "push"
+  in a `/git-conflicts <pr> --push` slash command → "push to protected
+  branch"). If auto mode covers the concern, **remove** the prompt hook rather
+  than trying to soften it; auto mode + deterministic Bash hooks cover the real
+  cases with context and no per-prompt LLM cost. (laurigates/claude-plugins
+  hooks-plugin #1765.)
+
 ## The `autoMode` block is the real lever
 
 Separate from `permissions`; user-settable in `~/.claude/settings.json` (it is

--- a/exact_dot_claude/rules/read-issue-thread-before-contributing.md
+++ b/exact_dot_claude/rules/read-issue-thread-before-contributing.md
@@ -1,0 +1,76 @@
+# Read the Full Issue Thread Before Scoping a Contribution
+
+Before building a PR (or even an approach) off a GitHub issue, **read every
+comment in the thread** — not a fetched summary, not just the body. Issues that
+look like simple feature requests are often where the maintainer has already
+**converged on a specific design** with other experts. A summary compresses
+exactly the part that matters: the decided mechanism, the agreed scope, and the
+work someone has already volunteered to do.
+
+## The trap
+
+`WebFetch` (and any "summarize this issue" step) returns a *compressed* view. It
+faithfully captures the issue **body** and headline asks, but silently drops the
+back-and-forth in the comments where the real decisions live. You then design
+against the body's framing, build a prototype, and discover — only if you go
+back and read the comments — that:
+
+- the maintainer picked a **different mechanism** than the obvious one,
+- the **scope** (MUST / WANT / NICE / OUT) was explicitly bounded,
+- a dependency was **already prototyped** by a collaborator (and may be
+  unreleased, so half your plan isn't even buildable yet),
+- your "open questions" were **already answered** in the thread — so asking them
+  reads as not having done the homework.
+
+> Canonical break (jnv #114 → PR #116, 2026-06): a WebFetch summary presented the
+> issue as "extend completion beyond JSON paths." The actual 33-comment thread was
+> a design discussion in which the maintainer and the jaq author had converged on
+> **token-based segmentation** (jaq's `load::lex` token trees) plus a new `yield`
+> filter (an *unmerged* jaq PR) for the in-paren case, with an explicit scope
+> ladder. We built a byte-scanner PoC and a PR body that re-litigated settled
+> questions — caught only when the user asked "did we check all the comments?"
+> The PR had to be reframed before it was safe to surface.
+
+## The rule
+
+When an issue is the basis for a contribution, read the comments **first**:
+
+```sh
+gh issue view <n> --repo <owner>/<repo> --json title,body,author,comments \
+  --jq '.body, (.comments[] | "--- " + .author.login + " ---\n" + .body)'
+```
+
+Specifically extract, before writing any code:
+
+1. **Decided mechanism** — has the maintainer chosen an implementation approach?
+   Build *that*, or explicitly propose an alternative knowing theirs exists.
+2. **Scope ladder** — MUST / WANT / NICE / OUT. Don't attempt OUT; don't skip MUST.
+3. **Dependencies in flight** — linked PRs/branches a collaborator is building.
+   Check their state (`gh pr view` → merged? released?) before depending on them.
+4. **Who's driving** — if the maintainer is mid-collaboration with another expert,
+   a drive-by PR may duplicate their work. Ask whether a contribution is welcome
+   *before* investing, and frame the PR as building on the thread, not restarting it.
+
+If you only have a summary and a gap has passed, **re-read the live thread** before
+acting — the discussion may have moved.
+
+## When it bites
+
+- Any external contribution scoped from an issue, especially a popular repo where
+  maintainers discuss design in comments.
+- Resuming work on an issue days later from a cached summary.
+- Letting an early `WebFetch`/research step stand in for the primary source.
+
+## Relationship to sibling rules
+
+- `verify-upstream-before-patching.md` — same instinct (check the authoritative
+  source before acting) for vendored code; this is the issue-thread analogue.
+- `tool-use-patterns.md` (WebFetch) — a summary is lossy; for a decision that
+  gates real work, go to the full source, not the fetched digest.
+
+## Rationale
+
+The cost asymmetry is stark: reading the thread is one `gh issue view` and a few
+minutes; skipping it costs a misaligned prototype, a PR that signals you didn't
+read the discussion, and a reframe-or-close under the maintainer's eye. The full
+thread is the spec; the summary is a lossy proxy for it.

--- a/exact_dot_claude/rules/squash-merge-orphans-post-merge-commits.md
+++ b/exact_dot_claude/rules/squash-merge-orphans-post-merge-commits.md
@@ -1,0 +1,84 @@
+# Squash-Merge Orphans Commits Added After the Merge
+
+A squash-merge collapses a branch's commits into **one new commit on `main`
+with a fresh SHA**. The branch's own commits keep their original SHAs and are
+never ancestors of `main`. So any commit you add to that branch *after* the
+squash-merge is **orphaned**: its content is in neither `main` nor the squashed
+commit. The branch still exists and still looks like it has unmerged work — but
+a new branch cut from `origin/main` silently lacks those post-merge commits.
+
+The failure is invisible at branch-create time. You `git switch -c follow-up
+origin/main`, write code that depends on a symbol or file you "know" is there
+(because you wrote it), and only a test import or a `git grep` reveals `main`
+never received it.
+
+## The trap (real: research PR #7 → PR #13, 2026-06)
+
+```
+# PR #7 squash-merged an EARLY state of feat/reddit-discovery-curation.
+# Two more commits were then added to that same branch:
+#   3dd9733  feat: keep reddit content out of the classifier  (adds _is_reddit_sourced)
+#   bfc1427  docs: note reddit secrets are gitops-managed
+# Neither reached main — the squash predated them.
+
+git switch -c follow-up origin/main        # branch lacks _is_reddit_sourced
+# new tests do:  from tag import _is_reddit_sourced   → ImportError on main
+git grep _is_reddit_sourced origin/main -- scripts/tag.py   # → nothing. Confirmed orphaned.
+```
+
+`gh pr view <branch>` reported PR #7 **merged**, which read as "the branch's
+work is in `main`" — but only the *squashed prefix* was. The post-merge commits
+were stranded on the (now-redundant-looking) feature branch.
+
+## The rule
+
+**Before branching off `origin/main` for follow-up work, verify `main` actually
+contains the code your new work depends on** — don't trust "the PR merged."
+Cheap checks, in order:
+
+```sh
+git fetch origin
+git grep <symbol> origin/main -- <path>          # is the symbol/function there?
+git show origin/main:<path> | grep <thing>       # is this file's content there?
+git log --oneline origin/main | head             # did the squash land what you think?
+```
+
+If the dependency is missing, the work lives in orphaned commits on the old
+branch. **Recover by replaying only those commits** onto `origin/main` with
+`--onto`, dropping the already-squashed prefix:
+
+```sh
+# <squashed-base> = the last commit whose content IS already in main (the squash point)
+git rebase --onto origin/main <squashed-base> <your-branch>
+git log --oneline origin/main..HEAD              # verify: ONLY the orphaned + new commits
+```
+
+This replays the post-merge commits (and your new ones) cleanly. Conflicts here
+are expected if `main` advanced past the squash with fixes touching the same
+files — resolve by keeping both (the merged fix AND the orphaned change).
+
+## When it bites
+
+- A PR squash-merged while you (or a teammate) kept committing to its branch.
+- Resuming a "merged" feature days later and branching fresh off `main`.
+- Any follow-up whose tests/imports reference symbols added late on a
+  squash-merged branch — the import error is the first signal, far downstream
+  of the real cause.
+
+## Relationship to sibling rules
+
+- `stacked-pr-merge-order.md` — the *other* squash hazard: a **stacked child
+  PR** auto-closes when its base branch is deleted. Shares the `git rebase
+  --onto` recovery mechanic; different trigger (a stack vs. post-merge commits
+  on one branch).
+- The instinct is the same as `verify-upstream-before-patching.md`: confirm the
+  authoritative state (`origin/main`) before acting, rather than trusting a
+  proxy signal ("the PR says merged").
+
+## Rationale
+
+"PR merged" and "my branch's full history is in `main`" are different claims
+under squash-merge, and the gap is exactly the commits added after the merge.
+One `git grep origin/main` before branching converts a silent missing-dependency
+hunt (import error → re-diagnosis → `--onto` rebase under time pressure) into a
+five-second check.

--- a/exact_dot_claude/rules/textual-merge-duplicates-identical-additions.md
+++ b/exact_dot_claude/rules/textual-merge-duplicates-identical-additions.md
@@ -1,0 +1,94 @@
+# A Textual Auto-Merge Silently Duplicates an Identical Addition Both Branches Made
+
+`git merge` resolves line-by-line, not semantically. When **two branches each
+add the same logical thing independently** — the same helper function, the same
+`use` import, the same enum arm, the same config key — and the additions land in
+**non-adjacent regions** of the file, git sees no overlapping hunk, declares
+`Automatic merge went well`, and **keeps both copies**. The result is a
+duplicate definition that does not compile (or a double import / double key the
+compiler or linter rejects), produced by a merge that reported success.
+
+The failure is invisible at merge time: there is no conflict, no marker, no
+prompt. `git status` is clean, the merge commit is ready, and only a build
+surfaces it — `the name ... is defined multiple times`, `duplicate definition`,
+`E0428`, a redeclaration error, etc.
+
+## The trap (real: jnv dogfood integration, 2026-06)
+
+Two feature branches each needed a cursor primitive and each added the **same**
+`set_cursor` helper to `query_editor.rs`:
+
+- `feat/context-aware-completion` added `fn set_cursor` near its
+  `replace_text_at`.
+- `feat/vi-editing` added an identical `fn set_cursor` in its vi block.
+
+Merging the second into the combined branch:
+
+```
+$ git merge --no-commit --no-ff feat/context-aware-completion
+Auto-merging src/query_editor.rs
+Automatic merge went well; stopped before committing as requested
+```
+
+…yet the merged file held **two** `fn set_cursor` definitions (the additions
+were ~20 lines apart, so no hunk overlapped). `cargo build` then failed with a
+duplicate-definition error. The merge "succeeding" is exactly what makes this
+bite — you trust the green message and commit a tree that cannot compile.
+
+## The rule
+
+- **Verify every non-trivial merge by building/testing, not by the merge
+  message.** `Automatic merge went well` means "no overlapping line hunks," not
+  "the result is correct." Run the compiler / `cargo build` / `cargo test` /
+  the linter on the merged tree before committing the merge.
+- **When two branches are known to add overlapping helpers** (the same util, the
+  same import, the same enum variant — common when sibling feature branches
+  solve related problems), **don't trust the auto-merge**: grep the merged file
+  for duplicates and hand-resolve to a single combined version.
+
+```sh
+# After a merge of branches that may both add the same symbol:
+git merge --no-commit --no-ff <branch>
+cargo build 2>&1 | grep -iE 'defined multiple times|duplicate'   # or your toolchain's check
+grep -c 'fn set_cursor' src/query_editor.rs                      # expect 1, not 2
+```
+
+If a duplicate is present, replace the file with the intended **single**
+combined version (keep one definition; merge the surrounding feature-specific
+code by hand) rather than accepting git's two-copy output.
+
+## When it bites
+
+- Integrating sibling feature branches that independently grew the same helper /
+  import / arm — especially a long-lived integration branch (a `dogfood` build)
+  merging several `feat/*` branches that each touched a shared file.
+- Cherry-picking or rebasing where the same fix was applied on two lines that
+  don't textually collide.
+- Any language where a duplicate symbol is a hard error (Rust, Go, C/C++,
+  TypeScript with `noRedeclare`); in looser languages the second copy silently
+  shadows the first instead — worse, because nothing errors at all.
+
+## Relationship to sibling rules
+
+Same instinct as the other merge-hazard rules — *a merge that reports success is
+not proof the result is correct*:
+
+- `squash-merge-orphans-post-merge-commits.md` — "PR merged" ≠ "all the branch's
+  commits are in main."
+- `stacked-pr-merge-order.md` — a stacked child auto-closes (not retargets) when
+  its base branch is deleted.
+- `shared-checkout-branch-isolation.md` — a commit can land on the wrong branch
+  with no error.
+
+This one is the *content*-level analogue: a clean merge can still produce a
+broken tree. The check is one build (or one `grep -c`) on the merged result
+before committing.
+
+## Rationale
+
+The green `merge went well` reads as a verdict on correctness; it is only a
+verdict on line adjacency. The gap is exactly the case where two branches did
+the same work in different places — increasingly common as parallel agents and
+sibling feature branches solve related problems independently. One compile of
+the merged tree before committing converts a silent duplicate-definition (caught
+later, mid-integration, under time pressure) into a five-second check.

--- a/exact_dot_claude/rules/tui-markdown-rendering.md
+++ b/exact_dot_claude/rules/tui-markdown-rendering.md
@@ -1,0 +1,83 @@
+---
+paths:
+  - "**/*.rs"
+  - "**/tui/**"
+  - "**/*markdown*"
+---
+
+# Rendering Markdown in a TUI With a Row-Precise Scroll Model
+
+**Scope**: rendering GitHub-flavored (or any) markdown bodies inside a
+terminal UI — `ratatui`/`crossterm` apps like `gh-board` and `eval-tui`,
+or anything that pre-wraps styled lines and scrolls by *visual row*. Skip
+for web/Markdown-to-HTML.
+
+## The trap
+
+Reaching for an off-the-shelf TUI markdown crate (`tui-markdown` is the
+obvious one) looks like the cheap path, but it carries two behaviors that
+quietly break a scrollable detail view:
+
+1. **Soft breaks collapse to spaces.** `tui-markdown` follows CommonMark,
+   where a *single* newline inside a paragraph is a soft break rendered as
+   a space — so `"Line 0\nLine 1\nLine 2"` becomes one reflowed paragraph.
+   GitHub renders body/comment newlines as `<br>` (hard breaks), so the
+   crate's output **diverges from how the source actually looks on
+   GitHub**.
+2. **It silently breaks "one source line = one visual row."** Any TUI that
+   pre-wraps to the inner width and scrolls a known number of *rows* (the
+   only way to get exact, row-precise scrolling once wrapping is on — see
+   `gh-board/src/tui/wrap.rs`) depends on a stable row count. Paragraph
+   reflow changes the row count nondeterministically, so scroll clamps,
+   "scroll to bottom", and comment-into-view math all drift. Tests that
+   assert one row per source line (a common shape) fail.
+
+A third, smaller annoyance: `tui-markdown` keeps **block** markers literal
+(`## Heading`, `- item` render with the `##`/`-` intact, merely styled)
+while stripping **inline** markers (`` ` ``, `*`) — an inconsistent read.
+
+## The rule
+
+For a scrollable TUI detail/body view, **hand-roll the renderer on
+`pulldown-cmark`** rather than adopting an opinionated rendering crate:
+
+- **Map soft *and* hard breaks to a row break** (`Event::SoftBreak |
+  Event::HardBreak ⇒ new line`). This restores GitHub fidelity *and* keeps
+  one source line = one visual row, so the scroll math stays exact.
+- **Keep width out of the renderer.** Emit clean, un-indented styled
+  `Vec<Line>`; let the caller add the body indent / comment gutter, and a
+  separate wrap pass do the column wrapping. A width-free renderer is pure
+  (`&str` in, lines out) and directly unit-testable — no `Rect`.
+- **Strip every marker, style by role**: headings bold+underline, inline
+  and fenced code tinted (code blocks behind a `│ ` gutter), lists →
+  bullets/ordinals, blockquotes → `▌ ` gutter + dim italic, links → blue
+  underline (drop the URL in a non-clickable view), task lists → glyphs,
+  thematic breaks → a rule line.
+
+This mirrors the established `wrap.rs`-over-`textwrap` precedent: when
+fidelity and a load-bearing invariant (here, row-precise scrolling) are at
+stake, a controlled ~450-line hand-roll beats fighting a crate's
+assumptions, and every behavior gets a test.
+
+## When it bites
+
+- A `ratatui` app showing issue/PR/comment bodies, logs, or any markdown
+  in a scrollable pane (gh-board's zoomed detail; eval-tui transcripts).
+- Porting the same "render markdown in a box" need between TUI projects —
+  the soft-break reflow is invisible until a multi-line body scrolls wrong
+  or a line-per-row test fails.
+
+## Verify
+
+A one-shot probe settles the crate's behavior before you commit to it:
+
+```
+cargo new --quiet /tmp/md-probe && cd /tmp/md-probe && cargo add tui-markdown ratatui
+# render "a\nb\nc" and print line count — 1 line (reflowed) vs 3 confirms the trap
+```
+
+## Ref
+
+- Evidence: `laurigates/gh-board` PR #46 (`src/tui/markdown.rs`,
+  `src/tui/wrap.rs`).
+- `pulldown-cmark` events: <https://docs.rs/pulldown-cmark>.

--- a/private_repos/private_CLAUDE.md
+++ b/private_repos/private_CLAUDE.md
@@ -17,6 +17,10 @@ This directory contains project repositories organized by owner/origin. Running 
 
 Run `/repo-activity` (user-global skill) to scan all repos and see recent activity: last commit info, active projects, uncommitted changes, and current branches.
 
+### Scheduled Routines
+
+Run `just routines` to list the portfolio's scheduled jobs (macOS LaunchAgents in `.routines/`) with live status — schedule, load state, run count, last exit, last run, and log path. The routines and how to choose a scheduler substrate (LaunchAgent vs cloud routine vs Desktop task) are documented in `.routines/README.md`. These are experimental/stop-gap; promote useful ones to a cloud routine or CI.
+
 ### Podio Ticket Management
 
 See `ForumViriumHelsinki/CLAUDE.md` for Podio Kanban workflows; `/podio-ticket-updates` is an FVH-scoped skill (`ForumViriumHelsinki/.claude/skills/`).


### PR DESCRIPTION
## Summary

Documentation/config maintenance batch for the dotfiles repo:

- **Global rules (`exact_dot_claude/rules/`)** — four new friction-captured rules plus an auto-mode extension:
  - `read-issue-thread-before-contributing` — read every comment before scoping a PR off an issue; summaries drop the decided design.
  - `squash-merge-orphans-post-merge-commits` — commits added after a squash-merge are orphaned; verify `origin/main` has the dependency before branching.
  - `textual-merge-duplicates-identical-additions` — a clean auto-merge can keep both copies when two branches add the same helper in non-adjacent regions.
  - `tui-markdown-rendering` — hand-roll on `pulldown-cmark` for row-precise TUI scrolling instead of adopting `tui-markdown`'s reflow.
  - `claude-code-auto-mode` — new "don't double-gate" section on deferring custom hooks under auto mode (`command` hooks check `permission_mode`; remove `prompt` hooks auto mode already covers).
- **`chore(zsh)`** — regenerate the `claude` zsh completion to pick up `claude mcp login`/`logout`.
- **`docs(repos)`** — note the experimental `just routines` scheduler workflow in `private_CLAUDE.md`.

All changes are docs/config; no behavioral code. Pre-commit (incl. secret scan) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
