### PR TITLE
refactor(nvim): replace dressing.nvim with snacks input, prune stale plugins

### DIFF
--- a/private_dot_config/nvim/CLAUDE.md
+++ b/private_dot_config/nvim/CLAUDE.md
@@ -20,7 +20,7 @@ Modern Neovim configuration using Lua with lazy.nvim plugin management.
 ## Plugin Categories
 
 - **Completion**: blink.cmp with LSP
-- **LSP/Formatting**: Mason (installs), conform.nvim (format), nvim-lint (lint), navic/navbuddy (navigation)
+- **LSP/Formatting**: Mason (installs), conform.nvim (format), nvim-lint (lint), navic (breadcrumbs in lualine)
 - **Navigation**: fzf-lua, oil.nvim, aerial.nvim
 - **Git**: gitsigns, fugitive
 - **UI**: tokyonight, lualine, noice.nvim

--- a/private_dot_config/nvim/lua/exact_plugins/dressing.lua
+++ b/private_dot_config/nvim/lua/exact_plugins/dressing.lua
@@ -1,8 +1,0 @@
--- Neovim plugin to improve the default vim.ui interfaces
-return {
-  {
-    "stevearc/dressing.nvim",
-    opts = {},
-    -- event = "VeryLazy",
-  },
-}

--- a/private_dot_config/nvim/lua/exact_plugins/init.lua
+++ b/private_dot_config/nvim/lua/exact_plugins/init.lua
@@ -89,5 +89,4 @@ return {
     "nmac427/guess-indent.nvim",
     opts = {},
   },
-  { "meznaric/key-analyzer.nvim", opts = {} },
 }

--- a/private_dot_config/nvim/lua/exact_plugins/key-analyzer.lua
+++ b/private_dot_config/nvim/lua/exact_plugins/key-analyzer.lua
@@ -1,6 +1,0 @@
-return {
-  {
-    "meznaric/key-analyzer.nvim",
-    opts = {},
-  },
-}

--- a/private_dot_config/nvim/lua/exact_plugins/mason.lua
+++ b/private_dot_config/nvim/lua/exact_plugins/mason.lua
@@ -25,15 +25,6 @@ return {
     event = "VeryLazy",
   },
   {
-    "hasansujon786/nvim-navbuddy",
-    dependencies = {
-      "SmiteshP/nvim-navic",
-      "MunifTanjim/nui.nvim",
-    },
-    opts = { lsp = { auto_attach = true } },
-    event = "VeryLazy",
-  },
-  {
     "b0o/schemastore.nvim",
     event = "VeryLazy",
   },

--- a/private_dot_config/nvim/lua/exact_plugins/nvim-jqx.lua
+++ b/private_dot_config/nvim/lua/exact_plugins/nvim-jqx.lua
@@ -1,7 +1,0 @@
-return {
-  {
-    -- Populate the quickfix with json entries
-    "gennaro-tedesco/nvim-jqx",
-    ft = { "json", "yaml" },
-  },
-}

--- a/private_dot_config/nvim/lua/exact_plugins/snacks.lua
+++ b/private_dot_config/nvim/lua/exact_plugins/snacks.lua
@@ -20,7 +20,8 @@ return {
       bufdelete = { enabled = true },
       dim = { enabled = true },
       indent = { enabled = true },
-      -- input = { enabled = true },
+      -- vim.ui.input + vim.ui.select (via picker) — replaces dressing.nvim (archived)
+      input = { enabled = true },
       rename = { enabled = true },
       scope = { enabled = true },
       util = { enabled = true },


### PR DESCRIPTION
## What

Acts on the `just nvim-plugins-audit` findings (non-treesitter items — the treesitter main-branch migration is a separate PR):

- **dressing.nvim → snacks**: dressing is archived and its README points to snacks.nvim. Enabled `input` in the existing snacks config (`vim.ui.input`); the already-enabled snacks picker keeps handling `vim.ui.select`. Deleted `dressing.lua`.
- **Removed nvim-jqx**: dormant 2.1 years, unused.
- **Removed nvim-navbuddy**: stale; overlaps aerial.nvim (`:AerialNavToggle` popup) and the snacks LSP-symbol picker. nvim-navic is unaffected — it has its own spec (`navic.lua`) and keeps feeding lualine breadcrumbs via `core/lsp.lua`.
- **Removed key-analyzer.nvim**: niche, eagerly loaded, unused.
- Updated `nvim/CLAUDE.md` plugin-category line accordingly.

## Verification

- Edited/new specs execute cleanly under Neovim's LuaJIT (`nvim --headless -l <spec>`).
- Local `mise run lint:lua` is currently broken by an environment issue (luacheck 1.2.0 is incompatible with brew lua 5.5 — `const` assignment error, unrelated to this change); CI luacheck covers it.
- After merge: `chezmoi apply ~/.config/nvim` (exact_ dir removes the deleted plugin files), then `:Lazy sync` to drop the uninstalled plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGFLB3G7PX4pdLh7cfzB9d