### PR TITLE
fix(claude): stop exact-guard false-positive on quoted chezmoi commands

### DIFF
--- a/exact_dot_claude/hooks/executable_chezmoi-exact-guard.sh
+++ b/exact_dot_claude/hooks/executable_chezmoi-exact-guard.sh
@@ -21,11 +21,15 @@ tool=$(jq -r '.tool_name // empty' <<<"$input" 2>/dev/null || echo "")
 cmd=$(jq -r '.tool_input.command // empty' <<<"$input" 2>/dev/null || echo "")
 [ -z "$cmd" ] && exit 0
 
-# Fast bail: only inspect commands that invoke `chezmoi ... apply`
-case "$cmd" in
-    *chezmoi*apply*) ;;
-    *) exit 0 ;;
-esac
+# Fast bail: only inspect commands that actually INVOKE `chezmoi ... apply`.
+# Strip quoted string literals first, so the words `chezmoi`/`apply` appearing
+# inside an argument or heredoc body (e.g. a `gh pr create --body` that
+# documents a chezmoi command) don't trip the guard — a real invocation is
+# never wrapped in quotes. Then require `chezmoi` at a command position with
+# `apply` as its own following token, so prose like "run chezmoi apply, then…"
+# (trailing punctuation, no shell boundary) is ignored too.
+code=$(sed -e "s/'[^']*'//g" -e 's/"[^"]*"//g' <<<"$cmd")
+grep -Eq '(^|[[:space:];&|(])chezmoi[[:space:]]([^|;&]*[[:space:]])?apply([[:space:]]|[;&|)]|$)' <<<"$code" || exit 0
 
 # Dry runs and verbose previews are safe
 case "$cmd" in


### PR DESCRIPTION
## What

Tighten the `chezmoi-exact-guard.sh` PreToolUse hook's fast-bail so it only fires on a real `chezmoi … apply` **invocation**, not on those words appearing inside a quoted argument or heredoc body.

## Why

The guard matched `*chezmoi*apply*` as a substring against the whole command string. So a perfectly safe command like:

```
gh pr create --body "After applying, a bare task works (chezmoi … apply)"
```

was **blocked** because the body text mentioned the command. This happened live this session while opening an unrelated PR — the guard blocked `gh pr create` and forced a `--body-file` workaround.

## Fix

1. Strip single/double-quoted string literals before the check — a real invocation is never wrapped in quotes.
2. Require `chezmoi` at a command position with the `apply` subcommand as its own following token (bounded by whitespace / shell separators), so prose like `run chezmoi apply, then…` is ignored too.

## Verification

Gate tested against every real-invocation form (bare, `--force`, scoped paths, flags-before-subcommand, `sudo -n`, `&&` chains) — **all still trigger** — and against the quoted/prose false positives — **all now ignored**. End-to-end, the hook exits 0 on the `gh pr create` case and still runs the `chezmoi status` deletion check on real applies. The guard's actual protection (catching applies that would delete unmanaged files) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
