### PR TITLE
docs(rules): read your own tracker before filing or reversing

### DIFF
--- a/exact_dot_claude/rules/read-issue-thread-before-contributing.md
+++ b/exact_dot_claude/rules/read-issue-thread-before-contributing.md
@@ -7,6 +7,10 @@ look like simple feature requests are often where the maintainer has already
 exactly the part that matters: the decided mechanism, the agreed scope, and the
 work someone has already volunteered to do.
 
+**Applies to repos you own too** (§ *Your own tracker*): the deference part is
+about upstream, but the load-bearing part is that a tracker records decisions
+past-you made and no longer remembers.
+
 ## The trap
 
 `WebFetch` (and any "summarize this issue" step) returns a *compressed* view. It
@@ -54,10 +58,34 @@ Specifically extract, before writing any code:
 If you only have a summary and a gap has passed, **re-read the live thread** before
 acting — the discussion may have moved.
 
+## Your own tracker — search before filing, read before reversing
+
+No maintainer to defer to is exactly why this gets skipped. Two failures:
+
+1. **Search before filing** — a well-researched duplicate is still a duplicate,
+   and the better write-up makes it *harder* to spot as one.
+   `gh issue list -R <o>/<r> --state all --search "<kw>" --json number,title,state`
+2. **Read before reversing** — an old issue records not just a problem but a
+   *decision with its reasoning*, including decisions to **defer**. Shipping the
+   deferred option because it is obviously better silently overrides a choice
+   made with context you no longer have.
+
+> Observed 2026-08 (pal-mcp-server), ten minutes apart: filed a detailed issue
+> duplicating a month-old one that had already diagnosed the same broken publish
+> pipeline — then merged a PR doing the very migration that issue **explicitly
+> deferred**. Neither was caught by review; both surfaced only from listing open
+> issues afterwards.
+
+The tell: calling something "the obvious fix" on a subsystem broken long enough
+for someone to have written about it — long-broken means *investigated*. When
+reversing a decision, say so on the PR and issue, quoting the old reasoning, so
+the next reader sees a decision changed rather than forgotten.
+
 ## When it bites
 
 - Any external contribution scoped from an issue, especially a popular repo where
   maintainers discuss design in comments.
+- **Your own repo**, when the tracker is the last place you think to look.
 - Resuming work on an issue days later from a cached summary.
 - Letting an early `WebFetch`/research step stand in for the primary source.
 


### PR DESCRIPTION
## What

Widens `read-issue-thread-before-contributing.md` to cover **your own** repos, not just upstream ones.

## Why

The rule reads as upstream etiquette, so it never fires on a repo you own — which is exactly where the tracker is doing its *other* job: recording decisions past-you made and no longer remembers.

Two failures ten minutes apart in one session (pal-mcp-server, 2026-08):

1. **Duplicate.** Filed a detailed issue for a broken publish pipeline — duplicating one from a month earlier that had already diagnosed the same root cause, listed the fix, and specified the verification. The better write-up made the duplicate *harder* to spot, not easier.
2. **Reversal.** Merged a PR migrating that pipeline to trusted publishing — which the same issue had **explicitly deferred**, with its reasoning stated ("to keep the first publish low-risk and consistent with silverbucket-mcp").

Neither was caught by review. Both surfaced only from listing open issues afterwards and recognising a title.

## The addition

- **Search before filing** — one `gh issue list --search` before writing.
- **Read before reversing** — an old issue records a decision *with reasoning*, including decisions to defer.
- **The tell**: calling something "the obvious fix" on a subsystem broken long enough for someone to have written about it. Long-broken means *investigated* — go find the investigation.
- **Say so when you do reverse one**, quoting the old reasoning, so the next reader sees a decision changed rather than forgotten.

## Size

`+1572` bytes, landing the always-loaded global context at **113,879** of the 114,000 budget.

A first draft was 633 bytes larger and the `claude-context-budget` pre-commit hook **refused the commit** — working exactly as intended, and worth noting since this rule competes for a nearly-full budget. Verified independently after trimming rather than trusting my own arithmetic:

```
$ bash tests/test-claude-context-budget.sh
unconditional_rule_bytes+claude_md=113879 path_scoped_bytes=35327 budget=114000
PASS=4 FAIL=0
```

If the budget needs reclaiming later, this rule is now the 5th-largest unconditional one and its worked-example blocks are the obvious candidates for a skill.

## Note on how this was committed

Authored in a temporary `git worktree` off `origin/main`, not in the shared checkout: local `main` there is **3 commits ahead of origin** (not mine) and several rule files were dirty from a concurrent session, so branching normally would have either bundled those commits into this PR or clobbered someone's in-flight edits. The worktree is removed; the shared checkout is untouched.
