### PR TITLE
fix(claude): drop unmatched Write() deny rule for CHANGELOG.md

### DIFF
--- a/exact_dot_claude/modify_settings.json
+++ b/exact_dot_claude/modify_settings.json
@@ -172,8 +172,7 @@ read -r -d '' overlay <<'OVERLAY' || true
       "Bash(git push --force *)",
       "Bash(git push -f *)",
       "Bash(kubectl config use-context *)",
-      "Edit(**/CHANGELOG.md)",
-      "Write(**/CHANGELOG.md)"
+      "Edit(**/CHANGELOG.md)"
     ],
     "ask": [],
     "defaultMode": "auto",

--- a/exact_dot_claude/rules/claude-code-auto-mode.md
+++ b/exact_dot_claude/rules/claude-code-auto-mode.md
@@ -49,7 +49,10 @@ entries.
 `permissions.deny` resolves before the classifier and cannot be overridden in
 any mode except `bypassPermissions`. Keep dangerous ops in `deny`
 (`git push --force *`, `git add -A`, `kubectl config use-context *`,
-`Write(**/CHANGELOG.md)`).
+`Edit(**/CHANGELOG.md)` — file-permission checks match only `Edit(path)`
+rules, which cover all file-editing tools including Write; a
+`Write(path)` deny rule is never matched and Claude Code warns about it
+at launch).
 
 **Use the space-delimited form for flag-scoped deny rules, not `:*`.**
 Colon-form patterns prefix-match the raw command string, so


### PR DESCRIPTION
## What

Removes `Write(**/CHANGELOG.md)` from the `permissions.deny` overlay in `exact_dot_claude/modify_settings.json`, keeping only `Edit(**/CHANGELOG.md)`, and updates the deny-backstop example in `rules/claude-code-auto-mode.md` accordingly.

## Why

Claude Code now warns at every launch:

> Permission deny rule: Write(**/CHANGELOG.md) is not matched by file permission checks — only Edit(path) rules are. Use Edit(**/CHANGELOG.md) instead (Edit rules cover all file-editing tools).

`Edit(path)` rules cover all file-editing tools (Write, Edit, NotebookEdit), so the Write entry was redundant and unmatched. Applied to the live `~/.claude/settings.json` via `chezmoi apply`; the warning no longer fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ybMwaDwhwhXsvMfBLk8Gq