### PR TITLE
fix(chezmoi): ignore Claude Code credential + settings-backup runtime files

### DIFF
--- a/exact_dot_claude/.chezmoiignore
+++ b/exact_dot_claude/.chezmoiignore
@@ -41,6 +41,8 @@ jobs/
 .last-update-result.json
 
 # Runtime files created by Claude Code
+.credentials.json
+settings.json.backup.*
 policy-limits.json
 remote-settings.json
 .update.lock


### PR DESCRIPTION
## What

Adds two entries to `exact_dot_claude/.chezmoiignore` under the runtime-files section: `.credentials.json` and `settings.json.backup.*`.

## Why

`~/.claude` is an `exact_` tree, so any unlisted top-level entry is deleted on `chezmoi apply`. While preparing #327, `chezmoi status ~/.claude` showed pending `D` lines for:

- `.credentials.json` — Claude Code auth state; deleting it would log the CLI out
- `settings.json.backup.<timestamp>` — written by Claude Code (2026-07-16) before migrating settings

Neither was registered in `.chezmoiignore`, so the next apply would have silently removed both. This is the same failure class as the `friction-reports/` deletion incident documented in `chezmoi-conventions.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ybMwaDwhwhXsvMfBLk8Gq