### PR TITLE
docs: modernize stale /namespace:command refs to bare plugin-skill form

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Managed in [laurigates/claude-plugins](https://github.com/laurigates/claude-plug
 
 ## MCP Servers
 
-Managed per-project in `.mcp.json`. Registry of available servers in `.chezmoidata.toml` under `[mcp_servers]`. Use `/configure:mcp` for guided setup.
+Managed per-project in `.mcp.json`. Registry of available servers in `.chezmoidata.toml` under `[mcp_servers]`. Use `/configure-mcp` for guided setup.
 
 ## Linting
 
@@ -87,7 +87,7 @@ Blueprint v3.3.0 manages project documentation and rules.
 - **ADRs**: `docs/adrs/` — 16 Architecture Decision Records ([index](docs/adrs/README.md))
 - **PRPs**: `docs/prps/` — Implementation plans (fish, NixOS, sketchybar)
 - **Manifest**: `docs/blueprint/manifest.json` — Configuration and task registry
-- **Commands**: `/blueprint:status`, `/blueprint:execute`, `/blueprint:derive-plans`
+- **Commands**: `/blueprint-status`, `/blueprint-execute`, `/blueprint-derive-plans`
 
 ## Sub-documentation
 

--- a/docs/adrs/0005-namespace-based-command-organization.md
+++ b/docs/adrs/0005-namespace-based-command-organization.md
@@ -2,7 +2,15 @@
 
 ## Status
 
-Accepted
+Superseded
+
+> **Superseded** by the Claude plugins marketplace
+> ([laurigates/claude-plugins](https://github.com/laurigates/claude-plugins)).
+> Commands are no longer organized as project-local `/namespace:command` files;
+> capabilities are now provided by plugin skills invoked with the bare
+> `/skill-name` form (e.g. `/configure-mcp`, `/blueprint-status`). The
+> `/namespace:command` syntax below is retained as a historical record of the
+> decision and no longer resolves.
 
 ## Date
 

--- a/docs/adrs/0008-project-scoped-mcp-servers.md
+++ b/docs/adrs/0008-project-scoped-mcp-servers.md
@@ -122,7 +122,7 @@ Maintain curated MCP server configurations in `.chezmoidata.toml`:
 
 **Interactive (recommended):**
 ```bash
-/configure:mcp  # Claude command for guided installation
+/configure-mcp  # Claude command for guided installation
 ```
 
 **Manual:**
@@ -228,4 +228,4 @@ Single config for entire monorepo.
 - Project MCP config: `.mcp.json`
 - Favorites registry: `.chezmoidata.toml` (`[mcp_servers]` section)
 - MCP management skill: `exact_dot_claude/skills/mcp-management/`
-- Installation command: `/configure:mcp`
+- Installation command: `/configure-mcp`

--- a/docs/adrs/0009-conventional-commits-release-please.md
+++ b/docs/adrs/0009-conventional-commits-release-please.md
@@ -240,7 +240,7 @@ Custom scripts to generate changelogs.
 
 - ADR-0006: Documentation-First Development (commits document changes)
 - ADR-0004: Subagent-First Delegation (git-commit-workflow skill)
-- ADR-0005: Namespace-Based Command Organization (/git:commit command)
+- ADR-0005: Namespace-Based Command Organization (/git-commit command)
 
 ## References
 

--- a/docs/adrs/0010-tiered-test-execution.md
+++ b/docs/adrs/0010-tiered-test-execution.md
@@ -2,7 +2,14 @@
 
 ## Status
 
-Accepted
+Accepted (command syntax superseded)
+
+> **Note:** The tiered test-execution *concept* (unit → integration → E2E with
+> specialized agents) still stands. The `/test:*` command catalog referenced
+> below is superseded by the `testing-plugin` marketplace skills, invoked with
+> the bare `/skill-name` form (e.g. `/test-quick`, `/test-full`,
+> `/test-consult`). The `/test:*` and `/git:commit` syntax in the body is
+> retained as a historical record and no longer resolves.
 
 ## Date
 

--- a/docs/blueprint/README.md
+++ b/docs/blueprint/README.md
@@ -18,12 +18,12 @@ Blueprint development structure for this project.
 ## Commands
 
 ```bash
-/blueprint:status          # Check configuration and task health
-/blueprint:derive-prd      # Generate PRD from existing docs/codebase
-/blueprint:derive-plans    # Derive docs from git history
-/blueprint:derive-rules    # Generate rules from git patterns
-/blueprint:generate-rules  # Generate rules from PRDs
-/blueprint:adr-validate    # Validate ADR relationships
-/blueprint:sync-ids        # Assign IDs to documents
-/blueprint:execute         # Run next logical action
+/blueprint-status          # Check configuration and task health
+/blueprint-derive-prd      # Generate PRD from existing docs/codebase
+/blueprint-derive-plans    # Derive docs from git history
+/blueprint-derive-rules    # Generate rules from git patterns
+/blueprint-generate-rules  # Generate rules from PRDs
+/blueprint-adr-validate    # Validate ADR relationships
+/blueprint-sync-ids        # Assign IDs to documents
+/blueprint-execute         # Run next logical action
 ```

--- a/docs/prds/project-overview.md
+++ b/docs/prds/project-overview.md
@@ -162,5 +162,5 @@ Ongoing improvements across all areas: AI tooling expansion, new tool integratio
 | NixOS | Declarative system configuration (ADR-0013) | Planned |
 
 ---
-*Generated from existing documentation via /blueprint:derive-prd*
+*Generated from existing documentation via /blueprint-derive-prd*
 *Review and update as project evolves*

--- a/exact_dot_claude/docs/blueprint-development/IMPLEMENTATION_SUMMARY.md
+++ b/exact_dot_claude/docs/blueprint-development/IMPLEMENTATION_SUMMARY.md
@@ -42,12 +42,12 @@ This document summarizes the Blueprint Development implementation in your dotfil
 
 ### Commands (`.claude/commands/`)
 
-1. **/blueprint:init** - Initialize Blueprint Development in a project
+1. **/blueprint-init** - Initialize Blueprint Development in a project
    - Creates `.claude/blueprints/` directory structure
    - Creates `work-overview.md` template
    - Guides user through setup
 
-2. **/blueprint:generate-skills** - Generate project-specific skills from PRDs
+2. **/blueprint-generate-skills** - Generate project-specific skills from PRDs
    - Analyzes PRD files
    - Generates four domain skills:
      * Architecture patterns
@@ -55,25 +55,25 @@ This document summarizes the Blueprint Development implementation in your dotfil
      * Implementation guides
      * Quality standards
 
-3. **/blueprint:generate-commands** - Generate workflow commands
+3. **/blueprint-generate-commands** - Generate workflow commands
    - Detects project type and stack
    - Creates customized commands:
-     * `/project:continue`
-     * `/project:test-loop`
+     * `/project-continue`
+     * `/project-test-loop`
      * Project-specific commands
 
-4. **/blueprint:work-order** - Create isolated work-order
+4. **/blueprint-work-order** - Create isolated work-order
    - Analyzes project state
    - Identifies next work unit
    - Generates minimal-context task package
 
-5. **/project:continue** - Analyze state and continue development
+5. **/project-continue** - Analyze state and continue development
    - Checks git status
    - Reads PRDs and work-overview
    - Identifies next task
    - Begins TDD workflow
 
-6. **/project:test-loop** - Run test → fix → refactor loop
+6. **/project-test-loop** - Run test → fix → refactor loop
    - Automated TDD cycle
    - Detects test commands
    - Fixes failures, refactors code
@@ -129,7 +129,7 @@ cd test-blueprint-dev
 git init
 
 # Initialize Blueprint Development
-/blueprint:init
+/blueprint-init
 
 # Follow the prompts
 ```
@@ -141,24 +141,24 @@ git init
 cd ~/projects/my-project
 
 # Initialize Blueprint Development
-/blueprint:init
+/blueprint-init
 
 # Generate skills from existing code/docs
-/blueprint:generate-skills
+/blueprint-generate-skills
 ```
 
 ### Validation Checklist
 
 Test each command to verify it works:
 
-- [ ] `/blueprint:init` creates directory structure
+- [ ] `/blueprint-init` creates directory structure
 - [ ] Write a sample PRD in `.claude/blueprints/prds/`
-- [ ] `/blueprint:generate-skills` creates four skills
+- [ ] `/blueprint-generate-skills` creates four skills
 - [ ] Skills are discoverable (mention "architecture" and skill activates)
-- [ ] `/blueprint:generate-commands` creates workflow commands
-- [ ] `/project:continue` analyzes state and starts work
-- [ ] `/blueprint:work-order` creates work-order document
-- [ ] `/project:test-loop` runs tests (if project has tests)
+- [ ] `/blueprint-generate-commands` creates workflow commands
+- [ ] `/project-continue` analyzes state and starts work
+- [ ] `/blueprint-work-order` creates work-order document
+- [ ] `/project-test-loop` runs tests (if project has tests)
 
 ## Next Steps
 
@@ -308,7 +308,7 @@ Track these to measure effectiveness:
 
 **Context Switching**:
 - How easily can you switch between projects?
-- Does `/project:continue` accurately resume?
+- Does `/project-continue` accurately resume?
 
 **AI Effectiveness**:
 - Do skills guide Claude correctly?

--- a/exact_dot_claude/docs/blueprint-development/README.md
+++ b/exact_dot_claude/docs/blueprint-development/README.md
@@ -97,7 +97,7 @@ Work-orders enable **isolated subagent execution** - hand a work-order to a suba
 ### 1. Write PRPs
 Create PRPs (Product Requirement Prompts) with curated context:
 ```bash
-/prp:create [feature-name]
+/prp-create [feature-name]
 ```
 
 This guides you through:
@@ -111,7 +111,7 @@ See [prp-template.md](prp-template.md) for structure.
 
 ### 2. Curate ai_docs (Optional)
 ```bash
-/prp:curate-docs [library-name]
+/prp-curate-docs [library-name]
 ```
 
 Creates curated documentation entries for frequently-used libraries.
@@ -119,22 +119,22 @@ Creates curated documentation entries for frequently-used libraries.
 ### 3. Generate Skills & Commands
 ```bash
 # In your project directory
-/blueprint:generate-skills
-/blueprint:generate-commands
+/blueprint-generate-skills
+/blueprint-generate-commands
 ```
 
 This analyzes PRPs and creates project-specific skills and commands in `.claude/`.
 
 ### 4. Start Development
 ```bash
-/project:continue
+/project-continue
 ```
 
 Claude analyzes project state (git status, PRPs, work-orders) and continues where you left off.
 
 Or execute a specific PRP:
 ```bash
-/prp:execute [feature-name]
+/prp-execute [feature-name]
 ```
 
 ### 5. Test-Driven Development
@@ -143,11 +143,11 @@ All generated skills enforce TDD:
 2. **GREEN** - Minimal implementation to pass
 3. **REFACTOR** - Improve while keeping tests green
 
-Use `/project:test-loop` to start automated test → fix cycles.
+Use `/project-test-loop` to start automated test → fix cycles.
 
 ### 6. Work-Order Generation
 ```bash
-/blueprint:work-order
+/blueprint-work-order
 ```
 
 Generates isolated task package for subagent execution with minimal context.
@@ -185,22 +185,22 @@ project-root/
 See [workflow.md](workflow.md) for complete workflow documentation.
 
 ### Phase 1: Planning
-1. Create PRPs with `/prp:create` - includes research and context curation
-2. Curate ai_docs for key libraries with `/prp:curate-docs`
-3. Run `/blueprint:generate-skills` to create project-specific skills
-4. Run `/blueprint:generate-commands` to create workflow commands
+1. Create PRPs with `/prp-create` - includes research and context curation
+2. Curate ai_docs for key libraries with `/prp-curate-docs`
+3. Run `/blueprint-generate-skills` to create project-specific skills
+4. Run `/blueprint-generate-commands` to create workflow commands
 5. Review confidence scores and refine if < 7
 
 ### Phase 2: Development
-1. Run `/project:continue` to analyze state and resume work
+1. Run `/project-continue` to analyze state and resume work
 2. Claude automatically discovers and applies project-specific skills
 3. Follow TDD workflow (tests first, then implementation)
-4. Use `/blueprint:work-order` to create isolated tasks for subagents
+4. Use `/blueprint-work-order` to create isolated tasks for subagents
 5. Commit incrementally with conventional commits
 
 ### Phase 3: Iteration
 1. Project state tracked in git, PRDs, and work-overview
-2. `/project:continue` picks up where you left off
+2. `/project-continue` picks up where you left off
 3. Skills evolve as patterns emerge (update skill definitions)
 4. Work-orders document completed and pending tasks
 
@@ -209,7 +209,7 @@ See [workflow.md](workflow.md) for complete workflow documentation.
 ### For Solo Developers
 - **Context persistence** - Project state and patterns codified, not just in your head
 - **Consistent patterns** - Skills enforce standards automatically
-- **Rapid context switching** - `/project:continue` quickly resumes any project
+- **Rapid context switching** - `/project-continue` quickly resumes any project
 
 ### For Teams
 - **Onboarding** - New contributors read skills to understand "how we build"
@@ -257,19 +257,19 @@ Use Blueprint Development in CI:
 See `.claude/commands/` for available commands:
 
 **PRP Commands:**
-- `/prp:create` - Create a PRP with systematic research and context curation
-- `/prp:execute` - Execute a PRP with validation loop
-- `/prp:curate-docs` - Curate library/project documentation for ai_docs
+- `/prp-create` - Create a PRP with systematic research and context curation
+- `/prp-execute` - Execute a PRP with validation loop
+- `/prp-curate-docs` - Curate library/project documentation for ai_docs
 
 **Blueprint Commands:**
-- `/blueprint:init` - Initialize Blueprint Development in a project
-- `/blueprint:generate-skills` - Generate skills from PRPs
-- `/blueprint:generate-commands` - Generate commands from PRPs
-- `/blueprint:work-order` - Create isolated work-order
+- `/blueprint-init` - Initialize Blueprint Development in a project
+- `/blueprint-generate-skills` - Generate skills from PRPs
+- `/blueprint-generate-commands` - Generate commands from PRPs
+- `/blueprint-work-order` - Create isolated work-order
 
 **Project Commands:**
-- `/project:continue` - Analyze state and continue work
-- `/project:test-loop` - Start TDD test → fix cycle
+- `/project-continue` - Analyze state and continue work
+- `/project-test-loop` - Start TDD test → fix cycle
 
 ## Skills
 

--- a/exact_dot_claude/docs/blueprint-development/ai_docs-template/README.md
+++ b/exact_dot_claude/docs/blueprint-development/ai_docs-template/README.md
@@ -300,9 +300,9 @@ Before adding to ai_docs:
 - [ ] Is it version-specific?
 - [ ] Are anti-patterns shown?
 
-### Using `/prp:curate-docs`
+### Using `/prp-curate-docs`
 
-Run `/prp:curate-docs` to:
+Run `/prp-curate-docs` to:
 1. Research a library's documentation
 2. Extract relevant patterns
 3. Generate ai_docs entry

--- a/exact_dot_claude/docs/blueprint-development/prd-template.md
+++ b/exact_dot_claude/docs/blueprint-development/prd-template.md
@@ -506,6 +506,6 @@ PRDs in Blueprint Development serve multiple purposes:
 2. **Architecture documentation** - How to structure the code
 3. **Skill generation input** - Source material for generating project-specific skills
 4. **Work-order context** - Background information for isolated tasks
-5. **Project continuity** - Enables `/project:continue` to understand goals
+5. **Project continuity** - Enables `/project-continue` to understand goals
 
 Well-written PRDs enable Blueprint Development to generate high-quality, project-specific skills and commands that enforce your architectural decisions, testing strategies, and quality standards automatically.

--- a/exact_dot_claude/docs/blueprint-development/prp-template.md
+++ b/exact_dot_claude/docs/blueprint-development/prp-template.md
@@ -735,6 +735,6 @@ PRPs (enhanced context) → Skills (patterns) → Work-Orders (tasks) → Subage
 - **Work-Orders** from `Task Breakdown`
 
 **PRP Confidence Score determines:**
-- **7+**: Execute with `/prp:execute`
+- **7+**: Execute with `/prp-execute`
 - **9+**: Delegate to subagent with work-order
 - **< 7**: Invest in research and documentation first

--- a/exact_dot_claude/docs/blueprint-development/work-order-template.md
+++ b/exact_dot_claude/docs/blueprint-development/work-order-template.md
@@ -563,7 +563,7 @@ If a work-order depends on another:
 ### 1. Generate Work-Order
 
 ```bash
-/blueprint:work-order
+/blueprint-work-order
 ```
 
 Claude analyzes project state and creates next logical work-order.

--- a/exact_dot_claude/docs/blueprint-development/workflow.md
+++ b/exact_dot_claude/docs/blueprint-development/workflow.md
@@ -16,7 +16,7 @@ PRDs → Generate Skills/Commands → Development Loop → Work-Orders → Subag
 
 ```bash
 cd your-project/
-/blueprint:init
+/blueprint-init
 ```
 
 **What happens:**
@@ -76,7 +76,7 @@ Write tests first for:
 ### Step 3: Generate Skills
 
 ```bash
-/blueprint:generate-skills
+/blueprint-generate-skills
 ```
 
 **What happens:**
@@ -234,13 +234,13 @@ description: "Code review criteria, performance baselines, and security standard
 ### Step 4: Generate Commands
 
 ```bash
-/blueprint:generate-commands
+/blueprint-generate-commands
 ```
 
 **What happens:**
 Claude generates workflow commands based on PRDs and project structure:
 
-**1. `/project:continue`** - Resume development
+**1. `/project-continue`** - Resume development
 ```markdown
 ---
 description: "Analyze project state and continue development where left off"
@@ -256,10 +256,10 @@ Analyze the current project state and continue development:
 5. Identify next logical task based on PRDs and project state
 6. Begin work following TDD workflow (tests first)
 
-If starting a new feature, create a work-order first with `/blueprint:work-order`.
+If starting a new feature, create a work-order first with `/blueprint-work-order`.
 ```
 
-**2. `/project:test-loop`** - TDD automation
+**2. `/project-test-loop`** - TDD automation
 ```markdown
 ---
 description: "Run test → fix → refactor loop with TDD workflow"
@@ -291,7 +291,7 @@ Stop and report when:
 ### Step 1: Start or Resume Work
 
 ```bash
-/project:continue
+/project-continue
 ```
 
 **What Claude does:**
@@ -456,7 +456,7 @@ Create work-orders for:
 ### Generate Work-Order
 
 ```bash
-/blueprint:work-order
+/blueprint-work-order
 ```
 
 **What Claude does:**
@@ -598,7 +598,7 @@ Add TOTP-based 2FA as optional security enhancement...
 
 Then regenerate skills:
 ```bash
-/blueprint:generate-skills
+/blueprint-generate-skills
 ```
 
 ### Continue Where You Left Off
@@ -606,11 +606,11 @@ Then regenerate skills:
 Switch between projects easily:
 ```bash
 cd project-a/
-/project:continue
+/project-continue
 # Resumes project A exactly where you left off
 
 cd ../project-b/
-/project:continue
+/project-continue
 # Resumes project B with its own context
 ```
 
@@ -620,9 +620,9 @@ cd ../project-b/
 
 Create multiple work-orders for parallel execution:
 ```bash
-/blueprint:work-order    # Creates 004-implement-password-reset.md
-/blueprint:work-order    # Creates 005-add-rate-limiting.md
-/blueprint:work-order    # Creates 006-setup-email-service.md
+/blueprint-work-order    # Creates 004-implement-password-reset.md
+/blueprint-work-order    # Creates 005-add-rate-limiting.md
+/blueprint-work-order    # Creates 006-setup-email-service.md
 
 # Execute in parallel with different subagents
 <execute work-order 004 with subagent-1>
@@ -655,11 +655,11 @@ Generate work-orders from CI failures:
 
 Blueprint Development workflow:
 
-1. **Initialize** - `/blueprint:init` creates structure
+1. **Initialize** - `/blueprint-init` creates structure
 2. **Plan** - Write PRDs defining features and architecture
 3. **Generate** - Create skills and commands from PRDs
-4. **Develop** - `/project:continue` resumes work with TDD
-5. **Delegate** - `/blueprint:work-order` creates isolated tasks
+4. **Develop** - `/project-continue` resumes work with TDD
+5. **Delegate** - `/blueprint-work-order` creates isolated tasks
 6. **Execute** - Subagents work on isolated work-orders
 7. **Iterate** - Refine skills and PRDs as patterns emerge
 


### PR DESCRIPTION
## Summary

Follow-up #1 of 3 from PR #283. The old `/namespace:command` slash-command syntax no longer resolves — the plugin marketplace uses bare `/skill-name` forms (`/configure-mcp`, `/blueprint-status`, `/test-quick`, …). These refs are **documentation, not executable**, so PR #283's regression test (`tests/test-claude-plugin-references.sh`) deliberately does not cover them — but stale syntax in live docs poisons agent/human context.

## Changes

**Live docs — rewritten to bare form:**
- `CLAUDE.md` — `/configure-mcp`, `/blueprint-{status,execute,derive-plans}`
- `docs/blueprint/README.md`, `docs/prds/project-overview.md`
- `exact_dot_claude/docs/blueprint-development/*` (whole methodology dir; applied to `~/.claude/docs/` via `chezmoi apply`)

**ADRs — triaged, not blanket-rewritten** (Accepted ADRs are supersede-don't-rewrite):
- **0005** (namespace-based command org): decision obsolete → Status **Superseded** + top-note; `/namespace:command` body kept as historical record
- **0010** (tiered test execution): the tiered-test *concept* stands, but the `/test:*` command catalog is superseded by `testing-plugin` skills → Status note + top-note; body kept
- **0008**: light-fixed 2 incidental `/configure:mcp` → `/configure-mcp`
- **0009**: light-fixed 1 incidental `/git:commit` → `/git-commit`

## Intentionally left alone

`exact_dot_claude/docs/prds/daily-catchup.PRD.md` (`/sync:daily`, 29 refs) — a **bespoke planned-command design**, not a stale plugin-namespace ref. Its colons are embedded in designed filenames (`sync:daily-state.json`, `.claude/commands/sync:daily.md`); a blind hyphenation would corrupt them. Out of scope for this concern.

## Verification

`git grep -nE '/[a-z][a-z0-9-]*:[a-z]' -- CLAUDE.md docs/ exact_dot_claude/docs/` now returns only the intended historical body text inside the two Superseded/noted ADRs (0005, 0010) and the out-of-scope `daily-catchup.PRD.md`. No colon-form refs remain in any live doc. `chezmoi status ~/.claude/docs/blueprint-development` is clean; pre-commit passed on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)