### PR TITLE
docs(claude): add refactor label to github-metadata-hygiene rule

### DIFF
--- a/private_repos/private_dot_claude/rules/github-metadata-hygiene.md
+++ b/private_repos/private_dot_claude/rules/github-metadata-hygiene.md
@@ -58,6 +58,7 @@ Use these standard type labels consistently:
 | `chore` | Maintenance, dependency updates, refactoring |
 | `docs` | Documentation changes |
 | `security` | Security-related fixes or improvements |
+| `refactor` | Code restructure with no behavior change |
 
 Check available labels with `gh label list -R <owner>/<repo>` before applying —
 do not create labels that don't exist without asking. Both scopes manage their


### PR DESCRIPTION
## What

Adds a `refactor` row to the standard-labels table in `private_repos/private_dot_claude/rules/github-metadata-hygiene.md`:

> `refactor` — Code restructure with no behavior change

## Why

Captures a local edit made to the target (`~/repos/.claude/rules/github-metadata-hygiene.md`) back into the chezmoi source, so `chezmoi apply` won't revert it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
