### PR TITLE
test(plugins): regression-test Claude plugin/marketplace references + fix drift

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -89,7 +89,6 @@
     "testing-plugin@laurigates-claude-plugins": true,
     "tools-plugin@laurigates-claude-plugins": true,
     "typescript-plugin@laurigates-claude-plugins": false,
-    "upstream-pr-plugin@laurigates-claude-plugins": false,
     "workflow-orchestration-plugin@laurigates-claude-plugins": true
   }
 }

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -80,7 +80,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.claude/plugins
-          key: claude-plugins-v1-${{ runner.os }}-lgates-claude-plugins
+          key: claude-plugins-v1-${{ runner.os }}-laurigates-claude-plugins
           restore-keys: |
             claude-plugins-v1-${{ runner.os }}-
 
@@ -90,21 +90,21 @@ jobs:
           claude /plugin marketplace add laurigates/claude-plugins
 
           # Install essential plugins for this repository
-          claude /plugin install dotfiles-plugin@lgates-claude-plugins
-          claude /plugin install git-plugin@lgates-claude-plugins
-          claude /plugin install github-actions-plugin@lgates-claude-plugins
-          claude /plugin install code-quality-plugin@lgates-claude-plugins
-          claude /plugin install testing-plugin@lgates-claude-plugins
-          claude /plugin install tools-plugin@lgates-claude-plugins
+          claude /plugin install configure-plugin@laurigates-claude-plugins
+          claude /plugin install git-plugin@laurigates-claude-plugins
+          claude /plugin install github-actions-plugin@laurigates-claude-plugins
+          claude /plugin install code-quality-plugin@laurigates-claude-plugins
+          claude /plugin install testing-plugin@laurigates-claude-plugins
+          claude /plugin install tools-plugin@laurigates-claude-plugins
 
           # List installed plugins for verification
           {
             echo "## 🔌 Installed Claude Plugins"
             echo ""
-            echo "Marketplace: \`lgates-claude-plugins\`"
+            echo "Marketplace: \`laurigates-claude-plugins\`"
             echo ""
             echo "Plugins installed:"
-            echo "- dotfiles-plugin"
+            echo "- configure-plugin"
             echo "- git-plugin"
             echo "- github-actions-plugin"
             echo "- code-quality-plugin"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ just plugins-enable
 
 Or install individually:
 ```bash
-claude /plugin install git-plugin@lgates-claude-plugins
+claude /plugin install git-plugin@laurigates-claude-plugins
 ```
 
 ### Bulk Plugin Management

--- a/exact_dot_claude/hooks/executable_claude-plugins-audit.sh
+++ b/exact_dot_claude/hooks/executable_claude-plugins-audit.sh
@@ -83,7 +83,7 @@ if [ -n "$undecided_list" ]; then
   echo "New plugin(s) not yet decided in the overlay enabledPlugins (defaulting OFF):"
   printf '%s\n' "$undecided_list" | sed 's/^/  • /'
   echo "  → decide each true/false in exact_dot_claude/modify_settings.json,"
-  echo "    or run /pin-plugins / /configure:claude-plugins --exhaustive."
+  echo "    or run /configure-claude-plugins --exhaustive."
 fi
 if [ -n "$stale_list" ]; then
   echo "Pinned plugin(s) no longer in the marketplace (safe to drop from overlay):"

--- a/exact_dot_claude/modify_settings.json
+++ b/exact_dot_claude/modify_settings.json
@@ -284,8 +284,7 @@ read -r -d '' overlay <<'OVERLAY' || true
     "prompt-engineering-plugin@laurigates-claude-plugins": true,
     "taskwarrior-plugin@laurigates-claude-plugins": true,
     "macos-plugin@laurigates-claude-plugins": true,
-    "session-plugin@laurigates-claude-plugins": true,
-    "upstream-pr-plugin@laurigates-claude-plugins": false
+    "session-plugin@laurigates-claude-plugins": true
   },
   "extraKnownMarketplaces": {
     "laurigates-claude-plugins": {

--- a/private_dot_config/just/plugins.just
+++ b/private_dot_config/just/plugins.just
@@ -84,12 +84,12 @@ plugins-reinstall: plugins-uninstall plugins-install plugins-enable
 # Configure current repository to use laurigates/claude-plugins marketplace (writes .claude/settings.json and workflows)
 plugins-setup-repo:
     @echo "{{BLUE}}Configuring Claude plugins for repository at $(pwd)...{{NORMAL}}"
-    CLAUDECODE= claude -p "/configure:claude-plugins --fix" --permission-mode acceptEdits
+    CLAUDECODE= claude -p "/configure-claude-plugins --fix" --permission-mode acceptEdits
 
 # Report current repository's Claude plugin configuration without changes
 plugins-check-repo:
     @echo "{{BLUE}}Checking Claude plugin configuration for repository at $(pwd)...{{NORMAL}}"
-    CLAUDECODE= claude -p "/configure:claude-plugins --check-only"
+    CLAUDECODE= claude -p "/configure-claude-plugins --check-only"
 
 # Audit committed project plugin pins for drift vs canonical (read-only)
 plugins-audit:

--- a/private_dot_config/mise/config.toml.tmpl
+++ b/private_dot_config/mise/config.toml.tmpl
@@ -185,17 +185,33 @@ description = "Check what changes would be made (alias for status)"
 # Testing & Quality Assurance
 # ----------------------------------------------------------------------------
 [tasks.test]
-description = "Run all tests (linting + setup verification + container testing)"
-depends = ["lint", "test:setup", "docker"]
+description = "Run all tests (linting + setup verification + plugin refs + container testing)"
+depends = ["lint", "test:setup", "test:plugin-refs", "docker"]
 
 [tasks."test:setup"]
 description = "Test initial setup script handles missing commands gracefully (Issue #128)"
 run = """
 #!/usr/bin/env bash
-if [ -x tests/test-initial-setup.sh ]; then
-    tests/test-initial-setup.sh
+# These tasks live in the global mise config and run from $HOME, so reference
+# the test by its absolute path in the chezmoi source tree.
+SCRIPT="{{ .chezmoi.sourceDir }}/tests/test-initial-setup.sh"
+if [ -x "$SCRIPT" ]; then
+    "$SCRIPT"
 else
-    echo "⚠️  Warning: tests/test-initial-setup.sh not found or not executable"
+    echo "⚠️  Warning: $SCRIPT not found or not executable"
+    exit 1
+fi
+"""
+
+[tasks."test:plugin-refs"]
+description = "Regression test: Claude plugin/marketplace references resolve (alias, plugin existence, slash commands)"
+run = """
+#!/usr/bin/env bash
+SCRIPT="{{ .chezmoi.sourceDir }}/tests/test-claude-plugin-references.sh"
+if [ -x "$SCRIPT" ]; then
+    "$SCRIPT"
+else
+    echo "⚠️  Warning: $SCRIPT not found or not executable"
     exit 1
 fi
 """

--- a/tests/test-claude-plugin-references.sh
+++ b/tests/test-claude-plugin-references.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# Regression test for Claude plugin / marketplace references across the repo.
+#
+# Pins three classes of broken-reference bug that have bitten this repo:
+#   A. Marketplace alias drift   — refs using an alias != the canonical one
+#                                  (e.g. `lgates-claude-plugins` instead of
+#                                  `laurigates-claude-plugins`), which makes
+#                                  `claude /plugin install foo@<alias>` fail.
+#   B. Nonexistent plugin refs    — `plugin@alias` naming a plugin that is not
+#                                  in the marketplace (e.g. `dotfiles-plugin`,
+#                                  or a stale pin like `upstream-pr-plugin`).
+#   C. Unresolvable slash command — a `claude -p "/cmd …"` headless invocation
+#                                  whose command does not resolve to a real
+#                                  skill/command (e.g. `/configure:claude-plugins`
+#                                  — wrong namespace — vs `/configure-claude-plugins`).
+#
+# Checks A is pure-text and always runs. Checks B and C resolve against the
+# installed marketplace; when it is absent (e.g. a minimal CI runner) they are
+# SKIPPED loudly rather than passing silently.
+#
+# Override the marketplace location with CLAUDE_PLUGINS_MARKETPLACE_DIR.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHEZMOI_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$CHEZMOI_DIR" || exit 1
+
+MARKETPLACE_DIR="${CLAUDE_PLUGINS_MARKETPLACE_DIR:-$HOME/.claude/plugins/marketplaces/laurigates-claude-plugins}"
+
+# Canonical alias: read from the marketplace manifest when present, else the
+# repo-identity default. The repo is laurigates/claude-plugins -> alias name.
+CANONICAL_ALIAS="laurigates-claude-plugins"
+if [[ -f "$MARKETPLACE_DIR/.claude-plugin/marketplace.json" ]] && command -v jq >/dev/null 2>&1; then
+    name="$(jq -r '.name // empty' "$MARKETPLACE_DIR/.claude-plugin/marketplace.json" 2>/dev/null || true)"
+    [[ -n "$name" ]] && CANONICAL_ALIAS="$name"
+fi
+
+# Built-in slash commands that resolve without a marketplace plugin. Keep
+# minimal; extend only when a recipe legitimately invokes a new built-in.
+BUILTIN_COMMANDS=(init review security-review code-review simplify verify run loop schedule fewer-permission-prompts claude-api help)
+
+# Paths excluded from text scans: this test (self-references the bad values)
+# and the ADR docs (historical record of the deprecated /namespace:command form).
+EXCLUDE_PATHSPEC=(':!tests/' ':!docs/adrs/')
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+pass_count=0; fail_count=0; skip_count=0
+log_test() { echo -e "${BLUE}TEST:${NC} $*"; }
+log_pass() { echo -e "${GREEN}✓ PASS:${NC} $*"; ((pass_count++)); }
+log_fail() { echo -e "${RED}✗ FAIL:${NC} $*"; ((fail_count++)); }
+log_skip() { echo -e "${YELLOW}● SKIP:${NC} $*"; ((skip_count++)); }
+
+# ----------------------------------------------------------------------------
+# Check A: marketplace alias consistency (no marketplace required)
+# ----------------------------------------------------------------------------
+check_alias_consistency() {
+    log_test "Marketplace alias references all use '$CANONICAL_ALIAS'"
+    # Match <token>-claude-plugins alias forms. The owner/repo path form
+    # `laurigates/claude-plugins` has a slash before `claude` so never matches
+    # the required `<token>-claude-plugins` shape.
+    # Match `<token>-claude-plugins` in an *alias* position: preceded by `@`,
+    # `-`, backtick, space, etc. — but NOT `/`. That excludes the slash-command
+    # skill name `/configure-claude-plugins` while keeping `@lgates-claude-plugins`,
+    # the cache-key literal, and step-summary echoes. The leading boundary char
+    # is captured by -o and stripped with sed.
+    local bad
+    bad="$(git grep -hoIE '(^|[^a-z0-9_/])[a-z][a-z0-9_]*-claude-plugins' -- . "${EXCLUDE_PATHSPEC[@]}" 2>/dev/null \
+        | sed -E 's/^[^a-z]//' | sort -u | grep -vxF "$CANONICAL_ALIAS" || true)"
+    if [[ -z "$bad" ]]; then
+        log_pass "No non-canonical marketplace aliases found"
+        return
+    fi
+    log_fail "Non-canonical marketplace alias(es) found (expected '$CANONICAL_ALIAS'):"
+    local alias
+    while IFS= read -r alias; do
+        [[ -z "$alias" ]] && continue
+        echo "    alias: $alias"
+        git grep -nIE "\b${alias}\b" -- . "${EXCLUDE_PATHSPEC[@]}" | sed 's/^/      /'
+    done <<< "$bad"
+}
+
+# ----------------------------------------------------------------------------
+# Check B: every plugin@alias reference names a plugin in the marketplace
+# ----------------------------------------------------------------------------
+check_plugin_existence() {
+    log_test "All 'plugin@alias' references name a plugin in the marketplace"
+    if [[ ! -d "$MARKETPLACE_DIR" ]]; then
+        log_skip "Marketplace not found at $MARKETPLACE_DIR — cannot verify plugin existence"
+        return
+    fi
+    # Collect referenced plugin names from `name-plugin@alias` tokens.
+    local refs
+    refs="$(git grep -hoIE '[a-z][a-z0-9-]*-plugin@[a-z0-9_-]+' -- . "${EXCLUDE_PATHSPEC[@]}" 2>/dev/null \
+        | sed 's/@.*//' | sort -u || true)"
+    if [[ -z "$refs" ]]; then
+        log_pass "No plugin@alias references to verify"
+        return
+    fi
+    local missing="" plugin
+    while IFS= read -r plugin; do
+        [[ -z "$plugin" ]] && continue
+        if [[ ! -d "$MARKETPLACE_DIR/$plugin" ]]; then
+            missing+="$plugin"$'\n'
+        fi
+    done <<< "$refs"
+    if [[ -z "$missing" ]]; then
+        log_pass "All referenced plugins exist in the marketplace"
+        return
+    fi
+    log_fail "Reference(s) to plugin(s) absent from the marketplace:"
+    while IFS= read -r plugin; do
+        [[ -z "$plugin" ]] && continue
+        echo "    plugin: $plugin"
+        git grep -nIE "\b${plugin}@" -- . "${EXCLUDE_PATHSPEC[@]}" | sed 's/^/      /'
+    done <<< "$missing"
+}
+
+# ----------------------------------------------------------------------------
+# Check C: every `claude -p "/cmd …"` slash command resolves
+# ----------------------------------------------------------------------------
+build_command_index() {
+    # Bare skill/command names across all plugins, one per line.
+    local d f
+    for d in "$MARKETPLACE_DIR"/*/skills/*/; do
+        [[ -d "$d" ]] && basename "$d"
+    done
+    for f in "$MARKETPLACE_DIR"/*/commands/*.md; do
+        [[ -e "$f" ]] && basename "$f" .md
+    done
+    printf '%s\n' "${BUILTIN_COMMANDS[@]}"
+}
+
+resolve_command() {
+    # $1 = command token (may be `name` or `plugin:name`)
+    local cmd="$1"
+    if [[ "$cmd" == *:* ]]; then
+        local plugin="${cmd%%:*}" name="${cmd#*:}"
+        [[ -d "$MARKETPLACE_DIR/$plugin/skills/$name" ]] && return 0
+        [[ -f "$MARKETPLACE_DIR/$plugin/commands/$name.md" ]] && return 0
+        return 1
+    fi
+    grep -qxF "$cmd" <<< "$COMMAND_INDEX"
+}
+
+check_command_resolution() {
+    log_test "All 'claude -p \"/cmd\"' invocations resolve to a real command"
+    if [[ ! -d "$MARKETPLACE_DIR" ]]; then
+        log_skip "Marketplace not found at $MARKETPLACE_DIR — cannot resolve slash commands"
+        return
+    fi
+    COMMAND_INDEX="$(build_command_index | sort -u)"
+    # Find claude headless invocations and pull the leading "/token" command.
+    # Matches: claude … -p … "/configure-claude-plugins --fix"
+    local hits
+    hits="$(git grep -nIE 'claude[^"]*-p[^"]*"/[a-z0-9:_-]+' -- . "${EXCLUDE_PATHSPEC[@]}" 2>/dev/null || true)"
+    if [[ -z "$hits" ]]; then
+        log_pass "No 'claude -p' slash-command invocations found"
+        return
+    fi
+    local any_bad=0 line cmd
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        cmd="$(grep -oE '"/[a-z0-9:_-]+' <<< "$line" | head -1 | sed 's|"/||')"
+        [[ -z "$cmd" ]] && continue
+        if resolve_command "$cmd"; then
+            log_pass "/$cmd resolves ($line)"
+        else
+            log_fail "/$cmd does NOT resolve — $line"
+            any_bad=1
+        fi
+    done <<< "$hits"
+    [[ $any_bad -eq 0 ]] || true
+}
+
+echo "========================================"
+echo "Claude Plugin Reference Regression Suite"
+echo "========================================"
+echo "Marketplace: $MARKETPLACE_DIR"
+echo "Canonical alias: $CANONICAL_ALIAS"
+echo ""
+
+check_alias_consistency
+echo ""
+check_plugin_existence
+echo ""
+check_command_resolution
+
+echo ""
+echo "========================================"
+echo -e "${GREEN}Passed:${NC} $pass_count   ${RED}Failed:${NC} $fail_count   ${YELLOW}Skipped:${NC} $skip_count"
+echo "========================================"
+if [[ $fail_count -eq 0 ]]; then
+    echo -e "${GREEN}✓ All plugin-reference checks passed${NC}"
+    [[ $skip_count -gt 0 ]] && echo -e "${YELLOW}  (some checks skipped — install the marketplace to run them)${NC}"
+    exit 0
+else
+    echo -e "${RED}✗ Plugin-reference regressions detected${NC}"
+    exit 1
+fi

--- a/tests/test-initial-setup.sh
+++ b/tests/test-initial-setup.sh
@@ -24,12 +24,14 @@ log_test() {
 
 log_pass() {
     echo -e "${GREEN}✓ PASS:${NC} $*"
-    ((pass_count++))
+    # Use assignment, not ((x++)): under `set -e` the post-increment returns
+    # exit 1 when the pre-value is 0, which would abort after the first PASS.
+    pass_count=$((pass_count + 1))
 }
 
 log_fail() {
     echo -e "${RED}✗ FAIL:${NC} $*"
-    ((fail_count++))
+    fail_count=$((fail_count + 1))
 }
 
 # Test 1: Verify script exists
@@ -107,11 +109,11 @@ test_skip_messages_exist() {
     local messages_found=0
 
     if grep -q "Skipping pre-commit hooks installation" "$SETUP_SCRIPT"; then
-        ((messages_found++))
+        messages_found=$((messages_found + 1))
     fi
 
     if grep -q "Skipping neovim plugin installation" "$SETUP_SCRIPT"; then
-        ((messages_found++))
+        messages_found=$((messages_found + 1))
     fi
 
     if [[ $messages_found -eq 2 ]]; then
@@ -127,7 +129,8 @@ test_skip_messages_exist() {
 test_script_syntax() {
     log_test "Verifying script has valid bash syntax"
     # Create a temporary file with template variables replaced
-    local temp_script=$(mktemp)
+    local temp_script
+    temp_script=$(mktemp)
     # Replace chezmoi template with a dummy path for syntax checking
     sed 's/{{ .chezmoi.sourceDir }}/\/tmp\/chezmoi/g' "$SETUP_SCRIPT" > "$temp_script"
 


### PR DESCRIPTION
## What

Adds a regression test that pins a class of broken-reference bugs in this
repo's Claude plugin automation, and fixes every instance the test found.

The trigger: `just plugins-setup-repo` failed with *"Unknown command:
/configure:claude-plugins"* — the recipe used the wrong slash-command
namespace. Rather than fix the one spot, the test sweeps the whole repo for
the same bug class.

## Regression test — `tests/test-claude-plugin-references.sh`

Three deterministic checks over all tracked files:

| Check | Catches |
|---|---|
| **A. Alias consistency** | any marketplace alias ≠ canonical `laurigates-claude-plugins` |
| **B. Plugin existence** | `plugin@alias` naming a plugin absent from the marketplace |
| **C. Command resolution** | a `claude -p "/cmd"` invocation whose command doesn't resolve to a real skill/command |

Check A is pure-text (always runs). B and C resolve against the installed
marketplace and **SKIP loudly** when it's absent (e.g. a minimal CI runner)
rather than passing silently. Wired into `mise run test` via a new
`test:plugin-refs` task.

## Instances fixed (found by the test)

- **Slash-command form** `/configure:claude-plugins` → `/configure-claude-plugins`
  in `plugins-setup-repo` / `plugins-check-repo` recipes and the audit-hook nudge.
- **Alias drift** `lgates-claude-plugins` → `laurigates-claude-plugins` in
  `claude.yml` (cache key, 6 install lines, step summary) and the `README` snippet.
- **Nonexistent plugins**: `dotfiles-plugin` → `configure-plugin` in `claude.yml`;
  dropped the stale `upstream-pr-plugin` pin from `.claude/settings.json` and the
  global `modify_settings.json` overlay.

## Incidental fixes

Wiring the test exposed that the mise test tasks run from `$HOME`, so their
relative `tests/` paths never resolved — fixed by resolving from
`{{ .chezmoi.sourceDir }}`. That in turn surfaced a `set -e` + `((count++))`
early-abort in `test-initial-setup.sh` (post-increment returns exit 1 on a 0
pre-value), now fixed. Both suites are green: `test:setup` 7/7, `test:plugin-refs` 4/4.

## Out of scope (noted for follow-up)

- Stale colon-namespace command refs in docs (`/configure:mcp`, `/blueprint:status`
  in `CLAUDE.md`) — not executable, and the ADRs are historical; left untouched.
- Plugin-pin exhaustiveness and outdated `--model` ids in workflows — these are
  `just plugins-audit` / judgment concerns, deliberately kept out of the
  deterministic test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
