### PR TITLE
chore(claude): refresh _claude completion for auto-mode reset

### DIFF
--- a/dot_zfunc/_claude
+++ b/dot_zfunc/_claude
@@ -12,7 +12,7 @@ _claude() {
     commands=(
         'agents:Manage background agents'
         'auth:Manage authentication'
-        'auto-mode:Inspect auto mode classifier'
+        'auto-mode:Inspect or reset auto mode classifier'
         'doctor:Check the health of your Claude Code'
         'gateway:Run the enterprise auth/telemetry'
         'install:Install Claude Code native build. Use'
@@ -104,7 +104,7 @@ _claude_config() {
     config_commands=(
         'agents:Manage background agents'
         'auth:Manage authentication'
-        'auto-mode:Inspect auto mode classifier'
+        'auto-mode:Inspect or reset auto mode classifier'
         'doctor:Check the health of your Claude Code'
         'gateway:Run the enterprise auth/telemetry'
         'install:Install Claude Code native build. Use'


### PR DESCRIPTION
## Summary

Regenerated the tracked zsh completion `dot_zfunc/_claude`. The `claude` CLI updated its `auto-mode` subcommand description to **"Inspect or reset auto mode classifier"**; this change picks it up in both the top-level and `config` command tables.

Mechanical regeneration — no hand edits.

## Testing

Pre-commit passed locally (trailing-whitespace, gitleaks, conventional-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ARaC2rDebsKVACxYBVDv8