### PR TITLE
fix(zsh): colour zsh-abbr abbreviations in syntax highlighting

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -348,6 +348,26 @@ zle -N rationalise-dot
 ABBR_DEFAULT_BINDINGS=0
 [ -f ~/zsh/zsh-abbr/zsh-abbr.zsh ] && source ~/zsh/zsh-abbr/zsh-abbr.zsh
 
+# A regular abbreviation isn't a command until it expands, so
+# zsh-syntax-highlighting resolves the unexpanded name (e.g. `gpls`), finds no
+# command/alias/function, and styles it as an error (red). This is a known,
+# accepted z-sy-h/zsh-abbr boundary (olets/zsh-abbr#23), and zsh-abbr's official
+# integration is to colour abbreviations via z-sy-h's `regexp` highlighter:
+#   https://zsh-abbr.olets.dev/integrations.html#zsh-syntax-highlighting
+# The anchored regex matches a bare abbreviation in command position — the
+# pre-expansion window where the red shows — with names joined from the arrays
+# zsh-abbr loaded, so there's no second source of truth. ${(Qk)} dequotes keys.
+# z-sy-h runs only `main` by default, so set it explicitly to keep `main` and
+# add `regexp` (a bare += would drop the default main highlighter). The global
+# line is guarded because an empty array would make the regex match anything.
+ZSH_HIGHLIGHT_HIGHLIGHTERS=(main regexp)
+if (( ${#ABBR_REGULAR_USER_ABBREVIATIONS} )); then
+  ZSH_HIGHLIGHT_REGEXP+=('^[[:space:]]*('${(j:|:)${(Qk)ABBR_REGULAR_USER_ABBREVIATIONS}}')$' fg=cyan,bold)
+fi
+if (( ${#ABBR_GLOBAL_USER_ABBREVIATIONS} )); then
+  ZSH_HIGHLIGHT_REGEXP+=('[[:<:]]('${(j:|:)${(Qk)ABBR_GLOBAL_USER_ABBREVIATIONS}}')$' fg=cyan,bold)
+fi
+
 
 #======================================================================
 # FZF Sourcing (keybindings & completions)


### PR DESCRIPTION
## Problem

A regular zsh-abbr abbreviation (e.g. `gpls`, `gils`, `jg`) isn't a command until it expands, so zsh-syntax-highlighting resolves the *unexpanded* name, finds no command/alias/function, and styles it as an error — it shows **red** as if it doesn't exist.

## Fix

Apply zsh-abbr's [official integration](https://zsh-abbr.olets.dev/integrations.html#zsh-syntax-highlighting) (see olets/zsh-abbr#23): colour abbreviations via z-sy-h's `regexp` highlighter, with an anchored regex matching a bare abbreviation in command position (the pre-expansion window where the red shows). Now they render cyan-bold, and once expanded to the full command they highlight normally.

## Details

- Abbreviation names are joined from the arrays zsh-abbr loaded the user file into, so there's **no second source of truth** — any new abbreviation gets the treatment automatically.
- z-sy-h runs only `main` by default, so the highlighter list is set explicitly to `(main regexp)`. A bare `+=(regexp)` (as the upstream snippet assumes) would have replaced the default and silently dropped `main`, killing all normal highlighting.
- The global-abbreviations line is guarded by a count check, because joining an empty array would make the regex match anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WH1U2NxQDivYjCDHoVv3Px