### PR TITLE
fix(docs): repoint stale slash-commands link to code.claude.com

### DIFF
--- a/exact_dot_claude/docs/prds/daily-catchup.PRD.md
+++ b/exact_dot_claude/docs/prds/daily-catchup.PRD.md
@@ -1926,7 +1926,7 @@ chezmoi apply  # If not using symlink
 ### References
 
 **Claude Code Documentation:**
-- Slash Commands: https://docs.anthropic.com/claude-code/commands
+- Slash Commands: https://code.claude.com/docs/en/slash-commands
 - MCP Protocol: https://modelcontextprotocol.io/
 
 **MCP Servers:**


### PR DESCRIPTION
## What

One URL in `exact_dot_claude/docs/prds/daily-catchup.PRD.md`:

`https://docs.anthropic.com/claude-code/commands` → `https://code.claude.com/docs/en/slash-commands`

## Why

The **Link Checker** workflow has been failing on `main`, and this 404 is the *only* error it reports. That path predates the docs reorganisation and no longer redirects.

Verified the replacement rather than assuming it — all three candidate forms resolve to the same final URL:

| Candidate | Result |
|---|---|
| `docs.claude.com/en/docs/claude-code/slash-commands` | 200 → `code.claude.com/docs/en/slash-commands` |
| `docs.anthropic.com/en/docs/claude-code/slash-commands` | 200 → `code.claude.com/docs/en/slash-commands` |
| `code.claude.com/docs/en/slash-commands` | 200 (final) |

Using the final destination avoids a redirect hop and matches the `code.claude.com` links already in `rules/claude-code-auto-mode.md`.

## Left alone

The two other `docs.anthropic.com` links in the repo (in `exact_dot_claude/docs/blueprint-development/README.md`) use the `/en/docs/` prefix and still redirect cleanly — the checker does not flag them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AF6S4A2q5ha5Yhk8duyMp