### PR TITLE
feat(completions): add taskwarrior zsh completion

### DIFF
--- a/.chezmoidata/completions.toml
+++ b/.chezmoidata/completions.toml
@@ -35,3 +35,7 @@
   ruff = "ruff generate-shell-completion zsh"
   deadbranch = "deadbranch completions zsh"
   "git-repo-agent" = "git-repo-agent completion zsh"
+  # task (taskwarrior): no generator subcommand — ship the bundled _task that
+  # Homebrew installs (uses task's _columns/_config/_context helper commands).
+  # The Apple Silicon brew site-functions dir isn't on fpath, so copy it to ~/.zfunc.
+  task = "cat \"$(brew --prefix)/share/zsh/site-functions/_task\""


### PR DESCRIPTION
## What

Adds zsh completion for the `task` (Taskwarrior) command via the existing completion-generation registry.

## Why

Taskwarrior ships **no** `task completion zsh` generator subcommand. Instead it bundles a static `_task` completer that drives off its `_columns` / `_config` / `_context` helper commands. Homebrew installs this file under `$(brew --prefix)/share/zsh/site-functions/_task`, but on Apple Silicon that directory (`/opt/homebrew/share/zsh/site-functions`) is not on `fpath`, so the completer was never discoverable — `task <TAB>` did nothing.

## How

Registers `task` in `.chezmoidata/completions.toml` with `cat "$(brew --prefix)/share/zsh/site-functions/_task"`, so `run_onchange_02-generate-completions.sh.tmpl` copies the bundled completer into `~/.zfunc/_task` like every other tool. The generator already guards on `command -v task`, so non-macOS/non-installed hosts skip it cleanly.

## Verification

- `chezmoi apply` generated `~/.zfunc/_task` (8.5 KB, `#compdef task`).
- Fresh `zsh -ic 'compinit; whence -w _task'` → `_task: function`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)