### PR TITLE
fix(zsh): group `just -g` recipe completion like bare `just`

### DIFF
--- a/dot_zfunc/_just
+++ b/dot_zfunc/_just
@@ -21,11 +21,39 @@ if (( ! $+functions[_just_clap] )); then
   [[ -n $_src ]] && eval "$_src"
 fi
 
+# Walk the words before the cursor. If they are *only* justfile-selecting
+# flags (`just -g <TAB>`, `just -f path/to/justfile <TAB>`, …), the cursor is
+# still at the recipe-name position: set `_just_dump_args` so `--dump` reads
+# the same justfile the recipe would run from, and return 0. Anything else
+# (a positional recipe already typed, an unrecognized flag) returns 1 so the
+# native clap completer takes over.
+_just_recipe_position() {
+  _just_dump_args=()
+  local i=2 w
+  while (( i < CURRENT )); do
+    w=$words[i]
+    case $w in
+      -g|--global-justfile|-u|--unstable|--justfile=*|--working-directory=*)
+        _just_dump_args+=$w
+        (( i++ ))
+        ;;
+      -f|--justfile|-d|--working-directory)
+        # Its value is the word under the cursor -> not a recipe position.
+        (( i + 1 < CURRENT )) || return 1
+        _just_dump_args+=($w $words[i+1])
+        (( i += 2 ))
+        ;;
+      *) return 1 ;;
+    esac
+  done
+  return 0
+}
+
 # Add recipe names grouped by their `[group(...)]` attribute.
 # Returns 0 if it added at least one group of matches.
 _just_recipes_grouped() {
   local json
-  json="$(just --dump --dump-format json 2>/dev/null)" || return 1
+  json="$(just $_just_dump_args --dump --dump-format json 2>/dev/null)" || return 1
   [[ -n $json ]] || return 1
 
   # Emit  group<TAB>name<TAB>doc  (ungrouped recipes get an empty group).
@@ -80,9 +108,12 @@ _just_recipes_grouped() {
   (( added ))
 }
 
-# Complete the recipe name in the first non-flag position with groups;
-# delegate everything else (flags, recipe arguments) to the native completer.
-if [[ ${words[CURRENT]} != -* ]] && (( CURRENT == 2 )); then
+# Complete the recipe name in the first positional slot with groups — also
+# after leading justfile-selecting flags, so `just -g <TAB>` groups the global
+# justfile's recipes instead of falling through to the flat clap list.
+# Delegate everything else (flags, recipe arguments) to the native completer.
+local -a _just_dump_args
+if [[ ${words[CURRENT]} != -* ]] && _just_recipe_position; then
   _just_recipes_grouped && return
 fi
 


### PR DESCRIPTION
Fixes `just -g <TAB>` falling back to the flat clap completion.

## What

`~/.zfunc/_just` (source: `dot_zfunc/_just`) only took its grouped path when the recipe name sat in word 2:

```zsh
if [[ ${words[CURRENT]} != -* ]] && (( CURRENT == 2 )); then
```

So `just -g <TAB>` landed at word 3 and fell through to `just`'s clap dynamic completer, which returns the global recipes flattened into one `values` group **alongside all 68 CLI flags** (154 candidates total). fzf-tab rendered that as a single unusable list — no `[group(...)]` headers, no `,`/`.` group switching.

## How

Adds `_just_recipe_position`, which walks the words before the cursor and accepts a leading run of justfile-selecting flags:

| Flag | Form |
|---|---|
| `-g` / `--global-justfile` | bare |
| `-u` / `--unstable` | bare |
| `-f` / `--justfile` | takes a value |
| `-d` / `--working-directory` | takes a value |
| `--justfile=…` / `--working-directory=…` | inline value |

Those flags are collected into `_just_dump_args` and passed to `just --dump`, so the group list is read from the **same justfile the recipe would actually run from**. Anything else — a flag's value under the cursor, a recipe already typed, an unrecognized flag — returns 1 and delegates to the native completer exactly as before.

## Verification

Exercised the real function with a stubbed `_describe` across eight cursor positions (from the chezmoi repo, which has both a local and a global justfile):

| Input | Result |
|---|---|
| `just <TAB>` | local groups: chezmoi, claude, info, maintain, nvim, plugins, setup, test |
| `just -g <TAB>` | **global groups: claude, git, plugins** ✅ |
| `just --global-justfile <TAB>` | global groups ✅ |
| `just -f ~/.config/just/justfile <TAB>` | global groups ✅ |
| `just -f <TAB>` | → clap (completing the path argument) ✅ |
| `just -g -<TAB>` | → clap (completing a flag) ✅ |
| `just -g plugins-list <TAB>` | → clap (recipe arguments) ✅ |
| `just plugins-list <TAB>` | → clap (recipe arguments) ✅ |

Also confirmed the file autoloads clean under `zsh -f` + `compinit`, and `pre-commit run --files dot_zfunc/_just` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FT48Qpo3D1W34kP9LNx4Qb