### PR TITLE
feat(zsh): complete tags for `git switch`, labelled with the --detach hint

### DIFF
--- a/dot_zfunc/__git_branch_names
+++ b/dot_zfunc/__git_branch_names
@@ -1,0 +1,62 @@
+#autoload
+#
+# Override of the __git_branch_names helper from zsh's own git completion
+# (Completion/Unix/_git, zsh 5.9 — the one macOS ships as /bin/zsh).
+#
+# Why this file exists
+# --------------------
+# `git switch <TAB>` offers branch names only, never tags. That is upstream's
+# deliberate choice, because git itself refuses a tag here:
+#
+#     $ git switch v1.0.0
+#     fatal: a branch is expected, got tag 'v1.0.0'
+#     hint: If you want to detach HEAD at the commit, try again with the
+#           --detach option.
+#
+# The flag is what makes it legal: zsh's `_git-switch` marks `-d/--detach` as
+# excluding positional 1, so with the flag present the argument is parsed as a
+# *start point* (heads + tags + commits) instead of a *branch name*. Hence
+# `git switch --detach v<TAB>` completes tags and bare `git switch v<TAB>` does
+# not.
+#
+# Rather than hide the tags or offer them unlabelled, this override adds them
+# as their own completion group whose description names the missing flag. In
+# fzf-tab that description becomes the group header:
+#
+#     [tag (needs --detach)] [branch name]
+#
+# How the override takes effect
+# -----------------------------
+# zsh's `_git` guards every helper it defines with
+#
+#     (( $+functions[__git_branch_names] )) || __git_branch_names () { ... }
+#
+# so a definition that already exists wins. compinit autoloads every `_*` file
+# in fpath that starts with `#autoload`, which makes $+functions true for this
+# name before `_git` ever runs. ~/.zfunc is on fpath via dot_zshrc.tmpl.
+#
+# Scope
+# -----
+# The tag group is added in exactly one completion context,
+# `*:git-switch:argument-1` — the "which ref am I switching to" position.
+# Every other caller of __git_branch_names (`git switch -c`, `git switch
+# --orphan`, `git branch -d`, …) takes the unmodified upstream path, since
+# offering a tag as a *new branch name* would be nonsense.
+#
+# Body below is upstream's verbatim, plus the one `if` block.
+
+__git_branch_names () {
+  local expl ret=1
+  declare -a branch_names
+
+  branch_names=(${${(f)"$(_call_program branchrefs git for-each-ref --format='"%(refname)"' refs/heads 2>/dev/null)"}#refs/heads/})
+  __git_command_successful $pipestatus || return 1
+
+  if [[ $curcontext == *:git-switch:argument-1 ]]; then
+    __git_switch_detach_tags "$@" && ret=0
+  fi
+
+  __git_describe_commit branch_names branch-names 'branch name' "$@" && ret=0
+
+  return ret
+}

--- a/dot_zfunc/__git_switch_detach_tags
+++ b/dot_zfunc/__git_switch_detach_tags
@@ -1,0 +1,25 @@
+#autoload
+#
+# Tags offered by `git switch <TAB>`, labelled with the flag they require.
+# Called only from the __git_branch_names override in this directory — see the
+# comment block there for the mechanism and the scoping.
+#
+# Mirrors zsh's own __git_tags_of_type (Completion/Unix/_git) for type
+# `commit`: list refs/tags, keep the ones that resolve to a commit (so blob and
+# tree tags, which `git switch --detach` cannot take, stay out). The only
+# departures are the completion tag name (`detach-tags`, so it can be styled
+# and previewed separately from the plain `commit-tags` group that
+# `git switch --detach` / `git checkout` already use) and the description,
+# which carries the hint.
+
+__git_switch_detach_tags () {
+  local expl
+  declare -a tags
+
+  tags=(${${(M)${(f)"$(_call_program commit-tag-refs "git for-each-ref --format='%(*objecttype)%(objecttype) %(refname)' refs/tags 2>/dev/null")"}:#commit(tag|) *}#commit(tag|) refs/tags/})
+  __git_command_successful $pipestatus || return 1
+  (( $#tags )) || return 1
+
+  _wanted detach-tags expl 'tag (needs --detach)' \
+    compadd -M 'r:|/=* r:|=*' "$@" -o numeric -a - tags
+}

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -298,6 +298,14 @@ zstyle ':fzf-tab:complete:git-checkout:*' fzf-preview \
 	"recent commit object name") git show --color=always $word | delta ;;
 	*) git log --color=always $word ;;
 	esac'
+# `git switch <tag>` is a hard error without --detach, so the tags offered in
+# that position live in their own group (see dot_zfunc/__git_branch_names) and
+# the preview repeats the flag as a copyable command line.
+zstyle ':fzf-tab:complete:git-switch:*' fzf-preview \
+	'case "$group" in
+	*detach*) printf "\033[1;33mhint: git switch --detach %s\033[0m\n\n" "$word"; git log --color=always -n 20 $word ;;
+	*) git log --color=always $word ;;
+	esac'
 
 # Enable IP addresses in completions (moved from fzf-tab section for clarity)
 zstyle ':completion:*' use-ip true


### PR DESCRIPTION
## What

`git switch <TAB>` now offers tags in addition to branches, in their own
completion group labelled with the flag they require:

```
[tag (needs --detach)] [branch name]
```

The fzf-tab preview pane for that group leads with `hint: git switch --detach <tag>`
above the tag's log.

## Why

`git switch <TAB>` offered branch names only. That is upstream zsh's deliberate
choice, because git itself refuses a tag in that position:

```
$ git switch v1.0.0
fatal: a branch is expected, got tag 'v1.0.0'
hint: If you want to detach HEAD at the commit, try again with the --detach option.
```

zsh's `_git-switch` marks `-d/--detach` as excluding positional 1, so with the
flag present the argument is parsed as a *start point* (heads + tags + commits)
instead of a *branch name*. That is why `git switch --detach v<TAB>` completed
tags and bare `git switch v<TAB>` did not.

Hiding the tags means the flag is undiscoverable; offering them unlabelled means
completing to a command git rejects. The labelled group does neither — the tags
are reachable and the group name says what is missing.

`git checkout` was never affected; it has offered a `[commit tag]` group all
along, verified against this config.

## How

`dot_zfunc/__git_branch_names` pre-defines the helper that zsh's `_git` would
otherwise define itself. `_git` guards every helper with
`(( $+functions[__git_branch_names] )) || __git_branch_names () { ... }`, and
compinit autoloads `#autoload` files from fpath, so the definition already
exists by the time `_git` runs. `~/.zfunc` is on fpath via `dot_zshrc.tmpl`.

Hooking that one helper avoids vendoring `_git-switch`'s entire `_arguments`
spec, which would have frozen `git switch`'s flag completion at zsh 5.9.

`dot_zfunc/__git_switch_detach_tags` mirrors zsh's `__git_tags_of_type commit`
(so blob and tree tags, which `--detach` cannot take, stay out), changing only
the completion tag name and the description.

## Scope

The tag group is added in exactly one completion context,
`*:git-switch:argument-1`. Verified behaviour, running the real `~/.zshrc` in a
pty with a scratch repo holding branches `main`/`feature-zzz` and tags
`v1.0.0`/`v2.3.4`/`release-alpha`:

| Completion | Result |
|---|---|
| `git switch <TAB>` | `[tag (needs --detach)]` + `[branch name]` |
| `git switch v<TAB>` | `v1.0.0` `v2.3.4` |
| `git switch -c <TAB>` | branches only |
| `git switch --orphan <TAB>` | branches only |
| `git branch -d <TAB>` | branches only |
| `git switch --detach <TAB>` | unchanged upstream path |
| `git checkout v<TAB>` | `v1.0.0` `v2.3.4` (unchanged) |
| `git switch <TAB>` in a repo with no tags | branches only, no empty group |

The last row and the `git switch v<TAB>` row are the control pair: a tagless
repo and a tagged one run through the identical harness, so "no tag group"
is distinguishable from "harness produced nothing".
