### PR TITLE
feat(scripts): add disk reclaim sweep with build-artifact retention

### DIFF
--- a/Library/LaunchAgents/com.lgates.reclaim.plist
+++ b/Library/LaunchAgents/com.lgates.reclaim.plist
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.lgates.reclaim</string>
+
+  <!-- Weekly auto-delete of regenerable build artifacts and package caches.
+       Everything it removes rebuilds on next use. Ollama models are NOT
+       included — see scripts/ollama-idle.sh for why that stays manual. -->
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-lc</string>
+    <string>"$HOME/scripts/reclaim.sh" --days 30 --apply</string>
+  </array>
+
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Weekday</key>
+    <integer>0</integer>
+    <key>Hour</key>
+    <integer>9</integer>
+    <key>Minute</key>
+    <integer>23</integer>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <false/>
+
+  <key>StandardOutPath</key>
+  <string>/Users/lgates/Library/Logs/reclaim.run.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>/Users/lgates/Library/Logs/reclaim.run.log</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/Users/lgates/.local/share/mise/shims:/Users/lgates/.cargo/bin:/Users/lgates/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+  </dict>
+</dict>
+</plist>

--- a/private_dot_config/just/maint.just
+++ b/private_dot_config/just/maint.just
@@ -6,3 +6,30 @@
 # ~/Documents/home-cleanup-2026-07/.
 home-audit:
     bash "$HOME/scripts/home-audit.sh"
+
+# Stale target/ node_modules/ .venv/ (dir mtime older than `days`) are whole-dir
+# removals; still-active Rust targets get `cargo sweep --time days` instead, so
+# recent builds stay warm. Rationale and the structured output format are
+# documented in the script header.
+# Preview reclaimable build artifacts + package caches (never deletes)
+reclaim-dry days="30":
+    bash "$HOME/scripts/reclaim.sh" --days {{ days }}
+
+# Everything this removes is regenerable. Also runs weekly, unattended, via the
+# com.lgates.reclaim launchd agent (Sundays 09:23, log in ~/Library/Logs/
+# reclaim.run.log) — run it by hand when you need the space sooner.
+# Delete stale build artifacts and prune package caches
+reclaim days="30":
+    bash "$HOME/scripts/reclaim.sh" --days {{ days }} --apply
+
+# Uses blob atime, not `ollama list`'s MODIFIED column — that shows when a model
+# was PULLED, which says nothing about whether you ever ran it.
+# Report ollama models by last actual use
+ollama-idle days="45":
+    bash "$HOME/scripts/ollama-idle.sh" --days {{ days }}
+
+# Deliberately NOT part of the weekly job — re-pulling a 25 GB model is slow
+# enough that it stays a deliberate choice.
+# Remove ollama models idle `days`+ (re-pullable)
+ollama-prune days="45":
+    bash "$HOME/scripts/ollama-idle.sh" --days {{ days }} --apply

--- a/scripts/ollama-idle.sh
+++ b/scripts/ollama-idle.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# ollama-idle.sh — report (and optionally prune) ollama models by LAST READ.
+#
+# `ollama list`'s MODIFIED column is the *pull* time, which says nothing about
+# whether you actually use a model — a model pulled yesterday and never run
+# looks fresher than one pulled last year and used daily. This reads the atime
+# of each model's blobs instead, which is the honest "last actually loaded"
+# signal. (Verified: neither / nor /System/Volumes/Data mounts noatime, so APFS
+# tracks access times here.)
+#
+# DRY-RUN BY DEFAULT. Pass --apply to `ollama rm` everything past the threshold.
+# Deliberately NOT wired into the weekly reclaim job — re-pulling a 25 GB model
+# over a home connection is a real cost, so this one stays a human decision.
+#
+# Backs `just -g ollama-idle` / `just -g ollama-prune`.
+set -euo pipefail
+
+days=45
+apply=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --apply) apply=1; shift ;;
+        --days) days="$2"; shift 2 ;;
+        -h|--help) echo "usage: ollama-idle.sh [--apply] [--days N]"; exit 0 ;;
+        *) echo "ollama-idle.sh: unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+command -v ollama >/dev/null 2>&1 || { echo "ollama-idle.sh: ollama not installed" >&2; exit 1; }
+
+idle_file="$(mktemp)"
+trap 'rm -f "$idle_file"' EXIT
+
+MODELS_DIR="${OLLAMA_MODELS:-$HOME/.ollama/models}" \
+IDLE_DAYS="$days" IDLE_FILE="$idle_file" python3 - <<'PY'
+import json, os, pathlib, time
+
+root = pathlib.Path(os.environ["MODELS_DIR"])
+threshold = int(os.environ["IDLE_DAYS"])
+now = time.time()
+rows = []
+
+for mf in (root / "manifests").rglob("*"):
+    if not mf.is_file():
+        continue
+    try:
+        m = json.loads(mf.read_text())
+    except Exception:
+        continue
+    # manifests/<registry>/<namespace...>/<model>/<tag>; drop the registry host.
+    parts = mf.relative_to(root / "manifests").parts
+    ns = "/".join(parts[1:-1])
+    # `library/` is ollama's default namespace and is elided in `ollama rm`.
+    name = f"{ns.removeprefix('library/')}:{parts[-1]}"
+    digests = [layer["digest"] for layer in m.get("layers", [])]
+    if m.get("config", {}).get("digest"):
+        digests.append(m["config"]["digest"])
+    size = atime = 0
+    for d in digests:
+        blob = root / "blobs" / d.replace(":", "-")
+        if blob.exists():
+            st = blob.stat()
+            size += st.st_size
+            atime = max(atime, st.st_atime)
+    if size:
+        rows.append((atime, size, name))
+
+rows.sort()
+print(f"{'LAST READ':<12} {'IDLE':>6} {'SIZE':>8}  MODEL")
+idle_total = idle_names = 0
+with open(os.environ["IDLE_FILE"], "w") as fh:
+    for atime, size, name in rows:
+        age = int((now - atime) // 86400)
+        mark = "  IDLE" if age >= threshold else ""
+        print(f"{time.strftime('%Y-%m-%d', time.localtime(atime))}   {age:>4}d {size/1e9:>7.1f}G  {name}{mark}")
+        if age >= threshold:
+            fh.write(name + "\n")
+            idle_total += size
+            idle_names += 1
+
+print()
+print(f"IDLE_THRESHOLD_DAYS={threshold}")
+print(f"IDLE_MODELS={idle_names}")
+print(f"IDLE_RECLAIMABLE_GB={idle_total/1e9:.1f}")
+PY
+
+if [ "$apply" -eq 1 ]; then
+    echo "=== PRUNING ==="
+    while IFS= read -r model; do
+        [ -n "$model" ] || continue
+        printf '%-32s ' "$model"
+        ollama rm "$model" >/dev/null 2>&1 && echo removed || echo FAILED
+    done < "$idle_file"
+    printf 'STATUS=applied\n'
+    printf 'DISK_AVAIL=%s\n' "$(df -h / | awk 'NR==2{print $4}')"
+else
+    printf 'STATUS=dry-run  (pass --apply to remove the IDLE models)\n'
+fi

--- a/scripts/reclaim.sh
+++ b/scripts/reclaim.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# reclaim.sh — deterministic build-artifact & package-cache reclaim sweep.
+#
+# Two complementary retention mechanisms, split by how stale the artifact is:
+#
+#   STALE  (dir mtime older than --days): remove the whole target/ node_modules/
+#          .venv/ directory. The project hasn't been built in months; keeping a
+#          partial artifact set buys nothing.
+#   ACTIVE (dir mtime within --days):     run `cargo sweep --time <days>` inside,
+#          trimming only the stale artifacts *within* a live target/ so recent
+#          builds stay warm. Rust only — no equivalent exists for node/python.
+#
+# Plus the regenerable package caches (uv, bun, go, brew, pre-commit, docker
+# build cache), all of which rebuild on next use.
+#
+# DRY-RUN BY DEFAULT. Pass --apply to actually delete. Emits the structured
+# `KEY=VALUE` / `RECLAIM …` rollup convention so a caller (or the weekly
+# launchd job) reads a verdict instead of re-deriving the computation.
+#
+# Companion to home-audit.sh; backs `just -g reclaim-dry` / `just -g reclaim`.
+set -euo pipefail
+
+days=30
+apply=0
+root="$HOME/repos"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --apply) apply=1; shift ;;
+        --days) days="$2"; shift 2 ;;
+        --root) root="$2"; shift 2 ;;
+        -h|--help)
+            echo "usage: reclaim.sh [--apply] [--days N] [--root DIR]"
+            exit 0 ;;
+        *) echo "reclaim.sh: unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+test "$(uname -s)" = "Darwin" || { echo "reclaim.sh: not Darwin, refusing" >&2; exit 1; }
+
+now=$(date +%s)
+cutoff=$(( now - days * 86400 ))
+total_kb=0
+cache_kb=0
+stale_list="$(mktemp)"
+active_list="$(mktemp)"
+trap 'rm -f "$stale_list" "$active_list"' EXIT
+
+# ---------------------------------------------------------------- artifacts
+
+echo "=== BUILD ARTIFACTS (root=$root days=$days) ==="
+
+# -prune stops the walk descending INTO a matched dir: a target/ inside
+# node_modules/ is already accounted for by its parent.
+while IFS= read -r dir; do
+    [ -d "$dir" ] || continue
+    mtime=$(stat -f %m "$dir" 2>/dev/null) || continue
+    size_kb=$(du -sxk "$dir" 2>/dev/null | cut -f1) || continue
+    [ "${size_kb:-0}" -lt 10240 ] && continue   # ignore <10 MB, not worth the noise
+    if [ "$mtime" -lt "$cutoff" ]; then
+        printf '%s\t%s\n' "$size_kb" "$dir" >> "$stale_list"
+    elif [ "$(basename "$dir")" = "target" ]; then
+        printf '%s\t%s\n' "$size_kb" "$dir" >> "$active_list"
+    fi
+done < <(find "$root" -maxdepth 5 -type d \
+    \( -name target -o -name node_modules -o -name .venv \) -prune 2>/dev/null)
+
+echo "--- stale (whole-dir removal) ---"
+while IFS=$'\t' read -r size_kb dir; do
+    age_days=$(( (now - $(stat -f %m "$dir")) / 86400 ))
+    printf 'RECLAIM kind=stale size_kb=%s age_days=%s path=%s\n' "$size_kb" "$age_days" "$dir"
+    total_kb=$(( total_kb + size_kb ))
+    [ "$apply" -eq 1 ] && rm -rf "$dir"
+done < <(sort -rn "$stale_list")
+
+echo "--- active rust targets (cargo sweep --time $days) ---"
+if command -v cargo-sweep >/dev/null 2>&1; then
+    while IFS=$'\t' read -r size_kb dir; do
+        crate_root="$(dirname "$dir")"
+        printf 'SWEEP size_kb=%s path=%s\n' "$size_kb" "$crate_root"
+        if [ "$apply" -eq 1 ]; then
+            cargo sweep --time "$days" "$crate_root" 2>&1 | tail -1 || true
+        fi
+    done < <(sort -rn "$active_list")
+else
+    echo "SKIP reason=cargo-sweep-not-installed  (cargo install cargo-sweep)"
+fi
+
+# ------------------------------------------------------------------ caches
+
+echo "=== PACKAGE CACHES ==="
+
+# Each entry: label, path to measure, command to purge.
+purge() {
+    local label="$1" path="$2"; shift 2
+    local size_kb=0
+    [ -e "$path" ] && size_kb=$(du -sxk "$path" 2>/dev/null | cut -f1)
+    printf 'CACHE name=%s size_kb=%s path=%s\n' "$label" "${size_kb:-0}" "$path"
+    cache_kb=$(( cache_kb + ${size_kb:-0} ))
+    if [ "$apply" -eq 1 ]; then
+        if "$@" >/dev/null 2>&1; then
+            printf 'CACHE_RESULT name=%s status=ok\n' "$label"
+        else
+            # uv in particular holds a lock while MCP servers / LSPs run out of
+            # its archive dir; a failure here is expected and non-fatal.
+            printf 'CACHE_RESULT name=%s status=failed\n' "$label"
+        fi
+    fi
+}
+
+command -v uv          >/dev/null 2>&1 && purge uv         "$HOME/.cache/uv"                  uv cache prune
+command -v bun         >/dev/null 2>&1 && purge bun        "$HOME/.bun/install/cache"         bun pm cache rm
+command -v go          >/dev/null 2>&1 && purge go-modcache "$HOME/go/pkg/mod"                go clean -modcache
+command -v brew        >/dev/null 2>&1 && purge homebrew   "$HOME/Library/Caches/Homebrew/downloads" brew cleanup -s
+command -v pre-commit  >/dev/null 2>&1 && purge pre-commit "$HOME/.cache/pre-commit"          pre-commit gc
+command -v docker      >/dev/null 2>&1 && purge docker-build "" docker builder prune -af
+
+echo "=== ROLLUP ==="
+# Two figures, deliberately NOT summed. Artifact removals are whole directories,
+# so that number is exact. The cache figure is the total size on disk — an UPPER
+# BOUND, because `uv cache prune` and `pre-commit gc` evict only unreferenced
+# entries and typically free a small fraction of it.
+printf 'ARTIFACT_RECLAIM_KB=%s\n' "$total_kb"
+printf 'ARTIFACT_RECLAIM_GB=%.1f\n' "$(echo "$total_kb" | awk '{print $1/1048576}')"
+printf 'CACHE_SIZE_KB=%s\n' "$cache_kb"
+printf 'CACHE_SIZE_GB=%.1f  (upper bound; prune/gc evict only unused entries)\n' \
+    "$(echo "$cache_kb" | awk '{print $1/1048576}')"
+printf 'DISK_AVAIL=%s\n' "$(df -h / | awk 'NR==2{print $4}')"
+if [ "$apply" -eq 1 ]; then
+    printf 'STATUS=applied\n'
+else
+    printf 'STATUS=dry-run  (pass --apply to delete)\n'
+fi


### PR DESCRIPTION
## Context

The machine had **5.2 GB free of 926 GB** (APFS container 99.4% used). Reclaiming was a manual hunt every time, and nothing aged out build artifacts — 103 GB sat in seven abandoned Rust `target/` dirs alone, and 185 GB of ollama models had not been read in 47+ days.

Reclaimed this session: **5.2 GB → 325 GB free.**

## What this adds

### `scripts/reclaim.sh`

Splits build artifacts by staleness, which is the part that needed thinking about:

| Artifact state | Action | Why |
|---|---|---|
| dir mtime older than `--days` | remove the whole `target/` / `node_modules/` / `.venv/` | not built in months; a partial artifact set buys nothing |
| within `--days` (Rust only) | `cargo sweep --time <days>` inside it | trims stale artifacts from a *live* target so recent builds stay warm |

Plus regenerable package caches: uv, bun, go modcache, Homebrew downloads, pre-commit, docker build cache.

Dry-run by default; `--apply` deletes. Emits the structured `KEY=VALUE` rollup convention so a caller reads a verdict rather than re-deriving the computation.

### `scripts/ollama-idle.sh`

Ranks models by **blob atime**, not `ollama list`'s MODIFIED column — that reports *pull* time, so a model downloaded once and never run looks fresher than one used daily. Verified atime is meaningful here: neither `/` nor `/System/Volumes/Data` mounts `noatime`.

### `just -g` recipes + weekly launchd agent

`reclaim-dry`, `reclaim`, `ollama-idle`, `ollama-prune` in `maint.just`. `com.lgates.reclaim` runs the sweep unattended Sundays 09:23, logging to `~/Library/Logs/reclaim.run.log`.

## Two deliberate choices

- **The rollup reports artifact and cache figures separately and does not sum them.** Whole-dir removals are exact; `uv cache prune` and `pre-commit gc` evict only *unreferenced* entries, so cache size is an upper bound on what they free. An earlier draft summed them and claimed 67.5 GB reclaimable when most of that was live uv cache.
- **Ollama pruning is excluded from the scheduled job.** Everything the weekly run deletes rebuilds locally in minutes; re-pulling a 25 GB model does not.

## Verification

- `shellcheck` clean on both scripts; `plutil -lint` OK on the plist
- Dry runs exercised against the real disk; `just -g --list` renders all four recipes
- Applied with path-scoped `chezmoi apply`, leaving three pre-existing drifted targets untouched (confirmed via `chezmoi status`)

## Not addressed

`~/.cache/uv` (36 GB) could not be cleared — the lock is held by four live `uv` processes running `pal-mcp-server` and `python-lsp-server` interpreters out of `~/.cache/uv/archive-v0/`. Forcing it would delete files under running processes. The weekly job uses `uv cache prune` and tolerates the failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUeU4LVGqKNPF7wrRFRRpf