### PR TITLE
docs(rules): bulk-sweep match-classification rule + chezmoi under-apply note

### DIFF
--- a/exact_dot_claude/rules/bulk-syntax-sweep-classify-matches.md
+++ b/exact_dot_claude/rules/bulk-syntax-sweep-classify-matches.md
@@ -1,0 +1,99 @@
+# Classify Every Match Before a Bulk Syntax-Modernization Sweep
+
+When modernizing a syntax across many files with a regex / `sed` / `perl`
+pass — a command rename (`/ns:cmd` → `/ns-cmd`), a tool rename, a path or
+import-style migration, an API-version bump in prose — the matched set is
+**heterogeneous even though every hit looks textually identical**. A single
+pattern catches genuine stale targets *and* several look-alikes that must NOT
+be transformed. Blindly rewriting all matches corrupts the look-alikes
+silently: the sweep reports success, and the damage surfaces far downstream
+(a broken designed filename, a rewritten immutable record).
+
+So before editing, **enumerate the matches and bucket each one** into one of
+four categories — each needs different handling.
+
+## The four categories
+
+| Category | Handling | Canonical example (command-syntax sweep, 2026-06) |
+|---|---|---|
+| **1. Genuine stale target** | Transform | `/configure:mcp` → `/configure-mcp` in live docs |
+| **2. False positive** — merely matches the pattern | Leave | `laurigates/dotfiles:latest` (docker tag); `redis://host:6379` (digit after `:`, not a command) |
+| **3. Out-of-scope design** legitimately using the old form — esp. **delimiter embedded in designed filenames/paths** | Leave; transforming corrupts the design | `/sync:daily` PRD whose colon also appears in `sync:daily-state.json`, `.claude/commands/sync:daily.md` |
+| **4. Immutable / historical record** matching the pattern | Supersede-/status-note, **do NOT rewrite the body** | Accepted ADRs documenting the old `/namespace:command` convention |
+
+Category 3 is the sharpest trap: the delimiter you're replacing (`:`, `/`,
+`.`, `-`) often also appears in **filenames, config keys, or URLs** that the
+matched token participates in. Hyphenating `/sync:daily` to `/sync-daily` also
+rewrites every `sync:daily-state.json` path in the same doc — silently
+breaking a design.
+
+## The verification is NOT "zero matches remain"
+
+The naive success test — *"re-run the grep; it should return nothing"* — is
+**wrong**, because categories 3 and 4 are *supposed* to keep matching. The
+correct test is:
+
+> **Zero matches remain *outside the intentionally-preserved set*.**
+
+Enumerate the preserved buckets (which files/lines are categories 2–4) up
+front, then verify the grep returns *only* those. A verification that demands
+literal zero will either fail spuriously or — worse — pressure you into
+corrupting a category-3 design or rewriting a category-4 record just to make
+the count go to zero. (In the 2026-06 sweep the plan's near-zero expectation
+silently omitted a whole category-3 file; classifying first caught it, the
+grep count would not have.)
+
+## Method
+
+```sh
+# 1. Enumerate every match, deduped, before touching anything
+git grep -nhoE '/[a-z][a-z0-9-]*:[a-z][a-z0-9-]*' -- <scope> | sort -u
+
+# 2. Tighten the pattern to drop obvious false positives at the source
+#    (e.g. require [a-z] after the delimiter to skip ":6379" ports/URLs)
+
+# 3. Bucket the remaining hits → categories 1–4 (read the surrounding line)
+
+# 4. Scope the transform to category-1 files ONLY; hand-handle 3 & 4
+perl -i -pe 's{/([a-z][a-z0-9-]*):([a-z][a-z0-9-]*)}{/$1-$2}g' <category-1 files>
+
+# 5. Verify: grep returns ONLY the pre-identified category 2–4 lines
+```
+
+Drive the false-positive exclusion into the **pattern** where you can (a port
+`:6379` is excluded by requiring a letter after the colon) so the sweep
+mechanically can't touch them; reserve manual judgment for categories 3 and 4,
+which look like real targets and can only be told apart by reading intent.
+
+## When it bites
+
+- Command-syntax migrations (`/ns:cmd` → `/ns-cmd`), tool/binary renames in
+  docs, path or import-style migrations, API-version bumps in prose — any
+  find-replace where the delimiter or token **also** appears in filenames,
+  config keys, URLs, unrelated designs, or historical records.
+- Docs trees that mix live guidance with **ADRs / changelogs / design PRDs** —
+  the live docs are category 1, the records are category 4, a planned-feature
+  PRD may be category 3, all matching the same regex.
+
+## Relationship to sibling rules
+
+- `verify-upstream-before-patching.md` / `read-issue-thread-before-contributing.md`
+  — same instinct: establish the authoritative *intent* before acting, don't
+  trust a surface signal.
+- `textual-merge-duplicates-identical-additions.md`,
+  `squash-merge-orphans-post-merge-commits.md` — kin in spirit: an automated
+  pass reporting success is not proof the *result* is correct; verify the
+  content, not the exit code.
+- ADR handling (category 4) follows the standard supersede-don't-rewrite
+  convention — set `Status: Superseded` + a top-note, leave the body as a
+  historical record.
+
+## Rationale
+
+The regex sees **text**; the transform needs **semantics**. The same surface
+pattern spans genuine targets, false positives, live designs that legitimately
+use the old form, and immutable records — and each demands different handling.
+Classifying the match-set up front converts a silent corruption (a broken
+designed filename, a rewritten ADR) — caught later, downstream, under
+time pressure — into a five-minute bucketing pass with the intent fresh in
+hand.

--- a/exact_dot_claude/rules/chezmoi-conventions.md
+++ b/exact_dot_claude/rules/chezmoi-conventions.md
@@ -183,6 +183,53 @@ jq -n --argjson cur "$current" --argjson ov "$overlay" '$cur * $ov'
 
 See the `chezmoi-expert` skill REFERENCE for the general `modify_` mechanics. For the permission-key specifics of a Claude Code settings overlay, see `claude-code-auto-mode.md`.
 
+## A Non-`--force` Apply Silently UNDER-Applies Drifted Targets
+
+`chezmoi apply <tree>` is **not** all-or-nothing. When some target files in
+the tree have **local edits made since chezmoi last wrote them** (target-side
+drift — a hand-edit, or another tool that rewrote the target), a non-`--force`
+apply syncs the *clean* files and **silently skips the drifted ones**, then
+**exits 0**. So "apply ran, exit 0" is **not** proof the whole tree synced —
+it can leave part of the tree unsynced with no error.
+
+Observed 2026-06 applying `~/.claude/docs/blueprint-development` (7 edited
+files): a plain `chezmoi apply -v <tree>` synced 3, exited 0 (looked done),
+and left 4 still `M` in `chezmoi status` because the targets had drifted.
+
+### The trap is reaching for `--force` reflexively
+
+The obvious "fix" — re-run with `--force` — is exactly the move that
+**clobbers the target-side edits**. `--force` skips the safety prompt and
+overwrites the drifted targets with the source, destroying whatever direct
+edits (yours or another tool's) caused the skip in the first place. The skip
+was chezmoi *protecting* those edits; forcing past it discards them.
+
+### The rule: diff before you force
+
+`chezmoi status <tree>` tells you **which** files are out of sync (the `M`/`D`
+flags). It does **not** tell you what would be lost. Before any `--force`:
+
+1. **`chezmoi diff <tree>`** — see *what* the apply would overwrite. The `-`
+   lines are the target-side edits that `--force` would destroy.
+2. **Judge the drift.** If those edits are unwanted (stale runtime state you
+   don't care about), `--force` is safe. If they're wanted, **capture them
+   back to source first** — `just capture-drift` (preview) → `just
+   capture-drift-apply`, or `chezmoi re-add` / hand-port per the Runtime Drift
+   workflow above (templates need `chezmoi merge`, not `re-add`).
+3. **Only then** `chezmoi apply --force <tree>`, and re-check `chezmoi status
+   <tree>` is clean (and `chezmoi diff <tree>` empty) to confirm the whole
+   tree actually synced.
+
+| Signal | Tells you | Use it to |
+|---|---|---|
+| `chezmoi status <tree>` after apply | *which* files didn't sync (`M`/`D`) | detect the silent under-apply |
+| `chezmoi diff <tree>` | *what* `--force` would overwrite | decide whether the drift is disposable before forcing |
+
+Prefer `chezmoi diff` over a reflexive `--force` precisely so that direct
+edits to target files aren't clobbered. `--force` is the last step after the
+diff confirms there's nothing worth keeping — never the first reaction to a
+partial apply.
+
 ## A Non-`dot_` File at the Source Root Silently Applies to `$HOME`
 
 Every file in the chezmoi source dir maps to a target unless ignored. A


### PR DESCRIPTION
## Summary

Two durable lessons codified from the PR #283 follow-up sweep (#284–#286), per a session retro.

### New rule — `bulk-syntax-sweep-classify-matches.md`

When modernizing a syntax across files with a regex/`sed`, the matched set is **heterogeneous even though every hit looks identical**. The rule says to classify each match before editing into four buckets, each handled differently:

1. **Genuine stale target** → transform
2. **False positive** (`laurigates/dotfiles:latest`, `redis://host:6379`) → leave
3. **Out-of-scope design** with the delimiter embedded in **designed filenames** (`/sync:daily` ↔ `sync:daily-state.json`) → leave; transforming corrupts the design
4. **Immutable historical record** (Accepted ADRs) → supersede-note, don't rewrite the body

Key insight: the success test is **not** "zero matches remain" but "zero *outside the intentionally-preserved set*" — the live sweep's near-zero expectation silently omitted a category-3 file; classifying caught it, the grep count would not have.

### Augment — `chezmoi-conventions.md`: "A Non-`--force` Apply Silently UNDER-Applies Drifted Targets"

A non-forced `chezmoi apply <tree>` syncs clean files and **silently skips drifted targets, exiting 0** (observed: 3 of 7 files applied, looked done). Exit-0 is not proof of a full sync.

Per @laurigates's steer, the fix is **not** a reflexive `--force` (it clobbers the very target-side edits the skip was protecting): run `chezmoi diff <tree>` to *see* what would be overwritten, capture wanted edits back to source first, and only force once the drift is confirmed disposable. `status` says *which* files differ; `diff` says *what* would be lost.

## Verification

Both files synced to `~/.claude/rules/` via scoped `chezmoi apply` (status clean, no stray ` D`). Pre-commit passed. The new rule is technique-oriented (always-loaded, no path scoping), consistent with `verify-upstream-before-patching.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)