### PR TITLE
feat(just,claude): global-recipe awareness + pr-todo blocked-PR recipe

### DIFF
--- a/exact_dot_claude/CLAUDE.md
+++ b/exact_dot_claude/CLAUDE.md
@@ -47,3 +47,4 @@ When installing new tools, prefer earlier options:
 ## Development Notes
 
 - If a justfile exists, prefer its recipes (check `just --help`) over calling tools directly (e.g. use `just test` instead of `bun run test`); run `just --list` to discover recipes
+- Global recipes also exist at `~/.config/just/justfile`, invokable from **any** directory via `just -g <recipe>` (source: `private_dot_config/just/*.just` in the dotfiles repo). Run `just -g --list` to discover them before re-deriving mechanical work — they cover branch cleanup (`branch-audit`), blocked-PR triage (`pr-todo`), Claude plugin management (`plugins-*`), MCP/Claude setup (`claude-setup`, `mcp-*`), and settings hygiene (`settings-audit`). Prefer an existing recipe over hand-rolling the equivalent (per the `offload-to-deterministic-substrate` rule).

--- a/private_dot_config/just/git.just
+++ b/private_dot_config/just/git.just
@@ -53,3 +53,40 @@ branch-audit:
       echo "# ${#merged[@]} branch(es) safe to delete:"
       echo "git branch -D ${merged[*]}"
     fi
+
+# List your own open PRs blocked on YOU — changes requested or CI failing. Read-only.
+#
+# Two independent GitHub searches, unioned by URL:
+#   1. --review=changes_requested — a reviewer asked for changes.
+#   2. --checks=failure           — the PR's checks are failing.
+# A PR matching both shows both reasons. Empty result prints a clean line
+# and still exits 0 (safe in pipelines / autonomous sweeps).
+[group: "git"]
+pr-todo:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    changes=$(gh search prs --author=@me --state=open --review=changes_requested \
+      --json repository,number,title,url \
+      --jq '.[] | [.url, .repository.nameWithOwner, "#"+(.number|tostring), "changes-requested", .title] | @tsv' 2>/dev/null || true)
+    failing=$(gh search prs --author=@me --state=open --checks=failure \
+      --json repository,number,title,url \
+      --jq '.[] | [.url, .repository.nameWithOwner, "#"+(.number|tostring), "ci-failing", .title] | @tsv' 2>/dev/null || true)
+
+    # Union by URL; a PR in both searches gets both reasons joined with "+".
+    rows=$(printf '%s\n%s\n' "$changes" "$failing" | grep -v '^$' | awk -F'\t' '
+      { url=$1; repo[$1]=$2; num[$1]=$3; title[$1]=$5;
+        reason[$1] = ($1 in reason) ? reason[$1]"+"$4 : $4 }
+      END { for (u in repo) printf "%s\t%s\t%s\t%s\t%s\n", repo[u], num[u], reason[u], title[u], u }
+    ' | sort)
+
+    if [ -z "$rows" ]; then
+      echo "Nothing blocked on you — no open PRs with changes requested or failing CI."
+      exit 0
+    fi
+
+    printf '%-40s %-7s %-24s %s\n' REPO PR REASON TITLE
+    printf '%.0s-' {1..100}; echo
+    printf '%s\n' "$rows" | while IFS=$'\t' read -r repo num reason title url; do
+      printf '%-40s %-7s %-24s %s\n' "$repo" "$num" "$reason" "$title"
+    done


### PR DESCRIPTION
## Summary

Two changes so agents discover and prefer the global `just -g` recipe set, plus a new recipe surfacing PRs awaiting the user.

- **CLAUDE.md global-recipe pointer** (`exact_dot_claude/CLAUDE.md`): adds an always-loaded bullet under `## Development Notes` pointing at `~/.config/just/justfile` and `just -g <recipe>`, with `just -g --list` as the self-updating discovery command (no enumerated catalog that drifts). Ties into the `offload-to-deterministic-substrate` rule.
- **`pr-todo` recipe** (`private_dot_config/just/git.just`): lists the user's own open PRs blocked on them — changes requested **or** CI failing — via two `gh search prs --author=@me` queries unioned by URL (a PR matching both shows both reasons). Read-only, exits 0 on empty, mirrors `branch-audit`'s table style.

## Verification

- `gh search prs` flags validated against the installed `gh` (`--review=changes_requested`, `--checks=failure`; exit 0, `[]` on empty)
- `chezmoi diff`/`status ~/.claude` clean — no stray exact_ deletions
- `just -g pr-todo` runs end-to-end and exits 0; `just -g --list` shows it under the git group
- pre-commit hooks pass (justfile parse/eval, context budget, doc references, gitleaks)

## Out of scope (pre-existing, flagged for separate cleanup)

`git.just` is imported by the global justfile but not the repo-root `justfile`, so `pr-todo`/`branch-audit` are `just -g`-only (not bare `just`). The repo-root justfile's import comments also still reference the dead `~/.user.justfile` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)