### PR TITLE
feat(mise): add jaq and jnv JSON tools

### DIFF
--- a/private_dot_config/mise/config.toml.tmpl
+++ b/private_dot_config/mise/config.toml.tmpl
@@ -104,6 +104,8 @@ rust = "latest"
 # Data Processing
 "aqua:jqlang/jq" = "latest"
 "aqua:mikefarah/yq" = "latest"
+"aqua:01mf02/jaq" = "latest"                   # jq clone (Rust)
+"aqua:ynqa/jnv" = "latest"                     # interactive JSON viewer
 
 # Terminal & Shell
 "aqua:ajeetdsouza/zoxide" = "latest"


### PR DESCRIPTION
## What

Adds two aqua-backed JSON tools to `private_dot_config/mise/config.toml.tmpl`, in the **Data Processing** group next to `jq`/`yq`:

- `aqua:01mf02/jaq` — jq clone (Rust)
- `aqua:ynqa/jnv` — interactive JSON viewer

## Why

These were installed at the target (`~/.config/mise/config.toml`) via `mise use` but never captured into the chezmoi source — so a `chezmoi apply` would have removed them. This reconciles that drift and places them in the tidy semantic group rather than appended at the end where `mise use` dropped them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
