### PR TITLE
feat(claude): capture orphaned shareable skill into chezmoi source

### DIFF
--- a/exact_dot_claude/skills/shareable/SKILL.md
+++ b/exact_dot_claude/skills/shareable/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: shareable
+description: Draft bite-sized "AI as coworker" wins, experiences, and useful failures for sharing on Google Chat. Use when the user says "draft a shareable about X", "share this win", "add a shareable", "make the technical/layman/one-liner/takeaway version of X", or "format the <topic> <register> for posting". Drafts each topic in four registers (layman, technical, one-liner, takeaway), queues them in FVH/shareables.md, and hands off a clipboard-ready Google Chat message to paste.
+---
+
+# Shareable — bite-sized sharing for Google Chat
+
+A low-friction workflow for sharing experiences, successes, and *useful
+failures* with colleagues on Google Chat. The user has two spaces in mind — an
+AI-use-case space ("tekoäly työkaverina", **includes non-technical
+colleagues**) and a technical space — but **drafts are organized by register,
+not by space**. The user routes each register to whichever space fits when they
+paste.
+
+Delivery is **draft → clipboard → the user pastes**. Posts as the user (not a
+bot), no credentials, human-in-the-loop. No webhook, no deploy.
+
+## The four registers
+
+Every topic is drafted in up to four registers. Default to producing all four;
+honor a request for a subset ("just the layman one", "make the takeaway").
+
+| Register | What it is | Shape |
+|---|---|---|
+| **layman** | Lead with the human outcome. Zero unexplained jargon — a non-technical colleague must get it. | 3–6 short lines, one idea |
+| **technical** | The mechanism, the how. Tool names fine. | Same brevity, mechanism-first |
+| **one-liner** | A single scannable sentence — a hook. | One sentence (use `prose-distill`) |
+| **takeaway** | Framed so a colleague can adopt it themselves. | "Try this: …" |
+
+**Categories** (set per topic in the note's metadata): `experience` |
+`success` | `useful-failure`. Support useful-failure explicitly across all
+registers — "I tried X, it didn't work, here's what I learned" is as shareable
+as a win. The user asked for failures, not just successes.
+
+## Quality bar
+
+Cold-read topic, two registers, to calibrate tone:
+
+> **layman** — 💡 A small habit that's quietly improved everything I send
+> "outward" (bug reports, docs, messages): before it goes out, I have a
+> *separate, fresh* AI read it with zero background — like handing it to a
+> brand-new colleague. If it confuses them, it'll confuse real readers too.
+> Catches the "obvious-to-me, baffling-to-everyone-else" trap before it ships.
+>
+> **one-liner** — I let a second, context-free AI "cold read" anything I send
+> outward — if a fresh reader is confused, so will real ones be.
+
+## Workflow
+
+### 1. Draft (intent: "draft a shareable about X", "add a shareable")
+
+1. **Source the topic in fact.** Read the relevant repo's `README.md` /
+   `CLAUDE.md` / `.claude/rules/`, or the relevant LakuVault note, before
+   writing. Ground every claim — these go to real colleagues.
+2. **Draft the requested registers** (default: all four). Keep each tight per
+   the table above. For the one-liner, lean on `prose-plugin:prose-distill`.
+3. **Append to the queue** as a new H2 topic section in
+   `~/Documents/LakuVault/FVH/shareables.md`, following the exact shape below.
+   New registers start `[ ]` (pending). The note's header comment documents the
+   conventions — match it.
+
+Topic section shape:
+
+```
+## <Topic title>
+- category: experience | success | useful-failure
+- source: <repo path or note>
+
+### [ ] layman
+​```text
+<layman message>
+​```
+
+### [ ] technical
+​```text
+<technical message>
+​```
+
+### [ ] one-liner
+​```text
+<one-sentence hook>
+​```
+
+### [ ] takeaway
+​```text
+<try-this tip>
+​```
+---
+```
+
+Author the `text` bodies in **light markdown** (`**bold**`, `-` bullets) — the
+conversion to Google Chat syntax happens on the way out, not in the note.
+
+### 2. Hand off for posting (intent: "format the cold-read takeaway for posting")
+
+Run the bundled helper — it extracts the block, converts it via
+`google-chat-format`, copies it to the clipboard, and prints it for review:
+
+```
+~/.claude/skills/shareable/format-draft.sh <register> "<topic substring>"
+```
+
+`<register>` is one of `layman|technical|one-liner|takeaway`. With no topic
+substring it grabs the first **pending** block for that register. Tell the user
+it's on the clipboard and ready to paste into whichever space they choose.
+
+The user can also do this without the skill via the LakuVault justfile:
+`just share-next <register>` (first pending) and `just share-list` (status
+overview).
+
+### 3. Mark posted (after the user confirms)
+
+Only after the user says it's posted, flip that register's checkbox
+`[ ]` → `[x]` in `shareables.md` (edit just the one `### [ ] <register>` line
+for that topic). Never auto-mark — an unposted draft must stay `[ ]`. Registers
+post independently, so flip only the one that went out.
+
+## Defer to
+
+- **`communication-plugin:google-chat-formatting`** — the Google Chat syntax
+  rules (single-`*` bold, `•` bullets, no `#` headers). The helper shells out
+  to `~/.local/bin/google-chat-format`, which implements them; don't reformat
+  by hand.
+- **`prose-plugin:prose-distill`** — for tightening drafts, especially the
+  one-liner.
+
+## Files
+
+- Queue note: `~/Documents/LakuVault/FVH/shareables.md` (versioned for free by
+  the vault's `vault-autocommit` LaunchAgent, every 10 min).
+- Helper: `~/.claude/skills/shareable/format-draft.sh`.

--- a/exact_dot_claude/skills/shareable/executable_format-draft.sh
+++ b/exact_dot_claude/skills/shareable/executable_format-draft.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# format-draft.sh — extract one topic+register block from the shareables
+# queue note, convert it to Google Chat syntax via google-chat-format, and
+# copy the result to the clipboard, ready to paste.
+#
+# Usage:
+#   format-draft.sh REGISTER [TOPIC_SUBSTRING]
+#
+#   REGISTER         one of: layman | technical | one-liner | takeaway
+#   TOPIC_SUBSTRING  optional, case-insensitive match against the H2 title.
+#                    If omitted, the FIRST pending ([ ]) block for REGISTER
+#                    (in file order) is used.
+#
+# Env:
+#   SHAREABLES   path to the queue note
+#                (default: ~/Documents/LakuVault/FVH/shareables.md)
+#
+# Prints the converted message to stdout (for review) and copies it to the
+# clipboard. Does NOT flip [ ]→[x]; that stays a deliberate, post-confirmation
+# step (done by the skill or by hand).
+
+set -euo pipefail
+
+REGISTER="${1:-layman}"
+TOPIC="${2:-}"
+SHAREABLES="${SHAREABLES:-$HOME/Documents/LakuVault/FVH/shareables.md}"
+
+if [[ ! -f "$SHAREABLES" ]]; then
+    echo "Error: queue note not found: $SHAREABLES" >&2
+    exit 1
+fi
+
+# Extract the raw markdown body for the requested topic+register block.
+body="$(SHAREABLES="$SHAREABLES" REGISTER="$REGISTER" TOPIC="$TOPIC" python3 - <<'PY'
+import os, re, sys
+
+path = os.environ["SHAREABLES"]
+register = os.environ["REGISTER"].strip().lower()
+topic_q = os.environ.get("TOPIC", "").strip().lower()
+
+lines = open(path, encoding="utf-8").read().splitlines()
+
+# Split into topics: an H2 (## , not ###) starts a new topic.
+topics = []  # list of (title, [body_lines])
+cur = None
+for ln in lines:
+    if re.match(r"^##\s+(?!#)", ln):
+        cur = {"title": ln[2:].strip(), "lines": []}
+        topics.append(cur)
+    elif cur is not None:
+        cur["lines"].append(ln)
+
+def blocks(topic):
+    """Yield (status, register_name, [text_lines]) for each H3 register block."""
+    tl = topic["lines"]
+    i = 0
+    while i < len(tl):
+        m = re.match(r"^###\s+\[([ xX])\]\s+([A-Za-z-]+)", tl[i])
+        if not m:
+            i += 1
+            continue
+        status, name = m.group(1).lower(), m.group(2).strip().lower()
+        # find the opening fence
+        j = i + 1
+        while j < len(tl) and not re.match(r"^```", tl[j]):
+            # stop if we hit the next H3 / H2 before any fence
+            if re.match(r"^###?\s", tl[j]):
+                break
+            j += 1
+        text = []
+        if j < len(tl) and re.match(r"^```", tl[j]):
+            j += 1
+            while j < len(tl) and not re.match(r"^```", tl[j]):
+                text.append(tl[j])
+                j += 1
+        yield status, name, text
+        i = j + 1
+
+# Candidate topics: filter by substring if a query was given.
+candidates = topics
+if topic_q:
+    candidates = [t for t in topics if topic_q in t["title"].lower()]
+    if not candidates:
+        sys.stderr.write(f"No topic matching '{topic_q}'.\n")
+        sys.exit(3)
+
+# When a topic was named, take that register regardless of status.
+# When no topic was named, take the first PENDING block for the register.
+for t in candidates:
+    for status, name, text in blocks(t):
+        if name != register:
+            continue
+        if not topic_q and status != " ":
+            continue
+        sys.stderr.write(f"→ {t['title']} :: {register}\n")
+        sys.stdout.write("\n".join(text).strip() + "\n")
+        sys.exit(0)
+
+if topic_q:
+    sys.stderr.write(f"Topic matched but no '{register}' block found.\n")
+else:
+    sys.stderr.write(f"No pending '{register}' block left.\n")
+sys.exit(4)
+PY
+)"
+
+# Convert to Google Chat syntax and copy to clipboard.
+converted="$(printf '%s\n' "$body" | google-chat-format 2>/dev/null)"
+
+if command -v pbcopy >/dev/null 2>&1; then
+    printf '%s' "$converted" | pbcopy
+elif command -v xclip >/dev/null 2>&1; then
+    printf '%s' "$converted" | xclip -selection clipboard
+elif command -v xsel >/dev/null 2>&1; then
+    printf '%s' "$converted" | xsel --clipboard --input
+else
+    echo "Warning: no clipboard tool (pbcopy/xclip/xsel); printing only." >&2
+fi
+
+echo "--- copied to clipboard, ready to paste ---"
+printf '%s\n' "$converted"


### PR DESCRIPTION
## What

Captures `~/.claude/skills/shareable/` (SKILL.md + `format-draft.sh` clipboard helper) into the chezmoi source at `exact_dot_claude/skills/shareable/`, verbatim via `chezmoi add` — the helper keeps its executable bit through the `executable_` prefix.

## Why

The skill was created directly in the target on 2026-06-22 and never captured: it works on this machine but is invisible to version control and absent on any other machine. This is exactly the orphan case the chezmoi-target-guard hook (#315) exists to flag — its test matrix surfaced this one.

## Public-repo review

- No secrets, tokens, or hostnames in either file.
- The queue-note default path (`~/Documents/LakuVault/FVH/shareables.md`) is personal-workflow, not secret, and overridable via `$SHAREABLES`; LakuVault paths already appear in the committed settings overlay.
- Depends on `~/.local/bin/google-chat-format` (communication-plugin) at runtime.

## Verification

`chezmoi status ~/.claude` and `chezmoi diff ~/.claude` are both empty after the add (source ≡ target), and `chezmoi unmanaged ~/.claude/skills` no longer lists anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Dd6GdKvZMxQkzcPgcq985