### PR TITLE
fix(zsh): rebind fzf preview toggle from ctrl-/ to ctrl-t

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -461,7 +461,7 @@ ghi() {
           --header '#       Labels               Updated     Title' \
           --preview 'GH_FORCE_TTY=1 gh issue view {1}' \
           --preview-window right:60%:wrap \
-          --bind 'ctrl-/:toggle-preview' \
+          --bind 'ctrl-t:toggle-preview' \
           --bind 'ctrl-d:preview-page-down,ctrl-u:preview-page-up')
 
     [[ -z "$selection" ]] && return 0
@@ -513,7 +513,7 @@ ghpc() {
           --header '#       State  CI    Review  Branch                    Title' \
           --preview 'GH_FORCE_TTY=1 gh pr view {1} && echo && echo "--- Checks ---" && GH_FORCE_TTY=1 gh pr checks {1}' \
           --preview-window right:60%:wrap \
-          --bind 'ctrl-/:toggle-preview' \
+          --bind 'ctrl-t:toggle-preview' \
           --bind 'ctrl-d:preview-page-down,ctrl-u:preview-page-up')
 
     [[ -z "$selection" ]] && return 0
@@ -640,10 +640,10 @@ _gh_pr_multi_select() {
     column -t -s $'\t' | \
     _gh_paint | \
     fzf --ansi --multi "${fzf_extra[@]}" \
-        --header "Tab mark · ^a all · ⏎ confirm ${verb}-merge · ^/ preview · ^d/u scroll" \
+        --header "Tab mark · ^a all · ⏎ confirm ${verb}-merge · ^t toggle preview · ^d/u scroll" \
         --bind 'tab:toggle+down,btab:toggle+up' \
         --bind 'ctrl-a:select-all' \
-        --bind 'ctrl-/:toggle-preview' \
+        --bind 'ctrl-t:toggle-preview' \
         --bind 'ctrl-d:preview-page-down,ctrl-u:preview-page-up' \
         --preview 'GH_FORCE_TTY=1 gh pr view {1} && echo && gh pr diff {1} --color=always | head -100' \
         --preview-window right:65%:wrap | \
@@ -699,9 +699,9 @@ _gh_pr_pick() {
     fzf --ansi --tac \
         --preview 'GH_FORCE_TTY=1 gh pr view {1} && echo && gh pr diff {1} --color=always | head -100' \
         --preview-window right:65%:wrap \
-        --bind 'ctrl-/:toggle-preview' \
+        --bind 'ctrl-t:toggle-preview' \
         --bind 'ctrl-d:preview-page-down,ctrl-u:preview-page-up' \
-        --header '⏎ select PR | ^/ toggle preview | ^d/u scroll' | \
+        --header '⏎ select PR | ^t toggle preview | ^d/u scroll' | \
     awk '{n=$1; sub(/^#/,"",n); print n}'
 }
 
@@ -720,9 +720,9 @@ _gh_issue_pick() {
     fzf --ansi \
         --preview 'GH_FORCE_TTY=1 gh issue view {1}' \
         --preview-window right:60%:wrap \
-        --bind 'ctrl-/:toggle-preview' \
+        --bind 'ctrl-t:toggle-preview' \
         --bind 'ctrl-d:preview-page-down,ctrl-u:preview-page-up' \
-        --header '⏎ select issue | ^/ toggle preview | ^d/u scroll' | \
+        --header '⏎ select issue | ^t toggle preview | ^d/u scroll' | \
     awk '{n=$1; sub(/^#/,"",n); print n}'
 }
 
@@ -745,9 +745,9 @@ _gh_run_pick() {
     fzf --ansi \
         --preview 'GH_FORCE_TTY=1 gh run view {1}' \
         --preview-window right:65%:wrap \
-        --bind 'ctrl-/:toggle-preview' \
+        --bind 'ctrl-t:toggle-preview' \
         --bind 'ctrl-d:preview-page-down,ctrl-u:preview-page-up' \
-        --header '⏎ select run | ^/ toggle preview | ^d/u scroll' | \
+        --header '⏎ select run | ^t toggle preview | ^d/u scroll' | \
     awk '{print $1}'
 }
 
@@ -766,9 +766,9 @@ _gh_workflow_pick() {
     fzf --ansi \
         --preview 'GH_FORCE_TTY=1 gh workflow view {1}' \
         --preview-window right:65%:wrap \
-        --bind 'ctrl-/:toggle-preview' \
+        --bind 'ctrl-t:toggle-preview' \
         --bind 'ctrl-d:preview-page-down,ctrl-u:preview-page-up' \
-        --header '⏎ select workflow | ^/ toggle preview | ^d/u scroll' | \
+        --header '⏎ select workflow | ^t toggle preview | ^d/u scroll' | \
     awk '{print $1}'
 }
 
@@ -824,10 +824,10 @@ ghrp() {
   local selections
   selections=$(print -r -- "$list" | column -t -s $'\t' | _gh_paint | \
       fzf --ansi --multi --tac \
-          --header 'Tab mark · ^a all · ⏎ confirm squash-merge · ^/ preview · ^d/u scroll' \
+          --header 'Tab mark · ^a all · ⏎ confirm squash-merge · ^t toggle preview · ^d/u scroll' \
           --bind 'tab:toggle+down,btab:toggle+up' \
           --bind 'ctrl-a:select-all' \
-          --bind 'ctrl-/:toggle-preview' \
+          --bind 'ctrl-t:toggle-preview' \
           --bind 'ctrl-d:preview-page-down,ctrl-u:preview-page-up' \
           --preview 'GH_FORCE_TTY=1 gh pr view {2} --repo {1}' \
           --preview-window right:60%:wrap)


### PR DESCRIPTION
## What

Rebinds the fzf `toggle-preview` key in all `gh` picker wrappers from `ctrl-/` to `ctrl-t`, and updates the picker headers from `^/ preview` to `^t toggle preview`.

## Why

`Ctrl+/` is impossible to type on Finnish/Nordic ISO layouts — `/` is `Shift+7`, so the terminal never emits the keycode and the preview toggle was dead in every picker. The `^/ preview` header also read as a truncated label since the glyph is meaningless on that layout.

Bare `Ctrl+<letter>` combos are forwarded by every terminal and layout; `ctrl-t` is unbound inside fzf by default and mnemonic for *toggle*.

## Scope

All 8 pickers: `ghi`, `ghpc`, `ghsq`/`ghrb` multi-select, `_gh_pr_pick`, `_gh_issue_pick`, `_gh_run_pick`, `_gh_workflow_pick`, `ghrp`. Rendered `~/.zshrc` syntax-checked with `zsh -n` and applied via chezmoi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUphJ7gyUPvuyeJdhajCN8