### PR TITLE
chore(mise): migrate npm-only CLI tools from ~/package.json

### DIFF
--- a/private_dot_config/mise/config.toml.tmpl
+++ b/private_dot_config/mise/config.toml.tmpl
@@ -132,6 +132,27 @@ chezmoi = "latest"
 usage = "latest"
 uv = "latest"
 "aqua:EmbarkStudios/cargo-deny" = "latest"    # Rust license/bans/sources gate (cargo deny)
+"npm:@gradient-tools/surface" = "0.8.0"       # docs-drift gate (see configure-plugin:configure-surface)
+
+# npm-only CLI tools
+# Migrated out of a hand-maintained ~/package.json (2026-08-14); these ship
+# exclusively on npm, so there is no aqua/pipx backend to prefer. Pinned rather
+# than "latest" because several are agent CLIs where a surprise major bump is
+# disruptive — bump deliberately via `mise upgrade --bump`.
+#
+# Deliberately NOT migrated: @musistudio/claude-code-router (ccr). v3 performs a
+# "global profile takeover" on first run, rewriting ~/.claude/settings.json with
+# an apiKeyHelper + ANTHROPIC_BASE_URL proxy wrapper (and ~/.codex/config.toml
+# with its own provider), which breaks Claude Code. Do not re-add.
+"npm:@dotenvx/dotenvx" = "2.21.0"                # .env encryption/loading
+"npm:@earendil-works/pi-coding-agent" = "0.84.1" # pi
+"npm:@google/gemini-cli" = "0.55.1"              # gemini
+"npm:@mermaid-js/mermaid-cli" = "11.16.0"        # mmdc (see tools-plugin:mermaid-diagrams)
+"npm:@playwright/test" = "1.62.1"                # playwright (browsers need `playwright install`)
+"npm:jsonlint" = "1.6.3"
+"npm:ocx" = "2.0.14"
+"npm:opencode-ai" = "1.17.16"                    # opencode — pinned exact upstream of this migration
+"npm:vitest" = "4.1.10"
 
 # ============================================================================
 # Environment Variables


### PR DESCRIPTION
## What

Migrates the CLI tools that ship exclusively on npm out of a hand-maintained `~/package.json` and into the mise registry in `private_dot_config/mise/config.toml.tmpl`.

Deliberately **excludes** `@musistudio/claude-code-router` (`ccr`) from the migration, with an inline comment explaining why.

## Why

The npm-only tools were the last holdouts declared outside the dotfiles source. Moving them into mise puts them alongside every other managed tool and makes them reproduce from this repo. They are pinned rather than `latest` because several are agent CLIs where a surprise major bump is disruptive — bump deliberately via `mise upgrade --bump`.

The `ccr` exclusion is the substantive part. Pinning it at `3.0.20` installed a version that performs a "global profile takeover" on first run, which on this machine:

- rewrote `~/.claude/settings.json` with an `apiKeyHelper` returning a static `ccr-profile-…` token, plus a wrapper exporting `ANTHROPIC_BASE_URL` / `ANTHROPIC_API_BASE_URL` / `CLAUDE_AGENT_API_BASE_URL` to `http://127.0.0.1:3456` and enabling a remote-sync channel;
- claimed `~/.codex/config.toml` with its own `model_provider` and bearer token;
- left a `global-profile-takeover.json` manifest naming both files as its targets, so the takeover re-applies on any subsequent run.

This broke Claude Code. The comment is in the config so the entry is not re-added from the old `package.json` by a future migration pass.

## Verification

- `mise ls | grep musistudio` → no match; `which -a ccr` → not found (both the mise install and a stale `~/.bun/bin/ccr` symlink removed).
- `chezmoi diff ~/.config/mise/config.toml` before apply showed exactly the comment addition and the one-line removal, nothing else.
- `chezmoi status ~/.claude` clean; `~/.claude/settings.json` has no `apiKeyHelper`, no proxy env keys. The chezmoi source overlay (`exact_dot_claude/modify_settings.json`) was never touched by the takeover.
- Router state removed: `~/.claude-code-router/`, the CCR-authored `~/.codex/` files, and two `settings.json.ccr-*` backups CCR had dropped inside `~/.claude/`.
- `~/.claude.json` shows the custom-API-key prompt was **rejected** (`approved: []`), so the injected token was never accepted.

Unrelated in-flight rule edits in the working tree were deliberately not bundled into this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1P5HDEuvG9XfA8HMEve9E
