### PR TITLE
fix(just): use bare skill names for plugins-bulk slash commands

### DIFF
--- a/private_dot_config/just/plugins.just
+++ b/private_dot_config/just/plugins.just
@@ -167,7 +167,7 @@ plugins-reconcile-keys repo:
 
 # ── Domain-scoped bulk install/check/re-eval across repos ─────────────────────
 # Orchestration layer over the per-repo judgment skills (configure-claude-plugins,
-# health-check --scope=stack, configure:repo). Enumerate a domain scope → fzf
+# health-check --scope=stack, configure-repo). Enumerate a domain scope → fzf
 # --multi checkbox picker → sequential per-repo action → deterministic alias
 # post-pass. AI-free orchestration; per-repo judgment still runs `claude -p`.
 
@@ -294,7 +294,11 @@ plugins-normalize-alias repo:
 plugins-bulk scope action="check":
     #!/usr/bin/env bash
     # actions: check (local jq annotation, read-only) | setup (/configure-claude-plugins
-    # --fix) | reeval (/health:check --scope=stack --fix) | full (/configure:repo --fix).
+    # --fix) | reeval (/health-check --scope=stack --fix) | full (/configure-repo --fix).
+    # Slash commands use the BARE skill name. A `namespace:command` form
+    # (/health:check, /configure:repo) is the deprecated pre-plugin syntax and
+    # resolves to nothing — `claude -p` exits 0 after printing "Unknown command",
+    # so the recipe reports ok and the repo is silently never processed.
     # Sequential (sibling claude subprocesses are rate-limited & per-repo expensive);
     # every claude call gets </dev/null so the picker loop never eats its stdin.
     # NOTE: reeval's fix flow uses per-category AskUserQuestion; under `-p` there is
@@ -320,8 +324,8 @@ plugins-bulk scope action="check":
       case "{{action}}" in
         check)  just -g _plugins-annotate "$repo" ;;
         setup)  CLAUDECODE= claude -p "/configure-claude-plugins --fix" --model {{claude_model}} --permission-mode auto </dev/null || rc=$? ;;
-        reeval) CLAUDECODE= claude -p "/health:check --scope=stack --fix" --model {{claude_model}} --permission-mode auto </dev/null || rc=$? ;;
-        full)   CLAUDECODE= claude -p "/configure:repo --fix" --model {{claude_model}} --permission-mode auto </dev/null || rc=$? ;;
+        reeval) CLAUDECODE= claude -p "/health-check --scope=stack --fix" --model {{claude_model}} --permission-mode auto </dev/null || rc=$? ;;
+        full)   CLAUDECODE= claude -p "/configure-repo --fix" --model {{claude_model}} --permission-mode auto </dev/null || rc=$? ;;
       esac
       if [ "$rc" -eq 0 ]; then echo "{{GREEN}}ok{{NORMAL}}"; ok=$((ok + 1)); else echo "{{YELLOW}}FAILED (rc=$rc){{NORMAL}}"; failed=$((failed + 1)); fi
       case "{{action}}" in

--- a/tests/test-claude-plugin-references.sh
+++ b/tests/test-claude-plugin-references.sh
@@ -56,17 +56,23 @@ log_skip() { echo -e "${YELLOW}● SKIP:${NC} $*"; ((skip_count++)); }
 # ----------------------------------------------------------------------------
 check_alias_consistency() {
     log_test "Marketplace alias references all use '$CANONICAL_ALIAS'"
-    # Match <token>-claude-plugins alias forms. The owner/repo path form
-    # `laurigates/claude-plugins` has a slash before `claude` so never matches
-    # the required `<token>-claude-plugins` shape.
-    # Match `<token>-claude-plugins` in an *alias* position: preceded by `@`,
-    # `-`, backtick, space, etc. — but NOT `/`. That excludes the slash-command
-    # skill name `/configure-claude-plugins` while keeping `@lgates-claude-plugins`,
-    # the cache-key literal, and step-summary echoes. The leading boundary char
-    # is captured by -o and stripped with sed.
+    # Match `<token>-claude-plugins` only where it is genuinely used AS an alias:
+    #   @<alias>        — a plugin pin / install target (`foo@lgates-claude-plugins`)
+    #   "<alias>":      — an extraKnownMarketplaces / enabledPlugins JSON key
+    # Anything else is prose or data, not a reference that can fail to resolve.
+    #
+    # A looser "any boundary char except /" match over-fires on two legitimate
+    # shapes that are NOT aliases, and did so until 2026-08:
+    #   - the skill NAME `configure-claude-plugins` in prose (it merely ends in
+    #     the same suffix; it is a skill, not a marketplace)
+    #   - the legacy-alias allowlists in plugins.just (plugins-normalize-alias
+    #     must *name* the deprecated aliases in order to rewrite them)
+    # Both are quoted-but-not-keys / pipe-separated, so neither shape matches.
+    # Trade-off: a bare unquoted alias mention in prose is no longer flagged.
     local bad
-    bad="$(git grep -hoIE '(^|[^a-z0-9_/])[a-z][a-z0-9_]*-claude-plugins' -- . "${EXCLUDE_PATHSPEC[@]}" 2>/dev/null \
-        | sed -E 's/^[^a-z]//' | sort -u | grep -vxF "$CANONICAL_ALIAS" || true)"
+    bad="$(git grep -hoIE '(@|")[a-z][a-z0-9_-]*-claude-plugins("[[:space:]]*:)?' -- . "${EXCLUDE_PATHSPEC[@]}" 2>/dev/null \
+        | grep -E '^@|":[[:space:]]*$|":$' \
+        | sed -E 's/^[@"]//; s/"[[:space:]]*:?$//' | sort -u | grep -vxF "$CANONICAL_ALIAS" || true)"
     if [[ -z "$bad" ]]; then
         log_pass "No non-canonical marketplace aliases found"
         return


### PR DESCRIPTION
## Problem

`just -g plugins-bulk <scope> reeval` and `... full` invoked slash commands in the deprecated pre-plugin `namespace:command` syntax:

| Recipe action | Invoked | Resolves? |
|---|---|---|
| `reeval` | `/health:check` | ❌ Unknown command |
| `full` | `/configure:repo` | ❌ Unknown command |

`claude -p` prints `Unknown command: /…` and **exits 0**, so the recipe's `rc` check reported `ok` and the repo was silently never processed. Nothing surfaced the failure.

## Fix

Bare skill names, verified to resolve against the installed marketplace inventory (`claude plugin details`):

- `/health:check` → `/health-check`
- `/configure:repo` → `/configure-repo`

`/configure-claude-plugins` (used by `plugins-setup-repo` / `plugins-check-repo` / `plugins-bulk setup`) was already correct and is unchanged.

## Why the existing guard didn't catch it

`tests/test-claude-plugin-references.sh` **did** flag both — it has been red for some time. The red was ignored because its alias check also produced a persistent false positive: it matched any `<token>-claude-plugins` at a non-slash boundary, firing on two legitimate shapes:

- the skill *name* `configure-claude-plugins` in prose (a skill, not a marketplace)
- the legacy-alias allowlists in `plugins-normalize-alias`, which must *name* the deprecated aliases in order to rewrite them

The check now matches only genuine alias positions — `@<alias>` and `"<alias>":` JSON keys. Both real drift shapes were re-verified with injected controls (an `@lgates-claude-plugins` pin and a `"lgates-claude-plugins":` key) — each still fails the suite.

## Verification

- `mise run test:plugin-refs` → **9 passed, 0 failed** (was 6/3)
- Injected-control run → correctly fails on both a bad alias and a bad command
- `just -g --list` parses; `chezmoi apply` of the target is live
- Portfolio sweep of every executable `claude -p "/…"` reference (chezmoi, `~/repos/.routines`, `laurigates/.github`, `ForumViriumHelsinki/.github`, `claude-plugins/.github/workflows`) found no other unresolvable command. Remaining `namespace:command` hits are all in `docs/adrs/` — historical record, already excluded by the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BVuDE2epgT6sb7UXn1phMv