### PR TITLE
feat(nvim)!: migrate nvim-treesitter to the main-branch rewrite

### DIFF
--- a/private_dot_config/mise/config.toml.tmpl
+++ b/private_dot_config/mise/config.toml.tmpl
@@ -122,6 +122,7 @@ opentofu = "1.11.2"
 d2 = "latest"
 "aqua:tmux/tmux-builds" = "latest"
 "aqua:gitleaks/gitleaks" = "latest"
+"aqua:tree-sitter/tree-sitter" = "latest"     # tree-sitter CLI (required by nvim-treesitter main branch)
 {{- if eq .chezmoi.os "darwin" }}
 "npm:pyright" = "latest"
 "npm:typescript-language-server" = "latest"

--- a/private_dot_config/nvim/lua/core/settings.lua
+++ b/private_dot_config/nvim/lua/core/settings.lua
@@ -60,6 +60,8 @@ opt.fillchars = {
   diff = "╱",
   eob = " ",
 }
-opt.foldexpr = "nvim_treesitter#foldexpr()"
-opt.foldtext = "nvim_treesitter#foldtext()"
--- opt.foldtext = ""
+-- Built-in treesitter foldexpr (the nvim_treesitter#foldexpr() vimscript
+-- function only exists on the archived master branch)
+opt.foldexpr = "v:lua.vim.treesitter.foldexpr()"
+-- Empty foldtext shows the folded line with its syntax highlighting (nvim 0.10+)
+opt.foldtext = ""

--- a/private_dot_config/nvim/lua/exact_plugins/treesitter.lua
+++ b/private_dot_config/nvim/lua/exact_plugins/treesitter.lua
@@ -1,118 +1,119 @@
--- Nvim Treesitter configurations and abstraction layer
+-- Nvim Treesitter — main-branch rewrite (the old master branch and its
+-- nvim-treesitter.configs module are archived). Parsers install via
+-- require("nvim-treesitter").install(); highlighting and indentation are
+-- enabled per-buffer in the FileType autocommand below using Neovim's
+-- built-in vim.treesitter. Requires nvim 0.12+ and the tree-sitter CLI
+-- (installed via mise: aqua:tree-sitter/tree-sitter).
+--
+-- Dropped relative to the master-branch config:
+-- - incremental_selection: removed upstream; flash.nvim's `S` (Treesitter)
+--   covers it.
+-- - textsubjects (`.` / `;` / `i;`): master-only, incompatible with the
+--   main branch (RRethy/nvim-treesitter-textsubjects#52).
+-- - lsp_interop peek (`<leader>df` / `<leader>dF`): removed upstream.
+
+local ensure_installed = {
+  "regex",
+  "bash",
+  "c",
+  "diff",
+  "dockerfile",
+  "git_config",
+  "git_rebase",
+  "gitattributes",
+  "gitcommit",
+  "gitignore",
+  "graphql",
+  "http",
+  "json",
+  "lua",
+  "markdown",
+  "markdown_inline",
+  "python",
+  "query",
+  "terraform",
+  "toml",
+  "vim",
+  "vimdoc",
+  "xml",
+  "yaml",
+}
+
 return {
   {
     "windwp/nvim-ts-autotag",
     opts = {},
   },
   {
-    "RRethy/nvim-treesitter-textsubjects",
-    dependencies = { "nvim-treesitter/nvim-treesitter" },
+    "nvim-treesitter/nvim-treesitter",
+    branch = "main",
+    lazy = false, -- upstream: does not support lazy-loading
+    build = ":TSUpdate",
+    config = function()
+      -- Async; no-op for parsers that are already installed
+      require("nvim-treesitter").install(ensure_installed)
+
+      vim.api.nvim_create_autocmd("FileType", {
+        group = vim.api.nvim_create_augroup("treesitter_start", { clear = true }),
+        callback = function(args)
+          local lang = vim.treesitter.language.get_lang(args.match) or args.match
+          local function start(buf)
+            if not pcall(vim.treesitter.start, buf, lang) then
+              return false
+            end
+            -- Experimental treesitter indentation (old `indent = { enable = true }`)
+            vim.bo[buf].indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
+            return true
+          end
+          if start(args.buf) then
+            return
+          end
+          -- Parser not installed yet: auto-install supported languages,
+          -- then retry (replaces the old `auto_install = true`)
+          if require("nvim-treesitter.parsers")[lang] then
+            require("nvim-treesitter").install(lang):await(function()
+              if vim.api.nvim_buf_is_valid(args.buf) then
+                start(args.buf)
+              end
+            end)
+          end
+        end,
+      })
+    end,
   },
   {
     "nvim-treesitter/nvim-treesitter-textobjects",
+    branch = "main",
     dependencies = { "nvim-treesitter/nvim-treesitter" },
-  },
-  {
-    "nvim-treesitter/nvim-treesitter",
-    main = "nvim-treesitter.configs",
-    build = ":TSUpdate",
-    opts = {
-      modules = {},
-      auto_install = true,
-      ignore_install = {},
-      ensure_installed = {
-        "regex",
-        "bash",
-        "c",
-        "diff",
-        "dockerfile",
-        "git_config",
-        "git_rebase",
-        "gitattributes",
-        "gitcommit",
-        "gitignore",
-        "graphql",
-        "http",
-        "json",
-        "lua",
-        "markdown",
-        "markdown_inline",
-        "python",
-        "query",
-        "terraform",
-        "toml",
-        "vim",
-        "vimdoc",
-        "xml",
-        "yaml",
-      },
-      sync_install = false,
-      highlight = { enable = true },
-      indent = { enable = true },
-      incremental_selection = { enable = true },
-      textobjects = {
+    config = function()
+      require("nvim-treesitter-textobjects").setup({
         select = {
-          enable = true,
-
           -- Automatically jump forward to textobj, similar to targets.vim
           lookahead = true,
-
-          keymaps = {
-            -- You can use the capture groups defined in textobjects.scm
-            ["af"] = "@function.outer",
-            ["if"] = "@function.inner",
-            ["ac"] = "@class.outer",
-            -- You can optionally set descriptions to the mappings (used in the desc parameter of
-            -- nvim_buf_set_keymap) which plugins like which-key display
-            ["ic"] = { query = "@class.inner", desc = "Select inner part of a class region" },
-            -- You can also use captures from other query groups like `locals.scm`
-            ["as"] = { query = "@scope", query_group = "locals", desc = "Select language scope" },
-          },
-          -- You can choose the select mode (default is charwise 'v')
-          --
-          -- Can also be a function which gets passed a table with the keys
-          -- * query_string: eg '@function.inner'
-          -- * method: eg 'v' or 'o'
-          -- and should return the mode ('v', 'V', or '<c-v>') or a table
-          -- mapping query_strings to modes.
           selection_modes = {
             ["@parameter.outer"] = "v", -- charwise
             ["@function.outer"] = "V", -- linewise
             ["@class.outer"] = "<c-v>", -- blockwise
           },
-          -- If you set this to `true` (default is `false`) then any textobject is
-          -- extended to include preceding or succeeding whitespace. Succeeding
-          -- whitespace has priority in order to act similarly to eg the built-in
-          -- `ap`.
-          --
-          -- Can also be a function which gets passed a table with the keys
-          -- * query_string: eg '@function.inner'
-          -- * selection_mode: eg 'v'
-          -- and should return true of false
           include_surrounding_whitespace = true,
         },
-        lsp_interop = {
-          enable = true,
-          border = "none",
-          floating_preview_opts = {},
-          peek_definition_code = {
-            ["<leader>df"] = "@function.outer",
-            ["<leader>dF"] = "@class.outer",
-          },
-        },
-      },
-      textsubjects = {
-        enable = true,
-        prev_selection = ",", -- (Optional) keymap to select the previous selection
-        keymaps = {
-          ["."] = "textsubjects-smart",
-          [";"] = "textsubjects-container-outer",
-          ["i;"] = {
-            "textsubjects-container-inner",
-            desc = "Select inside containers (classes, functions, etc.)",
-          },
-        },
-      },
-    },
+      })
+
+      local function select_textobject(query, group)
+        return function()
+          require("nvim-treesitter-textobjects.select").select_textobject(query, group or "textobjects")
+        end
+      end
+      vim.keymap.set({ "x", "o" }, "af", select_textobject("@function.outer"), { desc = "Select outer function" })
+      vim.keymap.set({ "x", "o" }, "if", select_textobject("@function.inner"), { desc = "Select inner function" })
+      vim.keymap.set({ "x", "o" }, "ac", select_textobject("@class.outer"), { desc = "Select outer class" })
+      vim.keymap.set({ "x", "o" }, "ic", select_textobject("@class.inner"), { desc = "Select inner class" })
+      vim.keymap.set(
+        { "x", "o" },
+        "as",
+        select_textobject("@local.scope", "locals"),
+        { desc = "Select language scope" }
+      )
+    end,
   },
 }


### PR DESCRIPTION
## Why

The nvim-treesitter repo was **archived April 2026**. Our config used the frozen `master`-branch API (`nvim-treesitter.configs`, `ensure_installed`, module tables), which is locked and only guaranteed for nvim 0.11 — we run 0.12 nightly. Companion PR for the audit's non-treesitter items: #304.

## What

- **nvim-treesitter** → `branch = "main"`, `lazy = false` (upstream: no lazy-loading). No `configs` module anymore:
  - parsers install via `require("nvim-treesitter").install(ensure_installed)` (async, no-op when installed)
  - highlighting + experimental indent enabled per-buffer in a `FileType` autocmd via built-in `vim.treesitter.start()`
  - missing supported parsers auto-install on first open and then attach (`install(lang):await(...)`) — replaces `auto_install = true`
- **textobjects** → `branch = "main"`; `af`/`if`/`ac`/`ic`/`as` keymaps defined explicitly through `nvim-treesitter-textobjects.select` (`as` uses the renamed `@local.scope` capture)
- **folds** (`core/settings.lua`): `nvim_treesitter#foldexpr()`/`#foldtext()` are master-only vimscript — switched to built-in `v:lua.vim.treesitter.foldexpr()` + empty `foldtext` (highlighted fold line, nvim 0.10+)
- **mise**: added `aqua:tree-sitter/tree-sitter` (tree-sitter CLI ≥ 0.26.1 is a hard requirement of the main branch for parser compilation)

## Dropped (breaking)

| Was | Why | Replacement |
|---|---|---|
| `incremental_selection` | removed upstream | flash.nvim `S` (Treesitter select) already bound |
| textsubjects `.` / `;` / `i;` | master-only; requires `nvim-treesitter.query` internals (RRethy/nvim-treesitter-textsubjects#52 open) | flash `S` / textobjects selects |
| `lsp_interop` peek `<leader>df`/`<leader>dF` | module removed upstream | LSP hover / definition preview |

## Post-merge

1. `chezmoi apply` (nvim config + mise config), then `mise install` for the tree-sitter CLI
2. `:Lazy sync` — lazy.nvim checks out the `main` branch for both plugins
3. `:TSUpdate` on first launch recompiles parsers; open a few filetypes and confirm highlighting/indent/folds

## Verification

- Spec files execute cleanly under Neovim's LuaJIT (`nvim --headless -l`)
- API calls verified against main-branch source: `install()` accepts `string|string[]` and returns a Task with `:await(cb)`; `indentexpr` and parser-table guard match upstream README/source
- Local luacheck currently broken (brew lua 5.5 incompatibility, pre-existing); CI covers lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGFLB3G7PX4pdLh7cfzB9d