### PR TITLE
docs(rules): name actors with proper nouns in AskUserQuestion labels

### DIFF
--- a/exact_dot_claude/rules/communication.md
+++ b/exact_dot_claude/rules/communication.md
@@ -20,3 +20,22 @@
 - Surface ambiguities early before implementation
 - Explain reasoning for technical decisions
 - State why you chose not to delegate when applicable
+
+## AskUserQuestion Actor Labels
+
+When an `AskUserQuestion` option assigns who performs an action, name the actor
+with a **perspective-independent proper noun** — `Claude` for the agent, `Lauri`
+for the user — never the deictic `I`/`me`/`you`. "I"/"you" are speaker-relative:
+the option is authored from Claude's perspective but read from Lauri's, so the
+reader has to mentally swap the referent on every option ("I drive the merge"
+reads as *Claude* drives, but the human selecting it parses it as *themselves*).
+Proper nouns fix the referent for both parties at once.
+
+- **Do**: `Claude merges the PRs and reports back` / `Lauri merges manually` /
+  `Claude retargets, Lauri does the final merge`.
+- **Don't**: `I merge the PRs` / `You merge manually` (perspective-ambiguous for
+  the human), and **don't** drop the actor entirely (`Merge the PRs`) — an
+  actorless label forces Claude to re-infer who was assigned when reading the
+  selection back, trading the human-side ambiguity for an agent-side one.
+- Generic roles (`Agent`/`User`) are the fallback only when the transcript will
+  be read by someone who doesn't know the names; default to `Claude`/`Lauri`.


### PR DESCRIPTION
## What

Adds an **AskUserQuestion Actor Labels** section to `communication.md`: when an option label assigns who performs an action, use perspective-independent proper nouns (`Claude` / `Lauri`) instead of deictic `I`/`you`, and never drop the actor entirely.

## Why

Deictic pronouns are speaker-relative — an option authored from Claude's perspective is read from Lauri's, so "I merge the PRs" reads as Claude driving to the author but as the human to the reader selecting it. Actorless labels ("Merge the PRs") shift the ambiguity to the agent side when the selection is read back. Proper nouns fix the referent for both parties; `Agent`/`User` remain the fallback for transcripts read by people who don't know the names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUphJ7gyUPvuyeJdhajCN8