### PR TITLE
feat(zsh): sort ghi issues oldest-first like ghsq

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -443,22 +443,24 @@ ghprls() {
 }
 
 # GitHub Issues → Claude: select issue and process with git:issue skill
+# Sorted oldest-first by creation date (like ghsq), with --layout=reverse so
+# the cursor starts on the oldest issue at the top.
 ghi() {
   local issue_num
   if [[ $# -eq 0 ]]; then
     # No args: interactive fzf selection
     local selection
-    selection=$(gh issue list --json number,title,labels,updatedAt \
-      --jq '.[] | [
+    selection=$(gh issue list --json number,title,labels,createdAt \
+      --jq 'sort_by(.createdAt) | .[] | [
         "#\(.number)",
         (if (.labels | length) > 0 then (.labels | map(.name) | join(","))[:20] else "-" end),
-        (.updatedAt | fromdateiso8601 | strftime("%Y-%m-%d")),
+        (.createdAt | fromdateiso8601 | strftime("%Y-%m-%d")),
         .title[:60]
       ] | @tsv' | \
       column -t -s $'\t' | \
       _gh_paint | \
-      fzf --ansi \
-          --header '#       Labels               Updated     Title' \
+      fzf --ansi --layout=reverse \
+          --header '#       Labels               Created     Title' \
           --preview 'GH_FORCE_TTY=1 gh issue view {1}' \
           --preview-window right:60%:wrap \
           --bind 'ctrl-t:toggle-preview' \


### PR DESCRIPTION
## Summary

`ghi` listed issues in `gh`'s default order (most-recently-updated first) with an **Updated** column, while the PR pickers `ghsq`/`ghrb` sort oldest-first by creation date and pass `--layout=reverse` so the cursor lands on the oldest entry at the top. This aligns `ghi` with that convention.

- `sort_by(.createdAt)` in the `--jq` pipeline (ascending, oldest first)
- `--layout=reverse` on the fzf call, so the oldest issue is at the top under the cursor
- Date column switched from **Updated** to **Created**, so the visible date matches the sort key

## Test plan

- `zsh -n` on the rendered `~/.zshrc` (via `chezmoi cat`) — parses clean
- Ran the `gh issue list … | jq | column -t` pipeline against this repo — issues come out ascending by creation date (#232 from 2026-06-08 at the top)
- `chezmoi apply ~/.zshrc` and exercised `ghi` interactively

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6JD1GzND7vv1uxWuPSWrx