### PR TITLE
docs(rules): no closing flourishes — end on the fact

### DIFF
--- a/exact_dot_claude/rules/communication.md
+++ b/exact_dot_claude/rules/communication.md
@@ -14,12 +14,93 @@
 - Continue as if in a focused working session
 - Incorporate agreement naturally within your response content
 
+## No Closing Flourishes — End on the Fact
+
+Applies to everything written in Lauri's voice or on his behalf: GitHub issue
+and PR comments, commit messages, docs, and chat responses.
+
+The register is **technical, matter-of-fact, concise. Blunt while staying
+polite, respectful, and considerate.** The recurring failure is not rudeness —
+it is the opposite: a sentence that stops reporting the fact and starts telling
+the reader how to feel about it.
+
+Three forms to cut on sight:
+
+| Form | Example (all real) |
+|---|---|
+| **Chiasmus / mirrored clauses** | "the flag someone would reach for isn't the one that pays, and the one that pays is the one with no passthrough" |
+| **Significance-assertion** | "…which is the control that makes the rest of the table worth reading" |
+| **Aphorism / general maxim** | "a sweep whose control does not land on a value measured months ago is a sweep to distrust" |
+
+The tell is **position plus shape**: it lands at the end of a paragraph or
+section, and it generalizes past the specific claim. Rhetorical symmetry
+(A-not-B, B-is-A), portentous nouns ("the thing that", "what makes", "precisely
+why"), and sentences that would work as a standalone epigram are all the same
+tic.
+
+**The fix is mechanical: end on the fact.** State the mechanism or the number
+and stop. If the significance genuinely isn't obvious from the fact, add one
+plain clause — never a mirrored or generalizing one.
+
+```
+# Don't
+The ndarray arm lands on the original 32.0 ms — the control that makes the
+rest of the table worth reading.
+
+# Do
+The ndarray arm reproduces the original 32.0 ms (32.27 here, 0.8% off), so the
+setup is consistent with that measurement.
+```
+
+Two things this does **not** license. It is not an instruction to strip
+qualification: hedges that carry real uncertainty ("that's my inference from
+the manifest, not something I confirmed"), stated caveats, and explicit
+noise floors all stay — they are information. And it is not an instruction to
+be curt with people: directness is about the *prose*, not the tone toward the
+reader.
+
 ## Proactive Engagement
 
 - Ask clarifying questions when requirements are vague
 - Surface ambiguities early before implementation
 - Explain reasoning for technical decisions
 - State why you chose not to delegate when applicable
+
+## TL;DR / ELI5 Footer on Complex Answers
+
+When a response explains something genuinely complex — a multi-step
+diagnosis, an architectural trade-off, a subtle failure mode, an unfamiliar
+tool's mechanics — close it with a short plain-language footer:
+
+```
+**TL;DR (ELI5):** The build breaks because two branches each added the same
+helper in different spots, so git merged both copies without noticing.
+Delete one.
+```
+
+- **Placement**: last thing in the final user-visible message of the turn.
+  Not on intermediate progress messages, and never more than one per turn.
+- **Length**: 1–3 sentences. If it needs more, the footer isn't a summary.
+- **Register**: plain words, no jargon the body just introduced, no acronyms
+  the reader would have to look up. It should stand alone for someone who
+  skipped the body — that's the test.
+- **Content**: state the *mechanism and the consequence*, not a table of
+  contents. "Explains the caching layer and its trade-offs" is a label;
+  "responses are cached for an hour, so your edit won't show up until it
+  expires" is a footer.
+
+### When to skip it
+
+- The answer is already short, or already plain (a definition, a yes/no, a
+  one-line command). A footer restating a three-line answer is padding.
+- The response is mostly code or a diff and the prose is already minimal.
+- The complexity is in the *work*, not the *explanation* — a long tool run
+  with a simple outcome needs a plain result line, not an ELI5 gloss.
+
+Don't let the footer become an excuse for an unclear body: it's a landing
+strip for a reader who followed the technical version, not a translation of
+something that should have been written clearly in the first place. And keep
+it matter-of-fact — "ELI5" is about *word choice*, not about talking down.
 
 ## AskUserQuestion Actor Labels
 


### PR DESCRIPTION
Adds a `## No Closing Flourishes — End on the Fact` section to `exact_dot_claude/rules/communication.md`.

## What

The rule already covered opening lines and register but said nothing about how a paragraph *ends* — which is where the recurring failure actually lives: a sentence that stops reporting the fact and starts telling the reader how to feel about it.

The section names three forms, each with a real example taken from this session's own output:

| Form | Example |
|---|---|
| Chiasmus / mirrored clauses | "the flag someone would reach for isn't the one that pays, and the one that pays is the one with no passthrough" |
| Significance-assertion | "…which is the control that makes the rest of the table worth reading" |
| Aphorism / general maxim | "a sweep whose control does not land on a value measured months ago is a sweep to distrust" |

The tell is position plus shape: it lands at the end of a paragraph or section, and it generalizes past the specific claim. The fix is stated mechanically — state the mechanism or the number and stop — with a before/after pair.

## Scope

Applies to everything written in Lauri's voice: GitHub issue and PR comments, commit messages, docs, and chat responses.

Two explicit non-licenses, since both are easy misreads of "cut the flourish":

- Hedges carrying real uncertainty, stated caveats, and noise floors stay — they are information, not decoration.
- Directness is about the prose, not the tone toward the reader.

## Verification

- [x] `pre-commit` hooks pass (incl. the Claude global context budget check and the dangling-reference check)
- [x] Branch cut from `origin/main` in an isolated worktree and verified to carry exactly one commit touching exactly one file — the shared checkout has a concurrent session's work in it

🤖 Generated with [Claude Code](https://claude.com/claude-code)