### PR TITLE
chore(mise,claude): add cargo-deny via aqua + deny-rule flag-pattern docs

### DIFF
--- a/exact_dot_claude/rules/claude-code-auto-mode.md
+++ b/exact_dot_claude/rules/claude-code-auto-mode.md
@@ -51,6 +51,16 @@ any mode except `bypassPermissions`. Keep dangerous ops in `deny`
 (`git push --force *`, `git add -A`, `kubectl config use-context *`,
 `Write(**/CHANGELOG.md)`).
 
+**Use the space-delimited form for flag-scoped deny rules, not `:*`.**
+Colon-form patterns prefix-match the raw command string, so
+`Bash(git push --force:*)` also hard-blocks `git push --force-with-lease …`
+— locking out the safe recovery form that the stacked-PR protocol
+(`git-hazards.md` trap #7) depends on. The space form
+`Bash(git push --force *)` stops the match at the exact flag (the trailing
+space can't match `-with-lease`), leaving lease-guarded pushes to the
+classifier's soft-deny instead of a hard block. (Caught in loractl PR #39
+review, 2026-07 — an agent-authored colon-form deny had silently widened.)
+
 ## Custom hooks vs. auto mode — don't double-gate
 
 A custom PreToolUse/UserPromptSubmit hook that re-implements a safety check

--- a/private_dot_config/mise/config.toml.tmpl
+++ b/private_dot_config/mise/config.toml.tmpl
@@ -131,6 +131,7 @@ d2 = "latest"
 chezmoi = "latest"
 usage = "latest"
 uv = "latest"
+"aqua:EmbarkStudios/cargo-deny" = "latest"    # Rust license/bans/sources gate (cargo deny)
 
 # ============================================================================
 # Environment Variables


### PR DESCRIPTION
## Summary

Lands two previously-unpushed local commits:

- **feat(mise): add cargo-deny via aqua backend** — adds `cargo-deny` through mise's aqua backend (checksum-verified standalone binary, per the tool-installation priority).
- **docs(claude): deny rules — space form, not `:*`, for flag-scoped patterns** — clarifies the correct permission-deny pattern form for flag-scoped matches.

These were committed locally on 2026-07-11 but never pushed; splitting them out of the `main` divergence and landing them cleanly via PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)