### PR TITLE
fix(chezmoi): stop repo-meta leaking into $HOME via .chezmoiignore

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -19,3 +19,14 @@ CLAUDE.md
 /**/__pycache__/
 plugins/
 .mcp.json
+# Repo-meta that lives at the source root for working *in this repo* but must not
+# apply to $HOME (same rationale as README.md / Dockerfile / plugins/ above).
+# Root-anchored so only the source-root copy is ignored, never a managed nested
+# target of the same basename.
+/LICENSE
+/DOCKER.md
+/docs/
+/tests/
+# ~/tmp is a scratch dir, not dotfiles state — chezmoi shouldn't manage it or the
+# one-off notes previously committed under tmp/.
+/tmp/


### PR DESCRIPTION
## What

Add root-anchored `.chezmoiignore` entries for `docs/`, `tests/`, `LICENSE`, `DOCKER.md`, and `tmp/`.

## Why

These live at the source root for working *in this repo*, but with no `dot_` prefix chezmoi was applying them to `~/docs`, `~/tests`, `~/LICENSE`, `~/DOCKER.md`, and `~/tmp` — the footgun documented in `.claude/rules/chezmoi-conventions.md` ("A Non-`dot_` File at the Source Root Silently Applies to `$HOME`"). Same category as the `README.md` / `Dockerfile` / `plugins/` entries already ignored here.

Surfaced during a `$HOME` cleanup audit: `~/docs`, `~/tests`, `~/LICENSE`, `~/DOCKER.md` were sitting in the home directory as chezmoi-managed copies.

## How

- Root-anchor each pattern (leading `/`) so only the source-root copy is ignored, never a managed nested target of the same basename.
- `tmp/` is gitignored scratch (one-off notes previously dropped there, not in the public repo); chezmoi should not manage it.

## Safety

- Home targets are byte-identical to source (`chezmoi diff` empty for each), so removing the leaked `~/` copies loses nothing — their source of truth is this repo.
- Verified the ignore delta is exactly `docs`/`tests`/`LICENSE`/`DOCKER.md` (+ children); no nested over-match.

## Post-merge follow-up

After merge + `chezmoi apply`, the already-deployed `~/docs`, `~/tests`, `~/LICENSE`, `~/DOCKER.md` and the managed `~/tmp` scratch files can be removed from `$HOME` (they will no longer be redeployed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)