### PR TITLE
feat(git): auto-install pre-commit into every clone via template dir

### DIFF
--- a/run_once_before_00-initial-setup.sh.tmpl
+++ b/run_once_before_00-initial-setup.sh.tmpl
@@ -37,6 +37,15 @@ git config --global status.showStash true
 if command -v pre-commit &> /dev/null; then
     echo "Installing pre-commit hooks..."
     (cd "{{ .chezmoi.sourceDir }}" && pre-commit install --install-hooks)
+
+    # Auto-install pre-commit into EVERY future `git clone` / `git init` via
+    # git's template directory, so we never have to remember `pre-commit install`
+    # per repo. pre-commit's templatedir hooks no-op gracefully in repos that
+    # have no .pre-commit-config.yaml, so this is safe to apply globally.
+    git_template_dir="${XDG_CONFIG_HOME:-$HOME/.config}/git/template"
+    echo "Configuring git template dir for auto pre-commit install: $git_template_dir"
+    pre-commit init-templatedir "$git_template_dir" -t pre-commit -t commit-msg
+    git config --global init.templateDir "$git_template_dir"
 else
     echo "Skipping pre-commit hooks installation (pre-commit not installed yet)"
     echo "Run 'chezmoi apply' again after installing pre-commit to set up hooks"


### PR DESCRIPTION
## Problem

Setting up a repo's pre-commit hooks requires remembering to run `pre-commit install` after each clone — easy to forget, so hooks silently don't run on freshly cloned repos.

## Fix

Wire git's `init.templateDir` to a pre-commit-managed template directory in the run_once initial-setup script:

```sh
pre-commit init-templatedir ~/.config/git/template -t pre-commit -t commit-msg
git config --global init.templateDir ~/.config/git/template
```

Now every future `git clone` / `git init` copies the hooks into `.git/hooks` automatically. pre-commit's templatedir hooks no-op gracefully in repos that have no `.pre-commit-config.yaml`, so this is safe to apply globally.

## Verification

- Fresh `git init` receives both `pre-commit` and `commit-msg` hooks.
- A commit in a config-less repo succeeds (`config file not found. Skipping`).

## Note

Editing the `run_once_` script changes its content hash, so it re-runs on the next `chezmoi apply` (idempotent — re-runs git config, nvim sync, macOS defaults). The template-dir commands were also run directly, so the current machine is already set up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoVmEUEh8s5XSucMTcx3ek