### PR TITLE
fix(chezmoi): skip pre-commit install when core.hooksPath is set

### DIFF
--- a/run_once_before_00-initial-setup.sh.tmpl
+++ b/run_once_before_00-initial-setup.sh.tmpl
@@ -35,8 +35,17 @@ git config --global status.showStash true
 
 # Install pre-commit hooks (if pre-commit is available)
 if command -v pre-commit &> /dev/null; then
-    echo "Installing pre-commit hooks..."
-    (cd "{{ .chezmoi.sourceDir }}" && pre-commit install --install-hooks)
+    # pre-commit refuses to install when core.hooksPath is set, and with
+    # `set -e` that failure aborts the entire chezmoi apply. Skip the
+    # per-repo install in that case — hooks are managed via the configured
+    # hooks path (or the git template dir below for fresh clones).
+    if git -C "{{ .chezmoi.sourceDir }}" config --get core.hooksPath > /dev/null; then
+        echo "Skipping pre-commit install: core.hooksPath is set for {{ .chezmoi.sourceDir }}"
+        echo "hint: git -C {{ .chezmoi.sourceDir }} config --unset-all core.hooksPath"
+    else
+        echo "Installing pre-commit hooks..."
+        (cd "{{ .chezmoi.sourceDir }}" && pre-commit install --install-hooks)
+    fi
 
     # Auto-install pre-commit into EVERY future `git clone` / `git init` via
     # git's template directory, so we never have to remember `pre-commit install`


### PR DESCRIPTION
## What

`just bump` (any `chezmoi apply`, really) aborted with:

```
[ERROR] Cowardly refusing to install hooks with `core.hooksPath` set.
chezmoi: 00-initial-setup.sh: exit status 1
```

`pre-commit install` refuses to run when `core.hooksPath` is configured for the repo, and `run_once_before_00-initial-setup.sh` runs under `set -e`, so that one refusal killed the entire apply.

## Fix

Guard the per-repo `pre-commit install --install-hooks` behind a `git config --get core.hooksPath` check: when a hooks path is set, log a skip message with the `--unset-all` hint and move on. The git template-dir setup from #299 (auto-installing pre-commit hooks into fresh clones) is unaffected and still runs — `pre-commit init-templatedir` doesn't perform the cowardly check.

## Verification

- Rendered template passes shellcheck.
- With the stray local `core.hooksPath` removed, `pre-commit install --install-hooks` succeeds and the hooks ran on this PR's own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bL2XsW8Hp6i7DzfxNMgRF