### PR TITLE
docs(rules): headless claude -p protected-path gate + branch-from-pushed-main

### DIFF
--- a/exact_dot_claude/rules/branch-from-pushed-main.md
+++ b/exact_dot_claude/rules/branch-from-pushed-main.md
@@ -1,0 +1,69 @@
+# Push/Stash Stray `main` Commits Before Branching — Else They Ride Into the PR
+
+When you cut a feature branch off local `main`, **any commits sitting unpushed
+on `main` come with it**. The branch starts at `main`'s tip, so a later
+`gh pr create --base main` diffs your branch against *origin*'s `main` — which
+doesn't have those stray commits — and the PR bundles them in alongside your
+intended change. On a squash-merge repo the squash then collapses *both* the
+stray commits and your real work into one commit on `origin/main`, landing the
+strays under an unrelated PR title. The PR shows more files than you changed,
+and the provenance is wrong.
+
+The failure is invisible at branch-create time: `git switch -c feat origin/main`
+*would* be clean, but `git switch -c feat` (off the local tip) silently inherits
+whatever local `main` is ahead by.
+
+## The trap (real: dotfiles PR #288, 2026-06)
+
+Local `main` carried one **unpushed** commit (`a2f93f5`, an unrelated rule).
+A feature branch cut from `main` therefore contained `a2f93f5` + the real
+justfile change. The PR's squash (`1bcbe83`) bundled **three files** — the
+stray rule plus the two intended files — under the justfile PR's title.
+Harmless here (the rule needed to land anyway), but the diff and the commit
+message disagreed about what the PR was. The SessionStart hook had even warned
+"unpushed commits"; the miss was not checking `git log origin/main..main`
+before branching.
+
+## The rule
+
+Before `git switch -c <branch>` for new PR work, confirm local `main` isn't
+ahead of its remote — and if it is, deal with the strays first:
+
+```sh
+git log --oneline origin/main..main      # empty == clean to branch from
+```
+
+- **Empty** → branch normally.
+- **Non-empty** → either push the strays first (`git push origin main`, if they
+  belong on `main`), or branch explicitly from the remote so they don't ride
+  along: `git switch -c <branch> origin/main`. Uncommitted working-tree edits
+  are not a problem (they don't get committed by branching) — only *committed*
+  unpushed commits do.
+
+The robust habit is to **always branch from `origin/main`** for fresh PR work:
+`git fetch origin && git switch -c <branch> origin/main`. That makes the PR diff
+exactly your commits regardless of local `main`'s state.
+
+## When it bites
+
+- Long-lived local `main` that accumulates the occasional direct commit before
+  it's pushed (docs tweaks, rule additions).
+- Squash-merge repos especially — the squash hides the bundling inside one
+  commit, so it's only visible in the file list, not the history.
+
+## Relationship to sibling rules
+
+- `squash-merge-orphans-post-merge-commits.md` — the *mirror* case: commits
+  added to a branch *after* its squash-merge are orphaned, not bundled.
+- `branch-merge-detection.md` — `git log origin/main..main` is the same
+  ancestry-aware check used there to reason about what a branch actually carries.
+- `git-add-atomic-pathspec.md`, `stacked-pr-merge-order.md` — kin: the diff /
+  merge result is not what a green command implies; verify the *content* landed.
+
+## Rationale
+
+"My branch has my change" and "my branch has *only* my change" are different
+claims whenever local `main` is ahead of origin. One `git log origin/main..main`
+(or just branching from `origin/main`) before cutting the branch converts a
+mislabeled PR — caught later in the file list, or after merge — into a
+five-second pre-flight check.

--- a/exact_dot_claude/rules/claude-code-auto-mode.md
+++ b/exact_dot_claude/rules/claude-code-auto-mode.md
@@ -113,6 +113,49 @@ intent; naming the exact action ("force-push this branch") is.
 API (Opus 4.7+/4.8 on Bedrock/Vertex/Foundry, which also need
 `CLAUDE_CODE_ENABLE_AUTO_MODE=1`).
 
+## Headless `claude -p`: `acceptEdits` does NOT clear the protected-path gate
+
+The permission *mode* and the protected-path gate are **separate checks**.
+`--permission-mode acceptEdits` auto-approves ordinary file edits, but writes
+to **protected paths** — notably `.claude/settings.json` — route to a separate
+gate that `acceptEdits` does not satisfy (the same routing that sends protected
+writes to the classifier under auto mode). In an interactive session you get a
+prompt; in a **non-interactive `claude -p` run there is nobody to grant it**, so
+the write **hangs *pending*** and the command **silently half-completes** —
+exit looks fine, unprotected files (`.github/workflows/…`) land, the protected
+file does not.
+
+The tell: a headless recipe that "ran successfully" but left
+`.claude/settings.json` unwritten, reported as `PENDING (write permission not
+granted)`.
+
+### Fix — pick the mode by blast radius
+
+For a headless recipe whose job is to write protected paths:
+
+| Mode | Behavior on the protected write | Use when |
+|---|---|---|
+| `acceptEdits` | **stalls pending** — wrong for headless | — |
+| `auto` | classifier auto-approves the legitimate in-repo write, still enforces hard/soft-deny | **preferred** — narrowest that works |
+| `bypassPermissions` | disables *all* checks for the run | only if `auto` is unavailable (older/pinned model) |
+
+`--permission-mode auto` is the right default — narrower than
+`bypassPermissions`, which unsandboxes the whole nested run. **But `auto`
+requires Opus 4.6+ / Sonnet 4.6+** (see below); on a runner with an older
+pinned model `auto` falls back to gating the protected write again, so a recipe
+that pins an old model in CI needs `bypassPermissions` (or no protected write).
+`--allowedTools 'Write(.claude/settings.json)'` does **not** help — the
+protected-path gate sits in front of the tool allowlist, and there is no
+classifier round-trip in `-p` mode anyway.
+
+Most surgical of all: have the recipe write `.claude/settings.json` directly
+(a `jq`/heredoc template), so no nested `claude` permission gate is involved.
+
+(Discovered 2026-06 fixing the dotfiles `plugins-setup-repo` justfile recipe:
+`claude -p "/configure-claude-plugins --fix" --permission-mode acceptEdits`
+wrote the workflows but stranded `.claude/settings.json`; switching to
+`--permission-mode auto` fixed it.)
+
 ## Ref
 
 - <https://code.claude.com/docs/en/permission-modes.md>


### PR DESCRIPTION
Two learnings distilled from the `plugins-setup-repo` justfile fix session (PR #288).

## `claude-code-auto-mode.md` — new section

Headless `claude -p` + protected-path gate. The permission *mode* and the protected-path gate are **separate checks**: `--permission-mode acceptEdits` auto-approves ordinary edits but does **not** clear the gate on protected paths like `.claude/settings.json`. In a non-interactive `-p` run there's no one to grant it, so the write hangs *pending* and the command silently half-completes (workflows land, settings doesn't). Adds a mode-by-blast-radius table: `auto` (preferred — narrowest that works) vs `bypassPermissions` (unsandboxes the run) vs writing the file directly. Notes the `auto` model requirement and why `--allowedTools` doesn't help.

## `branch-from-pushed-main.md` — new rule

Unpushed commits sitting on local `main` ride into a feature branch cut from `main`, so the PR bundles them under the wrong title — and on a squash repo the squash hides it inside one commit's file list. Fix: `git log origin/main..main` before branching, or just branch from `origin/main`. Links to the `squash-merge-orphans-post-merge-commits.md` mirror case.

Both observed first-hand this session: #288 stranded `.claude/settings.json` under `acceptEdits`, and bundled an unrelated unpushed rule commit into its squash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)