### PR TITLE
feat(telegram): human-realistic wait defaults for ask/poll

### DIFF
--- a/dot_local/bin/executable_telegram-ask
+++ b/dot_local/bin/executable_telegram-ask
@@ -2,7 +2,7 @@
 # telegram-ask — send a question to Telegram and wait for the user's reply.
 #
 # Usage:
-#   telegram-ask "Question text?"                       # default 5min timeout
+#   telegram-ask "Question text?"                       # default 1h timeout
 #   telegram-ask -t 30 "Quick question?"                # 30s timeout
 #   telegram-ask --pattern '^(YES|NO)$' "YES or NO?"    # require regex match
 #   telegram-ask -r 0 "No reminders, just wait"         # disable reminders
@@ -16,16 +16,16 @@
 # These are typically sourced from ~/.api_tokens via mise.
 #
 # While waiting, re-pings with a reminder at exponentially increasing
-# intervals (default: 30s, 60s, 120s, ... capped by --timeout) so a missed
-# phone notification gets a second and third chance before the deadline.
-# Disable with -r 0.
+# intervals (default: 5m, then 10m, 20m, ... capped by --timeout) so a
+# missed phone notification gets a second and third chance before the
+# deadline. Disable with -r 0.
 
 set -euo pipefail
 
-TIMEOUT=300
+TIMEOUT=3600
 PATTERN=""
 PARSE_MODE=""
-REMIND=30
+REMIND=300
 
 usage() {
   sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'

--- a/dot_local/bin/executable_telegram-poll
+++ b/dot_local/bin/executable_telegram-poll
@@ -22,16 +22,16 @@
 # telegram-ask instead — polls are for picking among fixed options.
 #
 # While waiting, re-pings with a reminder at exponentially increasing
-# intervals (default: 30s, 60s, 120s, ... capped by --timeout) so a missed
-# phone notification gets a second and third chance before the deadline.
-# Disable with -r 0.
+# intervals (default: 5m, then 10m, 20m, ... capped by --timeout) so a
+# missed phone notification gets a second and third chance before the
+# deadline. Disable with -r 0.
 
 set -euo pipefail
 
-TIMEOUT=300
+TIMEOUT=3600
 MULTIPLE="false"
 SILENT="false"
-REMIND=30
+REMIND=300
 
 usage() {
   sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'

--- a/exact_dot_claude/rules/validate-adversarial-constructions.md
+++ b/exact_dot_claude/rules/validate-adversarial-constructions.md
@@ -1,0 +1,67 @@
+---
+paths:
+  - "**/tests/**"
+  - "**/*_test.*"
+  - "**/*.test.*"
+  - "**/test_*.py"
+  - "**/docs/adrs/**"
+---
+
+# Simulation-Validate Adversarial Constructions Before Freezing Them
+
+An adversarial test construction — a discriminator input, a stress case, an
+accuracy gate, any "this case catches that bug" claim — is **unverified until a
+deterministic simulation of the exact mechanism under test shows it decisively
+separates broken from correct, on every seed**. Asserted-by-construction is a
+hypothesis, not a property: the construction encodes the author's noise model,
+and the noise model is exactly the thing most likely to be wrong.
+
+## The rule
+
+Before an adversarial case ships in a spec, ADR, or test suite:
+
+1. **Simulate the charged mechanism** (not a sketch of it — the same
+   quantization/rounding/precision path the real system takes) with the
+   defect present *and* absent.
+2. **Require decisive separation**: the broken variant must fail the gate
+   with margin on **every** seed; the correct variant must pass with margin.
+   A construction that separates on most seeds is a flaky gate, not a gate.
+3. **Encode the validation as a meta-test** that runs forever after — one
+   test proving the case still kills the broken variant (the gate has
+   teeth), one proving the correct variant still passes (the gate is
+   achievable, not aspirational). The meta-tests keep the case lethal as
+   magnitudes and code evolve.
+4. When the simulation and the construction disagree, **the simulation
+   wins** — re-derive the construction, and record the refuted version and
+   why it failed (the failure mode is usually a reusable lesson).
+
+## Why (measured, 2026-07, attention-engine ADR-0011)
+
+One protocol-design session fired this rule three times, each catch invisible
+to review-by-reading:
+
+- The first-draft smoothing discriminator was **refuted by simulation** — an
+  unsmoothed kernel passed it with ~25× margin, because unbiased rounding
+  dithers mean logit gaps through and a token-constant bias's quantization
+  error is softmax-shift-invariant. Plausible construction, zero teeth.
+- The redesigned construction was dead at implementation time for a different
+  reason: the drafting simulation had **omitted the `1/√d` score scale** the
+  real attention applies. Caught only by re-simulating with the real
+  mechanism (`Q ≡ 2` → measurably dead; `Q ≡ 16` → designed separation
+  restored exactly).
+- The pre-freeze calibration then caught the **noise model itself** being
+  wrong ~23×: near-uniform attention averages dense per-logit noise by
+  ~`1/√N`, so predicted output error was dominated by a floor the model
+  had ignored.
+
+Three independent designers and a four-lens adversarial review all missed the
+first defect; a 60-line NumPy simulation found it in seconds.
+
+## Related
+
+- `offload-to-deterministic-substrate.md` — the parent law: the simulation is
+  the deterministic substrate for the correctness of the *test design itself*.
+- `never-fabricate-test-identifiers.md` — sibling instinct: don't trust an
+  input you invented until the system confirms it does what you assume.
+- `prefer-diy-over-heavy-dependency.md` § diff-test — the same move applied to
+  verifying reimplementations.

--- a/exact_dot_claude/skills/telegram/SKILL.md
+++ b/exact_dot_claude/skills/telegram/SKILL.md
@@ -41,7 +41,7 @@ Returns immediately. Exit 0 on send, 2 on config error.
 ## telegram-ask
 
 ```
-# Default: 5-minute timeout, accept any reply
+# Default: 1-hour timeout, accept any reply
 answer=$(telegram-ask "Proceed with the deploy?")
 
 # Short timeout for an at-keyboard yes/no
@@ -59,8 +59,9 @@ Behaviour:
 3. Long-polls (`getUpdates`, `timeout=30`) until either a matching
    reply arrives or the deadline passes. While waiting, re-sends the
    question as a reminder at exponentially increasing intervals
-   (default: 30s, 60s, 120s, ... capped by `-t`) — a missed phone
-   notification gets more than one chance. Disable with `-r 0`.
+   (default: after 5m, then 10m, 20m, ... capped by `-t`) — a missed
+   phone notification gets more than one chance, without nagging
+   someone who's simply away from their phone. Disable with `-r 0`.
 4. On timeout: prints `TIMEOUT` to stderr, sends a "(timed out)"
    notice to the chat, and exits 1.
 5. On config error (missing token / chat id): exits 2 with a message
@@ -82,16 +83,33 @@ fi
 
 ## Calling pattern from inside a Claude Code session
 
-Use `Bash` with a long-enough `timeout` parameter. `telegram-ask` blocks
-the call until the user replies, so the Bash timeout must exceed the
-`telegram-ask -t` value.
+`telegram-ask` blocks until the user replies, and the default `-t` is
+now 3600s (1 hour) — longer than the Bash tool's 10-minute foreground
+cap. Two patterns:
+
+**Short waits (≤ ~9 min)**: pass an explicit `-t` and a Bash `timeout`
+that exceeds it.
 
 ```
 Bash(
-  command='telegram-ask -t 600 -p "^(YES|NO)$" "Run the destructive migration?"',
-  timeout=620000   # ms, must be > telegram-ask -t (seconds) * 1000
+  command='telegram-ask -t 480 -p "^(YES|NO)$" "Run the destructive migration?"',
+  timeout=500000   # ms, must be > telegram-ask -t (seconds) * 1000
 )
 ```
+
+**Long waits (default 1h)**: run in the background — the harness
+re-invokes you when the script exits, so no polling loop is needed.
+
+```
+Bash(
+  command='telegram-ask -p "^(YES|NO)$" "Run the destructive migration?"',
+  run_in_background=true
+)
+```
+
+Read the reply from the task output when it completes. Humans routinely
+take 15–60 minutes to notice a phone notification; prefer the
+background pattern over shrinking `-t` to fit a foreground call.
 
 If the user's reply is `YES`, proceed. Anything else (including
 `TIMEOUT`), do not proceed — surface the result and wait for fresh
@@ -100,7 +118,7 @@ direction.
 ## telegram-poll
 
 ```
-# Single-choice, default 5-minute timeout
+# Single-choice, default 1-hour timeout
 choice=$(telegram-poll "Which environment?" "staging" "prod" "both")
 
 # Short timeout for an at-keyboard pick
@@ -124,8 +142,8 @@ Behaviour:
    `timeout=30`) until a `poll_answer` for this poll's id arrives or the
    deadline passes. While waiting, sends a plain-text nudge ("Still
    waiting for your vote on: ...") at exponentially increasing intervals
-   (default: 30s, 60s, 120s, ... capped by `-t`) — same backoff as
-   `telegram-ask`. Disable with `-r 0`.
+   (default: after 5m, then 10m, 20m, ... capped by `-t`) — same backoff
+   as `telegram-ask`. Disable with `-r 0`.
 4. On answer: closes the poll (`stopPoll`) and prints the selected
    option text(s) to stdout, one per line — not the raw option index.
 5. On timeout: prints `TIMEOUT` to stderr, closes the poll, sends a
@@ -142,8 +160,9 @@ beats typing a reply for a menu of 3-10 choices. For yes/no or
 free-text confirmation, `telegram-ask` is still the right tool; a
 two-option poll is heavier than it needs to be for a plain yes/no.
 
-Calling pattern from inside a Claude Code session — same rule as
-`telegram-ask`: the Bash `timeout` must exceed the `-t` value.
+Calling pattern from inside a Claude Code session — same rules as
+`telegram-ask`: for a short explicit `-t`, the Bash `timeout` must
+exceed it; for the 1-hour default, use `run_in_background=true`.
 
 ```
 Bash(


### PR DESCRIPTION
## What

- `telegram-ask` / `telegram-poll`: default timeout raised 300s → **3600s (1 hour)**; first reminder nudge raised 30s → **5 minutes**, still doubling exponentially (5m → 10m → 20m, capped by the deadline).
- `telegram` skill: documents the new defaults and adds the `run_in_background=true` calling pattern, since the 1-hour default now exceeds the Bash tool's 10-minute foreground timeout cap.

## Why

The old defaults nudged at ~30s/90s/210s and gave up at 5 minutes — not realistic for a human away from their phone. Reminders now back off on human timescales and the wait survives a coffee break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpXfWJDmEAgZ29o7Kkj9Ff