### PR TITLE
chore(just): centralize Claude model in plugins-setup recipes

### DIFF
--- a/exact_dot_claude/rules/orbstack-gui-quit-orphans-helper.md
+++ b/exact_dot_claude/rules/orbstack-gui-quit-orphans-helper.md
@@ -1,0 +1,70 @@
+# Quitting the OrbStack GUI Orphans the Helper VM — Use `orb stop`
+
+Closing the OrbStack **app** does not stop the OrbStack **VM**. The
+`OrbStack Helper` process *is* the Linux VM, and it runs independently of
+the GUI front-end. Quitting the window — or `osascript -e 'quit app
+"OrbStack"'`, or even File→Quit — closes the UI and leaves the helper
+running, reparented to launchd. It keeps consuming ~40–50% CPU and ~20%
+RAM with **no visible app**, so a machine that feels hot "even though I
+closed everything" is often this orphaned VM.
+
+The failure is invisible: Activity Monitor shows no OrbStack *app*, yet
+`OrbStack Helper` sits near the top of the CPU list. Quitting the GUI
+again does nothing — there's no GUI left to quit.
+
+## The tell
+
+After "closing" OrbStack, the helper's parent PID is **1** (launchd) —
+it was reparented when the GUI exited, but never told to stop:
+
+```
+ps -Ao pid,ppid,pcpu,comm | grep -i '[o]rb'
+# 1531  1  47.1  /Applications/OrbStack.app/.../OrbStack Helper
+#       ^-- PPID 1 = orphaned to launchd, still running
+```
+
+A running `OrbStack Helper` with `PPID 1` after the app is "closed" is
+the signature.
+
+## The fix
+
+Stop the VM through the CLI, which actually shuts the Linux VM down
+(clean flush, not a hard kill):
+
+```
+orb stop
+```
+
+The binary is `/opt/homebrew/bin/orb` (Homebrew install) — it may not be
+on a non-interactive shell's PATH, so use the absolute path from scripts:
+`/opt/homebrew/bin/orb stop`. Verify it worked:
+
+```
+ps -Aceo pid,comm -r | grep -i '[o]rb' || echo "OrbStack stopped"
+```
+
+`orb start` brings the VM back, so stopping is fully reversible — no
+reason to hesitate. Prefer `orb stop` over `kill <pid>`: the kill skips
+the VM's own shutdown and can leave container/volume state mid-write.
+
+## When this bites
+
+- Triaging a hot/loud Mac: OrbStack is a common top CPU+RAM consumer that
+  survives "closing the app", so it reads as a phantom load.
+- Any script or agent that tries to free resources by quitting the GUI
+  (`osascript -e 'quit app "OrbStack"'`) — it won't stop the VM; call
+  `orb stop` instead.
+
+## Relationship to sibling rules
+
+- `disk-full-recovery.md` — OrbStack's VM disk image is also a frequent
+  space hog when the VM is left running; stopping it is the first step
+  before reclaiming.
+
+## Rationale
+
+The GUI and the VM are separate processes, but the app's framing ("quit
+OrbStack") implies quitting stops everything — it doesn't. One `orb stop`
+halts the actual resource consumer; checking `PPID 1` on the helper is
+the five-second diagnosis that distinguishes "orphaned VM" from "OrbStack
+genuinely gone".

--- a/private_dot_config/just/justfile
+++ b/private_dot_config/just/justfile
@@ -12,6 +12,11 @@
 #   • git.just      — Git branch hygiene (branch-audit)
 # Edit those, then `chezmoi apply`. Imports are relative to this file's directory.
 
+# Claude model used by headless `claude -p` recipes (single source of truth,
+# referenced as {{claude_model}} across the imported recipe files). Update here
+# to bump the version everywhere.
+claude_model := "claude-opus-4-8"
+
 import 'plugins.just'
 import 'claude.just'
 import 'git.just'

--- a/private_dot_config/just/plugins.just
+++ b/private_dot_config/just/plugins.just
@@ -84,12 +84,12 @@ plugins-reinstall: plugins-uninstall plugins-install plugins-enable
 # Configure current repository to use laurigates/claude-plugins marketplace (writes .claude/settings.json and workflows)
 plugins-setup-repo:
     @echo "{{BLUE}}Configuring Claude plugins for repository at $(pwd)...{{NORMAL}}"
-    CLAUDECODE= claude -p "/configure-claude-plugins --fix" --permission-mode acceptEdits
+    CLAUDECODE= claude -p "/configure-claude-plugins --fix" --model {{claude_model}} --permission-mode auto
 
 # Report current repository's Claude plugin configuration without changes
 plugins-check-repo:
     @echo "{{BLUE}}Checking Claude plugin configuration for repository at $(pwd)...{{NORMAL}}"
-    CLAUDECODE= claude -p "/configure-claude-plugins --check-only"
+    CLAUDECODE= claude -p "/configure-claude-plugins --check-only" --model {{claude_model}}
 
 # Audit committed project plugin pins for drift vs canonical (read-only)
 plugins-audit:


### PR DESCRIPTION
## Problem

`just -g plugins-setup-repo` stalled in its non-interactive `claude -p` run. `--permission-mode acceptEdits` auto-approves ordinary edits but does **not** clear the separate gate on the protected `.claude/settings.json` path. With no interactive prompt available in `-p` mode, the settings write hung pending and the recipe silently half-completed — `.github/` workflows landed, but `.claude/settings.json` did not.

## Changes

- **`plugins-setup-repo` → `--permission-mode auto`.** The auto-mode classifier auto-approves the legitimate in-repo settings write while still enforcing hard/soft-deny boundaries — narrower than `bypassPermissions`, which disables all checks.
- **`claude_model := "claude-opus-4-8"` in the global `justfile`** as a single source of truth. just merges imports into one namespace, so the variable is in scope for every imported recipe file.
- **`--model {{claude_model}}` on both `claude -p` recipes** (`plugins-setup-repo` + `plugins-check-repo`) so the pinned version is updated in one place.

## Verification

```
$ just -g --evaluate claude_model
claude-opus-4-8
$ just -g --show plugins-setup-repo
    CLAUDECODE= claude -p "/configure-claude-plugins --fix" --model {{ claude_model }} --permission-mode auto
```

## Note

`--permission-mode auto` requires Opus 4.6+ / Sonnet 4.6+ on the Anthropic API. On a runner with an older pinned model it would fall back to gating the protected write again — fine for local use, worth knowing if this recipe is ever run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)