### PR TITLE
fix(just): bind empty assoc array; add plugins-reconcile-keys

### DIFF
--- a/private_dot_config/just/plugins.just
+++ b/private_dot_config/just/plugins.just
@@ -118,6 +118,53 @@ plugins-sync-repo repo:
     printf '%s\n' "$new" > "$target"
     echo "{{GREEN}}Wrote $target — review with: git -C \"$(dirname "$(dirname "$target")")\" diff{{NORMAL}}"
 
+# Reconcile one repo's exhaustive plugin key SET against canonical, preserving its own enable values
+[group: "plugins"]
+plugins-reconcile-keys repo:
+    #!/usr/bin/env bash
+    # The safe half of plugins-sync-repo, for unattended use (the weekly routine).
+    # Membership only:
+    #   +  add canonical @laurigates-claude-plugins keys the repo is MISSING, using
+    #      canonical's value. This is the real functional bug: enabledPlugins is a
+    #      WHOLE-MAP replacement, so a plugin omitted from an exhaustive pin is
+    #      silently DISABLED in web/remote sessions.
+    #   -  drop keys pinned here that no longer exist in the live marketplace
+    #      (renamed/removed upstream) — dead pins that can never resolve.
+    #
+    # Deliberately does NOT touch the value of a key present in both. Enable state
+    # is stack-specific and drifts in BOTH directions on purpose: `infrastructure`
+    # keeps terraform-plugin/kubernetes-plugin ON where canonical has them OFF.
+    # Auto-"fixing" that would disable exactly the plugins a repo needs. Value
+    # drift is reported by plugins-audit and resolved by a human.
+    #
+    # Applies only to EXHAUSTIVE pins (>= floor keys, same floor as plugins-audit);
+    # a deliberate narrow subset is left untouched. Idempotent.
+    set -uo pipefail
+    repo="{{repo}}"; repo="${repo%/}"
+    s="$repo/.claude/settings.json"
+    canonical="$HOME/.claude/settings.json"
+    mp="laurigates-claude-plugins"
+    floor=30
+    if [ ! -f "$s" ];         then echo "{{YELLOW}}No $s{{NORMAL}}"; exit 1; fi
+    if [ ! -f "$canonical" ]; then echo "{{YELLOW}}No $canonical{{NORMAL}}"; exit 1; fi
+    n="$(jq -r --arg m "$mp" '[(.enabledPlugins // {}) | keys[] | select(endswith("@"+$m))] | length' "$s" 2>/dev/null)"
+    if [ -z "$n" ]; then echo "{{YELLOW}}Unreadable enabledPlugins: $s{{NORMAL}}"; exit 1; fi
+    if [ "$n" -lt "$floor" ]; then echo "{{GREEN}}Deliberate subset ($n < $floor) — untouched: $repo{{NORMAL}}"; exit 0; fi
+    live="$(curl -fsS "{{marketplace_url}}" | jq -c '[.plugins[].name]')" || live=""
+    if [ -z "$live" ] || [ "$live" = "[]" ]; then echo "{{YELLOW}}Marketplace fetch failed — refusing to reconcile (would look like every plugin was removed){{NORMAL}}"; exit 1; fi
+    new="$(jq --arg m "$mp" --argjson live "$live" --slurpfile c "$canonical" '
+        ($live | map(. + "@" + $m))                                             as $liveKeys
+      | (($c[0].enabledPlugins // {}) | with_entries(select((.key | endswith("@"+$m)) and (.key | IN($liveKeys[]))))) as $Canon
+      | ((.enabledPlugins   // {}) | with_entries(select((.key | endswith("@"+$m) | not) or (.key | IN($liveKeys[]))))) as $Kept
+      | .enabledPlugins = ($Canon + $Kept)
+    ' "$s" 2>/dev/null)"
+    if [ -z "$new" ]; then echo "{{YELLOW}}jq reconcile failed: $s{{NORMAL}}"; exit 1; fi
+    if [ "$(printf '%s' "$new" | jq -S .)" = "$(jq -S . "$s")" ]; then echo "{{GREEN}}Key set already canonical: $repo{{NORMAL}}"; exit 0; fi
+    echo "{{BLUE}}enabledPlugins key-set changes for $repo:{{NORMAL}}"
+    diff <(jq -S '.enabledPlugins // {}' "$s") <(printf '%s' "$new" | jq -S '.enabledPlugins') || true
+    printf '%s\n' "$new" > "$s"
+    echo "{{GREEN}}Wrote $s — review with: git -C \"$repo\" diff{{NORMAL}}"
+
 # ── Domain-scoped bulk install/check/re-eval across repos ─────────────────────
 # Orchestration layer over the per-repo judgment skills (configure-claude-plugins,
 # health-check --scope=stack, configure:repo). Enumerate a domain scope → fzf
@@ -160,7 +207,11 @@ _plugins-annotate repo:
     allow_re='^(laurigates-claude-plugins|claude-plugins|lgates-claude-plugins|laurigates-plugins)$'
     mapfile -t all_aliases < <(jq -r '(.enabledPlugins // {}) | keys[] | split("@") | .[-1]' "$s" 2>/dev/null)
     total=${#all_aliases[@]}
-    lauri_n=0; declare -A seen
+    # The `=()` is load-bearing: under `set -u`, bash treats a declared-but-never-
+    # assigned associative array as UNBOUND, so `${#seen[@]}` below aborts the
+    # recipe ("seen: unbound variable") for any repo with zero laurigates plugins
+    # — exactly the repos an audit most needs to report (OLMap, kicad-mcp).
+    lauri_n=0; declare -A seen=()
     for a in "${all_aliases[@]}"; do
       if [[ "$a" =~ $allow_re ]]; then lauri_n=$((lauri_n + 1)); seen["$a"]=1; fi
     done


### PR DESCRIPTION
Two changes to the canonical Claude-plugins recipes, both needed by the new weekly `plugins-audit` routine in `~/repos/.routines/`.

## 1. `_plugins-annotate` crashed on zero-plugin repos

```
/Users/lgates/tmp/just-bmqgEJ/_plugins-annotate: line 179: seen: unbound variable
```

Under `set -u`, bash 5.3 treats a `declare -A seen` that is never assigned as **unbound**, so `${#seen[@]}` aborts the recipe. It fired on exactly the repos an audit most needs to report — `OLMap` and `kicad-mcp`, which have a `claude.yml` workflow but **zero** plugins enabled. `declare -A seen=()` binds it.

Reproduce:

```
bash -c 'set -uo pipefail; declare -A seen; echo "${#seen[@]}"'   # seen: unbound variable
bash -c 'set -uo pipefail; declare -A seen=(); echo "${#seen[@]}"' # 0
```

## 2. New `plugins-reconcile-keys` — the unattended-safe half of `plugins-sync-repo`

Reconciles the key **set** of an exhaustive pin against canonical while leaving each repo's own enable/disable **values** alone:

- **+** adds canonical plugins the repo omits
- **−** drops pins for plugins no longer in the marketplace
- **=** never touches the value of a key present in both

The distinction is load-bearing, and is why the existing `plugins-sync-repo` must stay a deliberate interactive operation:

| | Is it a bug? |
|---|---|
| **Missing key** | **Yes.** `enabledPlugins` is a whole-map replacement, so a plugin omitted from an exhaustive pin is silently *disabled* in web/remote sessions. |
| **Differing value** | **No.** Stack-specific, and drifts in *both* directions on purpose — `infrastructure` keeps `terraform-plugin` and `kubernetes-plugin` **on** where canonical has them **off**. |

Measured across the four exhaustive-pinned repos before writing this:

| repo | value drift | canonical=false, repo=true | canonical=true, repo=false |
|---|---:|---:|---:|
| infrastructure | 6 | 4 | 2 |
| thelma | 13 | 5 | 8 |
| dev-workflow-overview | 16 | 8 | 8 |
| claude-plugins | 17 | 17 | 0 |

Blanket-syncing those would disable exactly the plugins each repo needs.

Also refuses to run when the marketplace fetch fails, rather than treating an empty response as "every plugin was removed" — which would strip pins portfolio-wide.

## Verification

```
$ just -g _plugins-annotate ~/repos/ForumViriumHelsinki/OLMap
/Users/lgates/repos/ForumViriumHelsinki/OLMap	enabled=0 lauri=0 none wf=claude.yml,claude-review.yml tracked   # was: unbound variable

$ just -g plugins-reconcile-keys ~/repos/ForumViriumHelsinki/infrastructure
  + comfyui-plugin / foundryvtt-plugin / session-plugin / software-design-plugin
  - upstream-pr-plugin        # gone from the marketplace

$ just -g plugins-reconcile-keys ~/repos/laurigates/loractl
Deliberate subset (8 < 30) — untouched
```

Re-running is a no-op ("Key set already canonical"). The `infrastructure` test write was reverted; the real change will land via the routine's PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zrh72rhT9VtdDYKnjRyVh