### PR TITLE
fix(zsh): restore grouped just completion after model-var centralization

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,16 @@ repos:
       # builds from source and needs a C linker, which isn't available on
       # minimal Linux hosts like TrueNAS where apt is disabled.
       - id: stylua-github
+  - repo: local
+    hooks:
+      # Validate justfile roots parse + evaluate (catches undefined variables
+      # across imported fragments — see scripts/check-justfiles.sh).
+      - id: check-justfiles
+        name: check justfiles parse and evaluate
+        entry: scripts/check-justfiles.sh
+        language: script
+        files: '(^|/)(justfile$|.*\.just$)'
+        pass_filenames: false
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.7
     hooks:

--- a/private_dot_config/just/justfile
+++ b/private_dot_config/just/justfile
@@ -11,11 +11,10 @@
 #   • claude.just   — Claude Code setup (mcp-*, cclsp, claude-setup, settings-audit)
 #   • git.just      — Git branch hygiene (branch-audit)
 # Edit those, then `chezmoi apply`. Imports are relative to this file's directory.
-
-# Claude model used by headless `claude -p` recipes (single source of truth,
-# referenced as {{claude_model}} across the imported recipe files). Update here
-# to bump the version everywhere.
-claude_model := "claude-opus-4-8"
+#
+# `claude_model` (for headless `claude -p` recipes) is defined in plugins.just,
+# not here — it must live in the shared imported file so every importer inherits
+# it. See the comment there.
 
 import 'plugins.just'
 import 'claude.just'

--- a/private_dot_config/just/plugins.just
+++ b/private_dot_config/just/plugins.just
@@ -8,6 +8,15 @@
 # justfile (~/.config/just/justfile) imports it as a sibling. Edit here, then
 # `chezmoi apply`.
 
+# Claude model for headless `claude -p` recipes (single source of truth,
+# referenced as {{claude_model}} in plugins-setup-repo / plugins-check-repo).
+# Defined HERE — not in an importing justfile — because this file is imported
+# by BOTH the dotfiles repo justfile and the global justfile; a definition in
+# only one importer leaves {{claude_model}} undefined in the other, breaking
+# every `just` invocation there (and silently downgrading the grouped `_just`
+# completer to flat). Bump the version here to update everywhere.
+claude_model := "claude-opus-4-8"
+
 marketplace := "laurigates-claude-plugins"
 marketplace_url := "https://raw.githubusercontent.com/laurigates/claude-plugins/refs/heads/main/.claude-plugin/marketplace.json"
 

--- a/scripts/check-justfiles.sh
+++ b/scripts/check-justfiles.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Validate that every top-level justfile still PARSES and EVALUATES.
+#
+# `just --dump` parses the justfile and evaluates all variables (without running
+# any recipe), so it fails on syntax errors AND on undefined-variable references
+# across `import`ed fragments — exactly the failure that broke completion in
+# PR #288 (a `{{claude_model}}` reference in the shared `plugins.just` was
+# defined in only one of its two importers, so `just` errored in the other,
+# silently downgrading the grouped `_just` fzf-tab completer to flat).
+#
+# Only justfile ROOTS are validated — imported fragments (plugins.just,
+# claude.just, git.just, nvim.just) are not standalone justfiles. Each root
+# pulls its fragments in via `import`, so validating the roots covers them.
+set -euo pipefail
+
+if ! command -v just >/dev/null 2>&1; then
+  echo "check-justfiles: 'just' not installed — skipping." >&2
+  exit 0
+fi
+
+# justfile roots (importers). Fragments are validated transitively via imports.
+roots=(
+  justfile                          # dotfiles repo root
+  private_dot_config/just/justfile  # global justfile source (~/.config/just/justfile)
+)
+
+status=0
+for f in "${roots[@]}"; do
+  [ -f "$f" ] || continue
+  if ! err="$(just --justfile "$f" --dump >/dev/null 2>&1 || just --justfile "$f" --dump 2>&1 >/dev/null)"; then
+    echo "check-justfiles: FAILED to evaluate $f" >&2
+    printf '%s\n' "$err" >&2
+    status=1
+  fi
+done
+
+exit "$status"


### PR DESCRIPTION
## Problem

Grouped/colorized `just <TAB>` completion silently stopped working. Root cause: PR #288 added `{{claude_model}}` references to the **shared** `private_dot_config/just/plugins.just` but defined `claude_model` only in the global justfile. `plugins.just` is imported by **both** the global justfile *and* this repo's root justfile, so in this repo `{{claude_model}}` was undefined and every `just` invocation failed:

```
error: variable `claude_model` not defined
  ——▶ private_dot_config/just/plugins.just:92:78
```

The custom `_just` completer parses `just --dump --dump-format json`; when that errors, it falls back to the flat clap completer — losing the `[group(...)]` grouping and coloring, with no visible error.

## Fix

- Move `claude_model := "claude-opus-4-8"` into `plugins.just` (the shared imported file) so **every** importer inherits it; drop the redundant copy from the global justfile.
- Add `scripts/check-justfiles.sh` + a `local` pre-commit hook that runs `just --dump` on both justfile roots — catches undefined-variable / parse errors across imports before they land. Verified: the hook fails on the exact #288 regression and passes once fixed.

## Verification

- `just --dump --dump-format json` succeeds in the repo root (59 recipes) and `just -g --list` still works.
- `pre-commit run check-justfiles --all-files` → Passed.
- Applied to `~/.config/just/{justfile,plugins.just}`; grouped completion restored in a fresh shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoVmEUEh8s5XSucMTcx3ek