### PR TITLE
docs(rules): a stale issue and a lying test bypass, both from one session

### DIFF
--- a/exact_dot_claude/rules/read-issue-thread-before-contributing.md
+++ b/exact_dot_claude/rules/read-issue-thread-before-contributing.md
@@ -81,10 +81,41 @@ for someone to have written about it — long-broken means *investigated*. When
 reversing a decision, say so on the PR and issue, quoting the old reasoning, so
 the next reader sees a decision changed rather than forgotten.
 
+## An issue's cited evidence expires — re-verify every line before acting on it
+
+Distinct from the sections above, which are about *discussion* you failed to
+read. Here you read everything, and the issue is simply **out of date**: it
+cites `file.ts:230` and asserts what is there, and between filing and today
+some unrelated PR fixed it. A well-written issue makes this worse — precise
+line numbers and quoted snippets read as verified fact, and the better the
+write-up, the less anyone re-checks it.
+
+> Observed 2026-08-13 (thelma #1055). A security issue's central claim was
+> "no `responseSchema` enforcement on the Gemini call — `gemini.ts:230` does
+> not pass it." True when filed on 05-13; false by the time it was worked.
+> #1060 had added it in between. The issue even listed *"`responseSchema`
+> enforcement is deliberately removed (currently absent)"* as a trigger to
+> re-evaluate — so writing the doc from the issue verbatim would have shipped
+> a threat model asserting the absence of the control that was by then its
+> primary defence, and inverted one of its own triggers.
+
+- **Re-read every file:line the issue cites, at HEAD, before writing anything
+  from it.** The issue is a *claim about the code*, and the code is the
+  authority — same instinct as `diagnose-at-the-failure-point.md`.
+- **Date the gap.** `gh issue view <n> --json createdAt` against
+  `git log -S'<symbol>' -- <path>` finds the PR that moved it. An issue older
+  than a few weeks on an active file should be assumed stale until checked.
+- **Report the correction in the PR that acts on it**, so the next reader sees
+  the issue's evidence was superseded rather than silently contradicted.
+- Corollary for *filing*: prefer citing behaviour and symbols over line
+  numbers, which rot fastest.
+
 ## When it bites
 
 - Any external contribution scoped from an issue, especially a popular repo where
   maintainers discuss design in comments.
+- **Acting on an issue filed weeks or months ago against a file that has since
+  changed** — the evidence is stale even though the thread is complete.
 - **Your own repo**, when the tracker is the last place you think to look.
 - Resuming work on an issue days later from a cached summary.
 - Letting an early `WebFetch`/research step stand in for the primary source.

--- a/exact_dot_claude/rules/validate-adversarial-constructions.md
+++ b/exact_dot_claude/rules/validate-adversarial-constructions.md
@@ -57,6 +57,41 @@ to review-by-reading:
 Three independent designers and a four-lens adversarial review all missed the
 first defect; a 60-line NumPy simulation found it in seconds.
 
+## The bypass must reproduce the old behaviour, not merely disable the new
+
+Step 3's "prove the gate has teeth" is normally done by reverting the fix and
+watching the test fail. The trap is that the quickest way to *disable* a guard
+is rarely the same thing as *restoring the pre-fix state* — and when it isn't,
+the run tells you nothing while looking like a clean verification.
+
+The tell is a **test that passes when you expected it to fail**. That reads as
+"weak assertion" and invites deleting the test; the real cause is usually that
+the bypass introduced a *different* failure which the test caught by accident.
+
+> Observed 2026-08 (thelma, funding-analysis). Adding a Zod `safeParse` after
+> `JSON.parse`, the teeth-check short-circuited the throw:
+> `if (false && !validated.success)`. Four of five tests failed as designed —
+> but `safeParse` returns **no `.data` on failure**, so `parsed` became
+> `undefined` and `parsed.dimensions` threw a `TypeError`. The fifth test
+> ("a failed parse is not cached") passed on that TypeError, not on the
+> behaviour it asserts. Re-run against a faithful stand-in —
+> `const validated = { success: true, data: raw }`, which is exactly what the
+> old unvalidated code did — and all five failed. The gate was fine; the
+> bypass was lying.
+
+- **Prefer deleting the new code to neutering it.** `git stash`, or check out
+  the pre-fix file, and run against that. A hand-written bypass is the same
+  retyping hazard as `never-fabricate-test-identifiers.md` § *extract the code,
+  don't retype it*.
+- **When a bypass is unavoidable, name the old behaviour and reproduce it
+  exactly** — including what the removed call returned on the failure path.
+  Short-circuiting a conditional leaves every binding it fed in a state the
+  original code never had.
+- **Read *which* tests fail, never just the count.** The set is the evidence;
+  a total that matches expectation can still be the wrong tests.
+- **A pass during a teeth-check is a finding, not a relief.** Diagnose it
+  before touching the test.
+
 ## Related
 
 - `offload-to-deterministic-substrate.md` — the parent law: the simulation is


### PR DESCRIPTION
Two rule additions, both from one session working thelma [#1055](https://github.com/ForumViriumHelsinki/thelma/issues/1055) — a security issue filed in May and acted on in August.

## `read-issue-thread-before-contributing.md` — an issue's cited evidence expires

The existing sections cover *discussion you failed to read*. This is the opposite case: you read everything, and the issue is simply **out of date**.

#1055's central claim was "no `responseSchema` enforcement on the Gemini call — `gemini.ts:230` does not pass it." True when filed on 05-13, false by the time it was worked: an unrelated PR had added it in between. Writing the threat model from the issue verbatim would have shipped a document asserting the absence of the control that was by then its **primary defence** — and inverted one of the issue's own re-evaluation triggers, which read *"`responseSchema` enforcement is deliberately removed (currently absent)"*.

What makes this dangerous is precisely what makes an issue good: exact line numbers and quoted snippets read as verified fact, so the better the write-up, the less anyone re-checks it.

Adds: re-read every cited `file:line` at HEAD before writing from an issue; date the gap (`gh issue view --json createdAt` against `git log -S`); report the correction in the PR that acts on it; and when *filing*, prefer symbols over line numbers, which rot fastest.

## `validate-adversarial-constructions.md` — the bypass must reproduce the old behaviour

Step 3 of that rule says prove the gate has teeth. In practice that means reverting the fix and watching the test fail — but **the quickest way to disable a guard is rarely the same as restoring the pre-fix state**, and when it isn't, the run looks like a clean verification while telling you nothing.

Observed this session while adding a Zod `safeParse`. The teeth-check short-circuited the throw with `if (false && !validated.success)`. Four of five tests failed as designed — but `safeParse` returns **no `.data` on failure**, so the result binding became `undefined`, a state the original code never had. The fifth test passed on an incidental `TypeError` rather than on the behaviour it asserts. Re-run against a faithful stand-in (`{ success: true, data: raw }` — exactly what the old unvalidated code did) and all five failed.

The tell is **a test passing when you expected it to fail**. That reads as a weak assertion and invites deleting the test; the real cause is usually that the bypass introduced a different failure the test caught by accident.

Adds: prefer deleting the new code (`git stash`, check out the pre-fix file) to neutering it; if a bypass is unavoidable, reproduce what the removed call returned on its failure path; read *which* tests fail, not just the count; and treat a pass during a teeth-check as a finding, not a relief.

---

Both are pure additions (66 lines, no deletions). Note this checkout had unrelated in-flight edits from a concurrent session — only these two files were staged, and `main` was restored afterwards.
