### PR TITLE
feat(zsh): complete `chezmoi edit` with managed source files

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -1013,6 +1013,22 @@ autoload -Uz compinit && compinit
 # Note: Completion definitions must be loaded AFTER compinit to ensure
 # they are properly registered with the zsh completion system
 
+# Custom completion for `chezmoi edit`: offer managed target files.
+# chezmoi's own cobra completion returns nothing for `edit`, so it falls
+# back to completing the entire filesystem. Restrict it to files/symlinks
+# that actually exist in the source directory (via `chezmoi managed`).
+# All other subcommands defer to the real _chezmoi completion.
+_chezmoi_edit_managed() {
+  if [[ ${words[2]} == edit && ${words[CURRENT]} != -* ]]; then
+    local -a managed
+    managed=("${(@f)$(command chezmoi managed --path-style=absolute --include=files,symlinks 2>/dev/null)}")
+    compadd -f -- "${managed[@]}"
+    return
+  fi
+  _chezmoi "$@"
+}
+compdef _chezmoi_edit_managed chezmoi
+
 # Custom completion for gh PR merge wrappers (ghsq, ghrb)
 # Lists open PRs with fzf-tab preview of PR details
 _gh_pr_merge_complete() {

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -614,16 +614,18 @@ _gh_batch_merge() {
 }
 
 # fzf multi-select over current-repo PRs → TSV "<tab>num<tab>title" lines for
-# the batch engine (empty repo field = current repo). $1 = header verb;
-# remaining args = extra fzf flags (e.g. --tac to reverse the list order).
+# the batch engine (empty repo field = current repo). List is sorted oldest→
+# newest (safer bet for clean rebase/squash order); $1 = header verb; remaining
+# args = extra fzf flags (callers pass --layout=reverse so the cursor starts
+# on the oldest PR, at the top, matching the sort direction).
 _gh_pr_multi_select() {
   local verb="$1"; shift
   local -a fzf_extra=("$@")
   local repo
   repo=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)
   gh pr list --limit 100 \
-      --json number,title,headRefName,isDraft,statusCheckRollup,reviewDecision \
-      --jq '.[] | [
+      --json number,title,headRefName,isDraft,statusCheckRollup,reviewDecision,createdAt \
+      --jq 'sort_by(.createdAt) | .[] | [
         "#\(.number)",
         (if .isDraft then "draft" else "ready" end),
         (if (.statusCheckRollup | length) == 0 then "⏳CI"
@@ -655,7 +657,7 @@ _gh_pr_multi_select() {
 # via completion) merges that single PR directly.
 ghsq() {
   if [[ $# -eq 0 ]]; then
-    local tsv; tsv=$(_gh_pr_multi_select squash --tac)
+    local tsv; tsv=$(_gh_pr_multi_select squash --layout=reverse)
     [[ -n "$tsv" ]] && _gh_batch_merge "$tsv" --squash --delete-branch
   else
     gh pr merge "${1%%\[*}" --squash --delete-branch
@@ -665,7 +667,7 @@ ghsq() {
 # Interactive PR merge (rebase) — multi-select twin of ghsq.
 ghrb() {
   if [[ $# -eq 0 ]]; then
-    local tsv; tsv=$(_gh_pr_multi_select rebase --tac)
+    local tsv; tsv=$(_gh_pr_multi_select rebase --layout=reverse)
     [[ -n "$tsv" ]] && _gh_batch_merge "$tsv" --rebase --delete-branch
   else
     gh pr merge "${1%%\[*}" --rebase --delete-branch


### PR DESCRIPTION
## What

Make `chezmoi edit <TAB>` complete only files/symlinks tracked in the chezmoi source directory, instead of falling back to whole-filesystem completion.

## Why

chezmoi's own cobra completion returns `:0` (no completions) for the `edit` subcommand, so zsh defaults to completing every path under the filesystem. Since `edit` only accepts managed source targets, this is noisy and lets you tab to files chezmoi can't edit.

## How

A wrapper compdef (`_chezmoi_edit_managed`) special-cases the `edit` subcommand — offering `chezmoi managed --path-style=absolute --include=files,symlinks` — and defers every other subcommand to the real `_chezmoi` completion. Flag completion (`chezmoi edit -<TAB>`) still passes through to `_chezmoi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)