### PR TITLE
feat(claude): add chezmoi drift-capture workflow + apply guard

### DIFF
--- a/exact_dot_claude/hooks/executable_chezmoi-drift-guard.sh
+++ b/exact_dot_claude/hooks/executable_chezmoi-drift-guard.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) — WARN (never block) when `chezmoi apply` would overwrite
+# local target edits that have not yet been captured into the source.
+#
+# `chezmoi apply` renders source → target, silently clobbering any edits made
+# directly to a target file. That is the exact data-loss this repo's
+# capture-drift workflow exists to prevent. Unlike apply-time DELETIONS
+# (handled by chezmoi-exact-guard.sh, which BLOCKS), overwriting target edits
+# is *often intentional* — so this guard only warns and lets the apply proceed,
+# surfacing the drift + the capture command via additionalContext.
+#
+# Detection: `chezmoi status` FIRST column == M, i.e. the target was modified
+# since chezmoi last wrote it (genuine local drift). This deliberately does NOT
+# use `chezmoi re-add --dry-run` / the status SECOND column, which flag any
+# source≠target delta and so fire on the normal "edit source, then apply" flow —
+# crying wolf on every apply that follows a source edit (chezmoi issue #4180's
+# ambiguity). Column 1 isolates real target drift. `just capture-drift` lists
+# specifics incl. templated sources (which need `chezmoi merge`, not re-add).
+# See rules/chezmoi-conventions.md ("re-add Skips Templates").
+#
+# Registered user-globally (modify_settings.json) so it fires regardless of cwd.
+set -euo pipefail
+
+input=$(cat)
+
+tool=$(jq -r '.tool_name // empty' <<<"$input" 2>/dev/null || echo "")
+[ "$tool" = "Bash" ] || exit 0
+
+cmd=$(jq -r '.tool_input.command // empty' <<<"$input" 2>/dev/null || echo "")
+[ -z "$cmd" ] && exit 0
+
+# Only inspect `chezmoi ... apply` invocations.
+case "$cmd" in
+    *chezmoi*apply*) ;;
+    *) exit 0 ;;
+esac
+
+# Dry runs and verbose previews write nothing — no drift to lose.
+case "$cmd" in
+    *--dry-run*|*" -n "*) exit 0 ;;
+esac
+
+command -v chezmoi >/dev/null 2>&1 || exit 0
+
+# Count targets modified since chezmoi last wrote them (status col1 == M).
+pending=$(chezmoi status 2>/dev/null | awk 'substr($0,1,1)=="M"' | grep -c . || true)
+pending=${pending:-0}
+[ "$pending" -eq 0 ] && exit 0
+
+msg="Heads-up: ${pending} chezmoi target file(s) have local edits made since chezmoi last wrote them, which this 'chezmoi apply' will OVERWRITE. If those edits are wanted, capture them first: 'just capture-drift' (preview) then 'just capture-drift-apply'. Templated sources also need 'chezmoi merge'. If the overwrite is intended, proceed."
+
+jq -nc --arg c "$msg" '{
+    hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "allow",
+        additionalContext: $c
+    }
+}'
+exit 0

--- a/exact_dot_claude/modify_settings.json
+++ b/exact_dot_claude/modify_settings.json
@@ -223,6 +223,10 @@ read -r -d '' overlay <<'OVERLAY' || true
           {
             "type": "command",
             "command": "bash ~/.claude/hooks/chezmoi-exact-guard.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/chezmoi-drift-guard.sh"
           }
         ]
       }

--- a/justfile
+++ b/justfile
@@ -47,6 +47,49 @@ verify:
     @echo "{{BLUE}}Verifying configuration integrity...{{NORMAL}}"
     chezmoi verify .
 
+# Drift = `chezmoi status` FIRST column M (target modified since chezmoi last
+# wrote it). A second-column-only change is a pending SOURCE edit, NOT drift —
+# keying on column 1 avoids flagging (and later reverting) un-applied source work.
+# Non-template files: `chezmoi re-add` captures them. Templates: re-add SKIPS
+# them, so they're listed for a manual `chezmoi merge`.
+# Preview local target edits to capture back into source (read-only). [paths...]
+capture-drift *targets:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    drift=$(chezmoi status {{targets}} 2>/dev/null | awk 'substr($0,1,1)=="M"{print substr($0,4)}')
+    if [ -z "$drift" ]; then echo "{{GREEN}}No target drift — nothing to capture.{{NORMAL}}"; exit 0; fi
+    plain=""; tmpl=""
+    while IFS= read -r t; do
+        [ -z "$t" ] && continue
+        case "$(chezmoi source-path "$HOME/$t" 2>/dev/null || true)" in
+            *.tmpl) tmpl+="    chezmoi merge ~/$t"$'\n' ;;
+            *)      plain+="    ~/$t"$'\n' ;;
+        esac
+    done <<< "$drift"
+    if [ -n "$plain" ]; then echo "{{BLUE}}Target edits re-add can capture:{{NORMAL}}"; printf '%s' "$plain"; fi
+    if [ -n "$tmpl" ]; then echo "{{YELLOW}}Drifted templates — merge by hand (re-add skips these):{{NORMAL}}"; printf '%s' "$tmpl"; fi
+    if [ -n "$plain" ]; then echo; echo "Capture non-templates: {{BOLD}}just capture-drift-apply{{NORMAL}} (append paths to scope)"; fi
+
+# Passes the drifted paths EXPLICITLY to `chezmoi re-add` so a bare re-add can't
+# also revert un-applied source edits. Skips templates (use `chezmoi merge`).
+# Capture drifted non-template target edits into source via re-add. [paths...]
+capture-drift-apply *targets:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    drift=$(chezmoi status {{targets}} 2>/dev/null | awk 'substr($0,1,1)=="M"{print substr($0,4)}')
+    paths=()
+    while IFS= read -r t; do
+        [ -z "$t" ] && continue
+        case "$(chezmoi source-path "$HOME/$t" 2>/dev/null || true)" in
+            *.tmpl) ;;
+            *) paths+=("$HOME/$t") ;;
+        esac
+    done <<< "$drift"
+    if [ ${#paths[@]} -eq 0 ]; then echo "{{GREEN}}No non-template target drift to capture.{{NORMAL}}"; exit 0; fi
+    echo "{{BLUE}}Capturing into source via re-add:{{NORMAL}}"; printf '  %s\n' "${paths[@]}"
+    chezmoi re-add "${paths[@]}"
+    echo "{{GREEN}}Done.{{NORMAL}} Drifted templates still need {{BOLD}}chezmoi merge{{NORMAL}} — see {{BOLD}}just capture-drift{{NORMAL}}."
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Testing
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

A workflow to capture local edits made directly to chezmoi *target* files back into the *source*, plus a guard that warns before an apply silently overwrites them.

**justfile recipes**
- `just capture-drift [paths...]` — read-only preview; lists drifted targets split into "re-add can capture" vs. "templates — merge by hand".
- `just capture-drift-apply [paths...]` — captures the non-template ones via `chezmoi re-add`, passing paths **explicitly** so a bare re-add can't revert un-applied source edits.

**`chezmoi-drift-guard.sh`** — PreToolUse(Bash) hook, registered alongside the existing `chezmoi-exact-guard.sh`. Non-blocking: `exit 0` + `permissionDecision: allow` + `additionalContext`, surfacing the capture commands before a `chezmoi apply` that would overwrite uncaptured target edits.

## Why a PreToolUse hook (not git / pre-commit / SessionStart)

- git / pre-commit fire on *source-repo commits*; drift lives in *target* files — wrong trigger, and they'd block unrelated commits.
- SessionStart would pay a `chezmoi status` cost every session; PreToolUse runs the check only at an actual apply.
- Mirrors `chezmoi-exact-guard.sh` (which *blocks* apply-time deletions). Deletions are near-always unintended → block; overwriting target edits is often intended → warn.

## Detection correctness

Keys on `chezmoi status` **first column == M** (target modified since chezmoi last wrote it). An earlier `re-add --dry-run` approach false-positived on the normal "edit source → apply" flow (chezmoi issue [#4180](https://github.com/twpayne/chezmoi/issues/4180) ambiguity) and would have *reverted* pending source edits. Verified empirically: source-edit → `␣M` (silent), direct target-edit → `MM` (warns).

## Testing

- shellcheck clean; recipes parse; both apply-guards registered at runtime.
- Regression: hook stays silent when only source is edited (no false positive).
- Positive: hook warns on real target drift; recipe routes templates to `chezmoi merge` and non-templates to re-add; all paths exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
