### PR TITLE
feat(claude): add telegram-poll for multiple-choice questions

### DIFF
--- a/dot_local/bin/executable_telegram-ask
+++ b/dot_local/bin/executable_telegram-ask
@@ -5,6 +5,7 @@
 #   telegram-ask "Question text?"                       # default 5min timeout
 #   telegram-ask -t 30 "Quick question?"                # 30s timeout
 #   telegram-ask --pattern '^(YES|NO)$' "YES or NO?"    # require regex match
+#   telegram-ask -r 0 "No reminders, just wait"         # disable reminders
 #
 # Exit codes:
 #   0  — got a reply (printed to stdout)
@@ -13,12 +14,18 @@
 #
 # Requires TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID in the environment.
 # These are typically sourced from ~/.api_tokens via mise.
+#
+# While waiting, re-pings with a reminder at exponentially increasing
+# intervals (default: 30s, 60s, 120s, ... capped by --timeout) so a missed
+# phone notification gets a second and third chance before the deadline.
+# Disable with -r 0.
 
 set -euo pipefail
 
 TIMEOUT=300
 PATTERN=""
 PARSE_MODE=""
+REMIND=30
 
 usage() {
   sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
@@ -30,6 +37,7 @@ while [[ $# -gt 0 ]]; do
     -t|--timeout) TIMEOUT="$2"; shift 2 ;;
     -p|--pattern) PATTERN="$2"; shift 2 ;;
     -m|--markdown) PARSE_MODE="MarkdownV2"; shift ;;
+    -r|--remind-after) REMIND="$2"; shift 2 ;;
     -h|--help) usage ;;
     --) shift; break ;;
     -*) echo "telegram-ask: unknown flag: $1" >&2; exit 2 ;;
@@ -72,12 +80,18 @@ offset=$(jq -r '([.result[].update_id] | max // -1) + 1' <<<"$drain")
 # 3. Long-poll for a reply from the target chat. Filter to replies-to-our-message
 #    when possible, but accept any text from the chat as a fallback.
 deadline=$(( $(date +%s) + TIMEOUT ))
+remind_interval=$REMIND
+remind_at=$(( REMIND > 0 ? $(date +%s) + REMIND : 0 ))
 
 while :; do
   now=$(date +%s)
   remaining=$(( deadline - now ))
   (( remaining <= 0 )) && break
   poll_timeout=$(( remaining < 30 ? remaining : 30 ))
+  if (( remind_at > 0 )); then
+    remind_wait=$(( remind_at - now ))
+    (( remind_wait > 0 && remind_wait < poll_timeout )) && poll_timeout=$remind_wait
+  fi
 
   updates=$(curl -fsS \
     "${API}/getUpdates?timeout=${poll_timeout}&offset=${offset}&allowed_updates=%5B%22message%22%5D" \
@@ -107,6 +121,18 @@ while :; do
     fi
     printf '%s\n' "$reply"
     exit 0
+  fi
+
+  now=$(date +%s)
+  if (( remind_at > 0 && now >= remind_at )); then
+    curl -fsS -X POST "${API}/sendMessage" \
+      -d "chat_id=${TELEGRAM_CHAT_ID}" \
+      --data-urlencode "text=⏳ Still waiting for your reply to: ${QUESTION}" \
+      -d 'reply_markup={"force_reply":true,"selective":true}' \
+      >/dev/null || true
+    remind_interval=$(( remind_interval * 2 ))
+    next_remind=$(( now + remind_interval ))
+    remind_at=$(( next_remind < deadline ? next_remind : 0 ))
   fi
 done
 

--- a/dot_local/bin/executable_telegram-poll
+++ b/dot_local/bin/executable_telegram-poll
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# telegram-poll — send a multiple-choice poll to Telegram and wait for the answer.
+#
+# Usage:
+#   telegram-poll "Deploy which env?" "staging" "prod" "both"
+#   telegram-poll -t 60 "Quick pick?" "A" "B"
+#   telegram-poll -M "Pick all that apply" "A" "B" "C"    # allow multiple selections
+#   telegram-poll -s "Silent poll" "A" "B"                # disable_notification
+#   telegram-poll -r 0 "No reminders, just wait" "A" "B"  # disable reminders
+#
+# Exit codes:
+#   0 — got an answer (selected option text(s) printed to stdout, one per line)
+#   1 — timeout (prints "TIMEOUT" to stderr)
+#   2 — usage / config error
+#
+# Requires TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID in the environment.
+# These are typically sourced from ~/.api_tokens via mise.
+#
+# Sends a non-anonymous poll (required to attribute the answer to the user)
+# to TELEGRAM_CHAT_ID, long-polls for a poll_answer update, then closes the
+# poll with stopPoll. For a yes/no or free-text confirmation, prefer
+# telegram-ask instead — polls are for picking among fixed options.
+#
+# While waiting, re-pings with a reminder at exponentially increasing
+# intervals (default: 30s, 60s, 120s, ... capped by --timeout) so a missed
+# phone notification gets a second and third chance before the deadline.
+# Disable with -r 0.
+
+set -euo pipefail
+
+TIMEOUT=300
+MULTIPLE="false"
+SILENT="false"
+REMIND=30
+
+usage() {
+  sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -t|--timeout) TIMEOUT="$2"; shift 2 ;;
+    -M|--multiple) MULTIPLE="true"; shift ;;
+    -s|--silent) SILENT="true"; shift ;;
+    -r|--remind-after) REMIND="$2"; shift 2 ;;
+    -h|--help) usage ;;
+    --) shift; break ;;
+    -*) echo "telegram-poll: unknown flag: $1" >&2; exit 2 ;;
+    *) break ;;
+  esac
+done
+
+if [[ $# -lt 3 ]]; then
+  echo "telegram-poll: need a question and at least 2 options" >&2
+  usage
+fi
+
+QUESTION="$1"; shift
+OPTIONS=("$@")
+
+if [[ ${#OPTIONS[@]} -gt 10 ]]; then
+  echo "telegram-poll: Telegram allows at most 10 options" >&2
+  exit 2
+fi
+
+: "${TELEGRAM_BOT_TOKEN:?telegram-poll: TELEGRAM_BOT_TOKEN not set (check ~/.api_tokens)}"
+: "${TELEGRAM_CHAT_ID:?telegram-poll: TELEGRAM_CHAT_ID not set (check ~/.api_tokens)}"
+
+API="https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}"
+
+options_json=$(printf '%s\n' "${OPTIONS[@]}" | jq -Rn '[inputs | {text: .}]')
+
+# 1. Send the poll. Non-anonymous so poll_answer updates identify the voter.
+sent=$(curl -fsS -X POST "${API}/sendPoll" \
+  -d "chat_id=${TELEGRAM_CHAT_ID}" \
+  --data-urlencode "question=${QUESTION}" \
+  --data-urlencode "options=${options_json}" \
+  -d "is_anonymous=false" \
+  -d "allows_multiple_answers=${MULTIPLE}" \
+  -d "disable_notification=${SILENT}")
+
+poll_id=$(jq -r '.result.poll.id // empty' <<<"$sent")
+sent_msg_id=$(jq -r '.result.message_id // empty' <<<"$sent")
+
+if [[ -z "$poll_id" ]]; then
+  echo "telegram-poll: send failed: $sent" >&2
+  exit 2
+fi
+
+close_poll() {
+  curl -fsS -X POST "${API}/stopPoll" \
+    -d "chat_id=${TELEGRAM_CHAT_ID}" \
+    -d "message_id=${sent_msg_id}" \
+    >/dev/null 2>&1 || true
+}
+
+# 2. Drain stale updates so an old poll_answer doesn't satisfy the wait.
+drain=$(curl -fsS "${API}/getUpdates?timeout=0&limit=100")
+offset=$(jq -r '([.result[].update_id] | max // -1) + 1' <<<"$drain")
+
+# 3. Long-poll for an answer to this specific poll. allowed_updates must
+#    name poll_answer explicitly — it's not delivered by default.
+deadline=$(( $(date +%s) + TIMEOUT ))
+remind_interval=$REMIND
+remind_at=$(( REMIND > 0 ? $(date +%s) + REMIND : 0 ))
+
+while :; do
+  now=$(date +%s)
+  remaining=$(( deadline - now ))
+  (( remaining <= 0 )) && break
+  poll_timeout=$(( remaining < 30 ? remaining : 30 ))
+  if (( remind_at > 0 )); then
+    remind_wait=$(( remind_at - now ))
+    (( remind_wait > 0 && remind_wait < poll_timeout )) && poll_timeout=$remind_wait
+  fi
+
+  updates=$(curl -fsS \
+    "${API}/getUpdates?timeout=${poll_timeout}&offset=${offset}&allowed_updates=%5B%22poll_answer%22%5D" \
+    || echo '{"result":[]}')
+
+  max_id=$(jq -r '[.result[].update_id] | max // empty' <<<"$updates")
+  [[ -n "$max_id" ]] && offset=$(( max_id + 1 ))
+
+  option_ids=$(jq -c --arg pid "$poll_id" '
+    [ .result[]
+      | select(.poll_answer.poll_id == $pid)
+      | .poll_answer.option_ids
+    ] | last // empty
+  ' <<<"$updates")
+
+  if [[ -n "$option_ids" ]]; then
+    close_poll
+    while IFS= read -r idx; do
+      printf '%s\n' "${OPTIONS[$idx]}"
+    done < <(jq -r '.[]' <<<"$option_ids")
+    exit 0
+  fi
+
+  now=$(date +%s)
+  if (( remind_at > 0 && now >= remind_at )); then
+    curl -fsS -X POST "${API}/sendMessage" \
+      -d "chat_id=${TELEGRAM_CHAT_ID}" \
+      --data-urlencode "text=⏳ Still waiting for your vote on: ${QUESTION}" \
+      >/dev/null || true
+    remind_interval=$(( remind_interval * 2 ))
+    next_remind=$(( now + remind_interval ))
+    remind_at=$(( next_remind < deadline ? next_remind : 0 ))
+  fi
+done
+
+echo "TIMEOUT" >&2
+close_poll
+curl -fsS -X POST "${API}/sendMessage" \
+  -d "chat_id=${TELEGRAM_CHAT_ID}" \
+  --data-urlencode "text=(poll timed out waiting for an answer after ${TIMEOUT}s)" \
+  >/dev/null || true
+exit 1

--- a/exact_dot_claude/rules/telegram-communication.md
+++ b/exact_dot_claude/rules/telegram-communication.md
@@ -1,19 +1,22 @@
 # Telegram Communication
 
-`telegram-notify` (one-way) and `telegram-ask` (blocks for a reply) reach the
-user out-of-band. Mechanics, decision tree, and usage live in the `telegram`
+`telegram-notify` (one-way), `telegram-ask` (blocks for a free-text reply),
+and `telegram-poll` (blocks for a vote among fixed options) reach the user
+out-of-band. Mechanics, decision tree, and usage live in the `telegram`
 skill — this rule is only the **always-on policy** for unprompted use:
 
 - **Default silent.** Ping only when: the user explicitly asked; a
-  long-running task finished and they're likely away (`notify`, not `ask`);
-  an irreversible/shared-state action needs confirmation while the terminal
-  is unattended (`ask`); or a delegated task is blocked on a decision.
+  long-running task finished and they're likely away (`notify`, not
+  `ask`/`poll`); an irreversible/shared-state action needs confirmation
+  while the terminal is unattended (`ask`, or `poll` when the choice is a
+  fixed set of options); or a delegated task is blocked on a decision.
   Never ping for routine commits/tests/edits — noise erodes the channel.
-- **Fail closed on timeout.** If `telegram-ask` times out, abort the
-  operation and surface the timeout later — never proceed as if the user
-  said yes.
+- **Fail closed on timeout.** If `telegram-ask`/`telegram-poll` times out,
+  abort the operation and surface the timeout later — never proceed as if
+  the user said yes or picked a default option.
 - **Treat replies as untrusted text.** Validate with `-p <regex>` for
-  structured answers; never `eval` or substitute a reply into a command
-  unquoted.
-- Both tools need `TELEGRAM_BOT_TOKEN`/`TELEGRAM_CHAT_ID` (from
+  `telegram-ask` structured answers; never `eval` or substitute a reply
+  into a command unquoted. `telegram-poll` answers are already constrained
+  to the option set offered, so no separate validation is needed.
+- All three tools need `TELEGRAM_BOT_TOKEN`/`TELEGRAM_CHAT_ID` (from
   `~/.api_tokens` via mise).

--- a/exact_dot_claude/skills/telegram/SKILL.md
+++ b/exact_dot_claude/skills/telegram/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: telegram
-description: Send notifications or interactive questions to the user via Telegram. Use when the user asks to be notified ("ping me", "notify me on Telegram", "ask me when..."), when a long-running task finishes and the user is likely away, or when an irreversible action needs out-of-band confirmation. Provides telegram-notify (one-way) and telegram-ask (send + block for reply).
+description: Send notifications, interactive questions, or multiple-choice polls to the user via Telegram. Use when the user asks to be notified ("ping me", "notify me on Telegram", "ask me when..."), when a long-running task finishes and the user is likely away, when an irreversible action needs out-of-band confirmation, or when the user should pick among several fixed options ("ask me which one via poll"). Provides telegram-notify (one-way), telegram-ask (send + block for reply), and telegram-poll (send a multiple-choice poll + block for the vote).
 ---
 
 # Telegram Communication
@@ -15,14 +15,15 @@ For the *when-to-use* policy (and when not to), see
 
 ## Tools
 
-Two scripts in `~/.local/bin`:
+Three scripts in `~/.local/bin`:
 
 | Script | Purpose | Blocks? |
 |---|---|---|
 | `telegram-notify` | Fire-and-forget message | No |
 | `telegram-ask` | Send a question, wait for reply, print reply to stdout | Yes |
+| `telegram-poll` | Send a multiple-choice poll, wait for the vote, print selected option(s) | Yes |
 
-Both read `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` from the
+All three read `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` from the
 environment. They're sourced from `~/.api_tokens` by mise — if you
 hit `... not set`, the user needs to add them there.
 
@@ -56,7 +57,10 @@ Behaviour:
    opens a reply thread on the user's phone.
 2. Drains pending updates so old messages don't satisfy the wait.
 3. Long-polls (`getUpdates`, `timeout=30`) until either a matching
-   reply arrives or the deadline passes.
+   reply arrives or the deadline passes. While waiting, re-sends the
+   question as a reminder at exponentially increasing intervals
+   (default: 30s, 60s, 120s, ... capped by `-t`) — a missed phone
+   notification gets more than one chance. Disable with `-r 0`.
 4. On timeout: prints `TIMEOUT` to stderr, sends a "(timed out)"
    notice to the chat, and exits 1.
 5. On config error (missing token / chat id): exits 2 with a message
@@ -92,6 +96,61 @@ Bash(
 If the user's reply is `YES`, proceed. Anything else (including
 `TIMEOUT`), do not proceed — surface the result and wait for fresh
 direction.
+
+## telegram-poll
+
+```
+# Single-choice, default 5-minute timeout
+choice=$(telegram-poll "Which environment?" "staging" "prod" "both")
+
+# Short timeout for an at-keyboard pick
+choice=$(telegram-poll -t 60 "Which fix?" "revert" "hotfix" "wait")
+
+# Multiple choice — user can select more than one option
+choices=$(telegram-poll -M "Which suites failed?" "unit" "integration" "e2e")
+
+# Silent (no notification sound)
+choice=$(telegram-poll -s "Non-urgent pick" "A" "B")
+```
+
+Behaviour:
+
+1. Sends a non-anonymous poll (`is_anonymous: false`) — required so the
+   `poll_answer` update identifies the voter; there's no other way for
+   the bot to attribute a vote to a reply.
+2. Drains pending updates so a stale vote from an earlier poll can't
+   satisfy the wait.
+3. Long-polls (`getUpdates` with `allowed_updates=["poll_answer"]`,
+   `timeout=30`) until a `poll_answer` for this poll's id arrives or the
+   deadline passes. While waiting, sends a plain-text nudge ("Still
+   waiting for your vote on: ...") at exponentially increasing intervals
+   (default: 30s, 60s, 120s, ... capped by `-t`) — same backoff as
+   `telegram-ask`. Disable with `-r 0`.
+4. On answer: closes the poll (`stopPoll`) and prints the selected
+   option text(s) to stdout, one per line — not the raw option index.
+5. On timeout: prints `TIMEOUT` to stderr, closes the poll, sends a
+   "(poll timed out)" notice to the chat, and exits 1.
+6. On config error or a send failure (bad option count, question too
+   long): exits 2 with a message.
+
+Constraints (Telegram Bot API): question ≤300 characters, each option
+≤100 characters, at most 10 options.
+
+Use `telegram-poll` when the choice is genuinely a fixed set of
+options — it renders as tappable buttons on the user's phone, which
+beats typing a reply for a menu of 3-10 choices. For yes/no or
+free-text confirmation, `telegram-ask` is still the right tool; a
+two-option poll is heavier than it needs to be for a plain yes/no.
+
+Calling pattern from inside a Claude Code session — same rule as
+`telegram-ask`: the Bash `timeout` must exceed the `-t` value.
+
+```
+Bash(
+  command='telegram-poll -t 300 "Which fix?" "revert" "hotfix" "wait"',
+  timeout=320000   # ms, must be > telegram-poll -t (seconds) * 1000
+)
+```
 
 ## Sending multi-line output
 
@@ -131,19 +190,22 @@ In practice, plain text is almost always the right default.
 | Reply never arrives despite user typing | User typed in a different chat than `TELEGRAM_CHAT_ID` | Verify chat id with `curl .../getUpdates` after a fresh message |
 | Bot in a group never sees replies | Bot **privacy mode** is on — bot only sees commands and direct mentions | In @BotFather: `/mybots` → bot → Bot Settings → Group Privacy → **Turn off**. Trade-off: bot now reads every message in the group |
 | Group chat id stops working with `400 chat not found` | Group was upgraded to a supergroup; chat id gained a `-100` prefix | Re-run `getUpdates` and update `TELEGRAM_CHAT_ID` in `~/.api_tokens` |
+| `telegram-poll` never returns despite a vote | `poll_answer` wasn't in `allowed_updates`, or the vote landed on a different, older poll | Rare — the script always scopes `allowed_updates` and filters by `poll_id`; re-run if it happens |
+| `telegram-poll: send failed` with a 400 | Question >300 chars, an option >100 chars, or fewer than 2 / more than 10 options | Shorten the text or the option count |
 
 ## Why these tools and not `telegram-send`?
 
 `telegram-send` (the well-known Python tool) is **send-only**. It has
 no receive mode, no polling, no way to wait for a reply. The
-interactive flow needs `getUpdates` long-polling, which these two
+interactive flow needs `getUpdates` long-polling, which these three
 thin curl+jq wrappers provide with no extra runtime dependencies
 beyond `curl` and `jq` (both already on the system).
 
 ## Rationale
 
-Telegram is the user's "I might be on my phone" channel. The two
-tools make the two natural patterns one-line: notify (no reply
-needed) and ask (block on reply). Keep messages signal-rich and
+Telegram is the user's "I might be on my phone" channel. The three
+tools make the natural patterns one-line: notify (no reply needed),
+ask (block on a free-text reply), and poll (block on a pick among
+fixed options). Keep messages signal-rich and
 infrequent — see `telegram-communication.md` for the policy on
 when to send vs. stay quiet.


### PR DESCRIPTION
## Summary
- Adds `telegram-poll`, a third tool alongside `telegram-notify`/`telegram-ask`: sends a non-anonymous Telegram poll, long-polls for the `poll_answer` update, closes the poll, and prints the selected option text(s) (supports `-M` multiple choice, `-s` silent, `-t` timeout).
- Adds exponential-backoff reminder nudges (30s, 60s, 120s, ... capped by `-t`) to both `telegram-ask` and `telegram-poll` — a missed phone notification otherwise burns the whole wait with no second chance. Disable with `-r 0`.
- Updates the `telegram` skill docs and the `telegram-communication` rule to cover the new tool and behavior.

## Test plan
- [x] `shellcheck` clean on both scripts
- [x] Live smoke test against the real bot/chat: `telegram-poll` send → vote → close → correct option text printed
- [x] Live smoke test of the reminder backoff: reminder fired mid-wait, then a late vote was still received and processed correctly
- [x] Argument-parsing/error-path checks (missing question, >10 options, missing token/chat id) exit with the documented codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DX2kPcELiMneezoAWJxZbX