### PR TITLE
docs(claude): non-exact rules/ neither purges orphans nor flags them

### DIFF
--- a/.claude/rules/chezmoi-conventions.md
+++ b/.claude/rules/chezmoi-conventions.md
@@ -70,6 +70,16 @@ Two traps stack here:
   `rules/`, `skills/` under `exact_dot_claude/`) tolerate unmanaged files.
   That asymmetry is why damage can look partial — and why "it survived last
   time" proves nothing about a sibling path.
+- **The flip side: non-`exact_` subdirs never PURGE either.** Deleting or
+  moving a source file out of `exact_dot_claude/rules/` leaves the old
+  target **orphaned in `~/.claude/rules/`** — still loading into every
+  session — with no `D` line in `chezmoi status` to flag it (bit twice in
+  the 2026-07 context diet). After removing a rule from source, delete the
+  target yourself and verify it's truly unmanaged first:
+  `chezmoi source-path ~/.claude/rules/<f> || rm ~/.claude/rules/<f>`.
+  The inverse leak also happens — a rule created directly in the target is
+  never captured to source and silently loads forever; sweep with
+  `for f in ~/.claude/rules/*.md; do chezmoi source-path "$f" >/dev/null 2>&1 || echo "UNMANAGED: $f"; done`.
 
 ## Finding the Source File — Ask Chezmoi, Don't Translate
 


### PR DESCRIPTION
## What

Session distill from the #300 context diet: document in `.claude/rules/chezmoi-conventions.md` that **non-`exact_` subdirs neither purge orphaned targets nor flag them** — the flip side of the existing per-directory-level note.

- Moving/deleting a source file out of `exact_dot_claude/rules/` leaves the old target orphaned in `~/.claude/rules/`, still loading into every session, with **no `D` line in `chezmoi status`** to reveal it. Manual target cleanup + `chezmoi source-path` verification documented.
- The inverse leak too: a rule created directly in the target is never captured to source and silently loads forever — includes the unmanaged-file sweep one-liner.

Both directions bit during the #300 diet (7 orphaned targets after the wave-1 moves; one 4.7 KB unmanaged rule found loading invisibly).

## Why not in #300

The commit was authored on the #300 branch during session wrap-up, but the PR had already been squash-merged — pushing would have orphaned it (hazard #2 in the freshly consolidated `git-hazards.md`, fittingly). Cherry-picked onto a fresh branch from `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVnFBnQFMWKgd8h4kTCjZy
