### PR TITLE
feat(git): per-location identity via includeIf

### DIFF
--- a/private_dot_config/git/personal.inc
+++ b/private_dot_config/git/personal.inc
@@ -1,0 +1,7 @@
+# Personal git identity, pulled in by [includeIf] rules in ~/.config/git/config
+# for repos under personal locations (see run_onchange_after_10-git-identity.sh).
+# Note: these emails already appear throughout this public repo's commit history,
+# so there is nothing here that is not already public.
+[user]
+	name = Lauri Gates
+	email = lauri.gates@gmail.com

--- a/run_onchange_after_10-git-identity.sh
+++ b/run_onchange_after_10-git-identity.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Per-location git identity via includeIf.
+#
+# Default (global) identity is FVH work; commits in personal locations override
+# to the personal identity in ~/.config/git/personal.inc. git evaluates the
+# includeIf directives by repo location at runtime, so the right author is
+# stamped automatically with no per-repo `git config` needed.
+#
+# This is a run_onchange script (not the heavy run_once initial-setup): editing
+# it re-applies just these settings on the next `chezmoi apply`. `git config`
+# is idempotent, so re-running only re-asserts the values.
+set -euo pipefail
+
+PERSONAL="$HOME/.config/git/personal.inc"
+
+# Default identity: FVH work (already public in this repo's commit history).
+git config --global user.name "Lauri Gates"
+git config --global user.email "lauri.gates@forumvirium.fi"
+
+# Personal-location overrides. Trailing slash => matches all repos *under* the
+# path; the umbrella ~/repos repo is matched by its exact .git dir.
+git config --global "includeIf.gitdir:~/repos/.git.path"                 "$PERSONAL"
+git config --global "includeIf.gitdir:~/repos/laurigates/.path"          "$PERSONAL"
+git config --global "includeIf.gitdir:~/.local/share/chezmoi/.path"      "$PERSONAL"
+git config --global "includeIf.gitdir:~/Documents/LakuVault/.path"       "$PERSONAL"


### PR DESCRIPTION
## What

Personal-location repos now commit under the personal identity (`lauri.gates@gmail.com`) instead of inheriting the global FVH work identity. Uses git's `includeIf "gitdir:…"` to pick the author by repo location at runtime — no per-repo `git config` needed.

| `includeIf "gitdir:…"` | Identity |
|---|---|
| `~/repos/.git` (repos-claude-config umbrella) | personal |
| `~/repos/laurigates/` (nested personal repos) | personal |
| `~/.local/share/chezmoi/` (this dotfiles checkout) | personal |
| `~/Documents/LakuVault/` (personal vault) | personal |
| `~/repos/ForumViriumHelsinki/*` | FVH (default) |

## Why additive scripts, not a declarative template

`~/.config/git/config` is co-owned at runtime by `gh auth` (the `[credential …]` helper blocks). A static `.tmpl` is authoritative for the whole file and would either clobber gh's setup or delete it. So:

- `private_dot_config/git/personal.inc` — declarative managed source (nothing writes to it at runtime → no drift)
- `run_onchange_after_10-git-identity.sh` — injects the default identity + `includeIf` via `git config --global`; re-applies on edit without re-triggering the heavy `run_once` initial-setup, and leaves gh's credential helpers untouched

The template-vs-script tradeoff is captured for later in #290.

## Verification

Confirmed per-location resolution on this machine:
- personal locations (dotfiles, `~/repos` umbrella, nested `~/repos/laurigates/*`, LakuVault) → `lauri.gates@gmail.com`
- `~/repos/ForumViriumHelsinki/*` → `lauri.gates@forumvirium.fi`
- shellcheck clean

Note: `lauri.gates@gmail.com` already appears in 477 commits in this public repo's history, so `personal.inc` leaks nothing new.

Refs #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NvG4uoCVXpzN7QmjCJovw