### PR TITLE
ci: centralize Claude --model ids via repo variables with inline defaults

### DIFF
--- a/.github/workflows/auto-fix-ci-failures.yml
+++ b/.github/workflows/auto-fix-ci-failures.yml
@@ -186,7 +186,7 @@ jobs:
             After making changes, explain what you fixed and why.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --model claude-opus-4-5-20251101
+            --model ${{ vars.CLAUDE_MODEL || 'claude-opus-4-8' }}
             --allowed-tools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(bun:*),Bash(npm:*),Bash(npx:*),Bash(gh:*)"
 
       - name: Push fix branch

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -64,5 +64,5 @@ jobs:
 
           # Claude Code configuration via CLI arguments
           claude_args: |
-            --model claude-opus-4-5-20251101
+            --model ${{ vars.CLAUDE_MODEL || 'claude-opus-4-8' }}
             --allowedTools "${{ steps.tools-config.outputs.allowed_tools }}"

--- a/.github/workflows/claude-config-validation.yml
+++ b/.github/workflows/claude-config-validation.yml
@@ -70,7 +70,7 @@ jobs:
 
             **1. Agent Files (*.md in agents/)**
             - Required frontmatter: `name`, `model`, `color`, `description`, `tools`
-            - Model should be valid Claude model (claude-sonnet-4-5, claude-opus-4-5, etc.)
+            - Model should be valid Claude model (claude-sonnet-4-6, claude-opus-4-8, etc.)
             - Description should clearly state use case
             - Tools should follow least-privilege principle
             - Check for deprecated model names
@@ -144,7 +144,7 @@ jobs:
                - List what would be changed
 
           claude_args: |
-            --model claude-sonnet-4-5-20250929
+            --model ${{ vars.CLAUDE_MODEL_FAST || 'claude-sonnet-4-6' }}
             --allowedTools "${{ steps.tools-config.outputs.allowed_tools }}"
             --max-turns 50
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -153,7 +153,7 @@ jobs:
 
           # Claude Code configuration via CLI arguments
           claude_args: |
-            --model claude-opus-4-5-20251101
+            --model ${{ vars.CLAUDE_MODEL || 'claude-opus-4-8' }}
             --allowedTools ${{ steps.tools-config.outputs.allowed_tools }}
             --max-turns 100
 


### PR DESCRIPTION
## Summary

Follow-up #2 of 3 from PR #283. Four AI workflows hardcoded **retired model snapshots** (`claude-opus-4-5-20251101`, `claude-sonnet-4-5-20250929`). This centralizes the model id behind a single GitHub Actions repo variable, with a safe inline default so an unset variable can never pass an empty `--model`.

## Changes

| Workflow | Before | After |
|---|---|---|
| `claude.yml` | `--model claude-opus-4-5-20251101` | `--model ${{ vars.CLAUDE_MODEL \|\| 'claude-opus-4-8' }}` |
| `claude-code-review.yml` | same | same |
| `auto-fix-ci-failures.yml` | same | same |
| `claude-config-validation.yml` | `--model claude-sonnet-4-5-20250929` | `--model ${{ vars.CLAUDE_MODEL_FAST \|\| 'claude-sonnet-4-6' }}` (kept on sonnet by design) |

Also refreshed the stale example model list in `claude-config-validation.yml` (`claude-sonnet-4-5, claude-opus-4-5` → `claude-sonnet-4-6, claude-opus-4-8`).

## Repo variables (set)

```
CLAUDE_MODEL=claude-opus-4-8
CLAUDE_MODEL_FAST=claude-sonnet-4-6
```

Wired up so the indirection is real (optional given the `||` default). Model ids are not secret, so a repo *variable* (not secret) is appropriate for this public repo.

## Verification

`actionlint` clean on all four files (the three pre-existing `steps.claude.outputs.changed` warnings are unrelated to this change). No `claude-opus-4-5` / `claude-sonnet-4-5` ids remain in `.github/`. `gh variable list` confirms both variables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)