### PR TITLE
feat(zsh): order fpath deliberately (brew appended) and pin lookup order with a test

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -118,7 +118,17 @@ jobs:
           # the prompt is set by starship (eval "$(starship init zsh)"), which
           # isn't installed in this job — the assertion would always fail. The
           # meaningful smoke test is that sourcing .zshrc doesn't crash zsh.
-          timeout 10s zsh -c "
+          #
+          # The timeout guards against a HANG (a config change that blocks on
+          # input), not against slowness — it is not a perf budget. Keep it
+          # generous: the old 10s left no margin and turned normal drift into a
+          # red build. Measured cold-runner cost of this step: ~6s on
+          # 2026-07-30, ~9s on 2026-08-18 — i.e. 90% of the old budget before
+          # any given PR adds anything. A change that pushes real startup time
+          # near this limit is a genuine problem worth its own investigation;
+          # note that the benchmarks workflow does NOT cover it, because it
+          # times a minimal /tmp/test.zshrc rather than the applied ~/.zshrc.
+          timeout 60s zsh -c "
             source ~/.zshrc
             if [[ -n \"\$ZSH_VERSION\" ]]; then
               echo \"✅ zsh configuration loaded successfully\"

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -152,10 +152,30 @@ export TMPDIR="$HOME/tmp/"
 # Remove "/" from WORDCHARS so that Ctrl+W doesn't kill directory paths.
 WORDCHARS="${WORDCHARS//[\/]}"
 
-# Load brew and related completions if it is installed
-# Prepend homebrew to path
-# Avoid using brew shellenv for setup, because brew completions are messed up
-# Handle macos and linux paths for homebrew
+# Put homebrew on PATH. Handles the macos and linux homebrew prefixes.
+#
+# Deliberately NOT `eval "$(brew shellenv)"`, and brew's
+# share/zsh/site-functions is deliberately NOT on fpath. shellenv emits
+# `fpath[1,0]="$HOMEBREW_PREFIX/share/zsh/site-functions"` + `export FPATH`,
+# which has two consequences:
+#
+#   1. Position 1 puts brew's completions ahead of BOTH ~/.zfunc and zsh's
+#      own /usr/share/zsh/*/functions. First match in fpath wins, so brew's
+#      build-time snapshots would shadow the freshly generated ~/.zfunc ones,
+#      and brew's `_git` (git's bash-completion wrapper) would shadow zsh's
+#      much richer native `_git`.
+#   2. `export FPATH` leaks that inverted order into every child zsh --
+#      `zsh -f` included, which is supposed to read no config at all.
+#
+# Completions instead come from ~/.zfunc, generated from the tools themselves
+# by run_onchange_02-generate-completions.sh.tmpl. To pick up a completer that
+# only Homebrew ships, add it to .chezmoidata/completions.toml rather than
+# putting the directory on fpath -- the `task` entry there is the pattern.
+#
+# (A 2023-era comment also blamed brew completions for fzf-tab misbehaving on
+# e.g. kubectl. That was a load-order bug, root-caused and fixed in d4fb8c5
+# "fix(zsh): load fzf-tab after compinit"; it is not a reason for any of the
+# above.)
 
 # Cache brew prefix to avoid multiple calls (improves shell startup performance)
 {{ if eq .chezmoi.os "darwin" }}

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -154,10 +154,9 @@ WORDCHARS="${WORDCHARS//[\/]}"
 
 # Put homebrew on PATH. Handles the macos and linux homebrew prefixes.
 #
-# Deliberately NOT `eval "$(brew shellenv)"`, and brew's
-# share/zsh/site-functions is deliberately NOT on fpath. shellenv emits
-# `fpath[1,0]="$HOMEBREW_PREFIX/share/zsh/site-functions"` + `export FPATH`,
-# which has two consequences:
+# Deliberately NOT `eval "$(brew shellenv)"`. Brew's zsh site-functions dir IS
+# on fpath, but appended by hand further down -- never via shellenv, which emits
+# `fpath[1,0]="$HOMEBREW_PREFIX/share/zsh/site-functions"` + `export FPATH`:
 #
 #   1. Position 1 puts brew's completions ahead of BOTH ~/.zfunc and zsh's
 #      own /usr/share/zsh/*/functions. First match in fpath wins, so brew's
@@ -167,10 +166,12 @@ WORDCHARS="${WORDCHARS//[\/]}"
 #   2. `export FPATH` leaks that inverted order into every child zsh --
 #      `zsh -f` included, which is supposed to read no config at all.
 #
-# Completions instead come from ~/.zfunc, generated from the tools themselves
-# by run_onchange_02-generate-completions.sh.tmpl. To pick up a completer that
-# only Homebrew ships, add it to .chezmoidata/completions.toml rather than
-# putting the directory on fpath -- the `task` entry there is the pattern.
+# Appending is the safe half of the same idea: it shadows nothing and still
+# reaches the completers only Homebrew ships. See the fpath block near compinit.
+#
+# shellenv is also avoided for PATH because it prepends brew ahead of mise, and
+# the intended order is mise > brew > system. tests/test-shell-precedence.sh
+# pins both orders.
 #
 # (A 2023-era comment also blamed brew completions for fzf-tab misbehaving on
 # e.g. kubectl. That was a load-order bug, root-caused and fixed in d4fb8c5
@@ -190,6 +191,11 @@ if type /home/linuxbrew/.linuxbrew/bin/brew &> /dev/null; then
 fi
 {{ end }}
 
+# PATH precedence is mise > brew > system. mise activate PREPENDS its installs,
+# so it establishes that order -- which means any later `PATH="x:$PATH"` jumps
+# ahead of mise and silently shadows a managed tool. Add new PATH entries ABOVE
+# this line, or append (`path+=(...)`) instead of prepending.
+# tests/test-shell-precedence.sh fails on a mise-managed command that loses.
 eval "$(mise activate zsh)"
 
 # Set these envs after mise has been initialized since neovim may be installed by mise.
@@ -1333,11 +1339,21 @@ EOF
 #======================================================================
 
 # Android SDK (for Tauri Android development)
+# NOTE: prepends AFTER `mise activate`, so platform-tools outranks mise. Fine
+# today -- mise manages nothing that collides with adb/fastboot -- but if it
+# ever does, this is the line that wins. See the note at `mise activate`.
 export ANDROID_HOME="/opt/homebrew/share/android-commandlinetools"
 export NDK_HOME="$ANDROID_HOME/ndk/26.1.10909125"
 export PATH="$ANDROID_HOME/platform-tools:$PATH"
 
 # bun
+# NOTE: prepends AFTER `mise activate`, so anything in ~/.bun/bin outranks mise.
+# That directory is legacy: it holds bin symlinks into ~/node_modules from the
+# hand-maintained ~/package.json that #360 migrated into mise. Ten of those were
+# left behind by that migration and shadowed their mise-managed replacements;
+# they have been removed, leaving only packages mise does NOT manage. Do not
+# reintroduce a global install here for something mise can manage -- prefer a
+# mise entry, or this line silently wins. See the note at `mise activate`.
 export BUN_INSTALL="$HOME/.bun"
 export PATH="$BUN_INSTALL/bin:$PATH"
 
@@ -1361,14 +1377,41 @@ eval "$(atuin init zsh)"
 # Completion System Initialization
 #======================================================================
 
-# Add custom completion directory to fpath (if not already added above)
-# NOTE: This needs to be before compinit
-[ -d ~/.zfunc ] && fpath+=~/.zfunc
+# fpath order is load-bearing -- first match wins, so this block decides which
+# copy of a duplicated completer is used. Pinned by tests/test-shell-precedence.sh.
+#
+#   1. ~/.zfunc        generated FROM THE BINARY THAT ACTUALLY RUNS, by
+#                      run_onchange_02-generate-completions.sh.tmpl. Must come
+#                      first, or zsh's bundled copies win instead: _npm, _pip
+#                      and _luarocks all exist in both places, and the system
+#                      ones ship with zsh (5.9 = 2022) while the generated ones
+#                      track the mise-installed tool.
+#   2. zsh's own       /usr/share/zsh/*/functions. Deliberately ahead of brew:
+#                      the only two names in both are _git and _luarocks, and
+#                      zsh's native _git is far richer than brew's (which is
+#                      git's bash-completion wrapper). dot_zfunc/__git_branch_names
+#                      hooks zsh's _git and goes inert if brew's wins.
+#   3. brew            last, so it adds the ~30 completers nothing else ships
+#                      (_bat, _delta, _k9s, _yq, _zoxide, ...) without
+#                      displacing anything above it.
+#
+# NOTE: all of this needs to be before compinit.
+[ -d ~/.zfunc ] && fpath=(~/.zfunc $fpath)
+if [ -n "$HOMEBREW_PREFIX" ] && [ -d "$HOMEBREW_PREFIX/share/zsh/site-functions" ]; then
+  fpath+=("$HOMEBREW_PREFIX/share/zsh/site-functions")
+fi
 
 # Load Homebrew path configurations (if available)
 # Path modifications should be done before compinit
 if [ -n "$HOMEBREW_PREFIX" ]; then
     # google-cloud-sdk path (this modifies PATH, so keep it before compinit)
+    #
+    # KNOWN EXCEPTION to mise > brew > system: path.zsh.inc PREPENDS, and it
+    # runs after `mise activate`, so gcloud's bundled bin/ outranks mise. It
+    # ships its own kubectl, so `kubectl` resolves to gcloud's copy rather than
+    # the mise-managed one. tests/test-shell-precedence.sh allowlists exactly
+    # that one command; to fix rather than tolerate it, move this block above
+    # `eval "$(mise activate zsh)"` and drop kubectl from the allowlist.
     [ -f "$HOMEBREW_PREFIX/share/google-cloud-sdk/path.zsh.inc" ] && \
       source "$HOMEBREW_PREFIX/share/google-cloud-sdk/path.zsh.inc" 2>/dev/null
 fi

--- a/private_dot_config/mise/config.toml.tmpl
+++ b/private_dot_config/mise/config.toml.tmpl
@@ -209,7 +209,7 @@ description = "Check what changes would be made (alias for status)"
 # ----------------------------------------------------------------------------
 [tasks.test]
 description = "Run all tests (linting + setup verification + plugin refs + context budget + container testing)"
-depends = ["lint", "test:setup", "test:plugin-refs", "test:context-budget", "docker"]
+depends = ["lint", "test:setup", "test:plugin-refs", "test:context-budget", "test:shell-precedence", "docker"]
 
 [tasks."test:setup"]
 description = "Test initial setup script handles missing commands gracefully (Issue #128)"
@@ -244,6 +244,19 @@ description = "Regression test: always-loaded Claude global context stays within
 run = """
 #!/usr/bin/env bash
 SCRIPT="{{ .chezmoi.sourceDir }}/tests/test-claude-context-budget.sh"
+if [ -x "$SCRIPT" ]; then
+    "$SCRIPT"
+else
+    echo "⚠️  Warning: $SCRIPT not found or not executable"
+    exit 1
+fi
+"""
+
+[tasks."test:shell-precedence"]
+description = "Regression test: interactive-shell lookup order (PATH mise > brew > system; fpath ~/.zfunc > zsh > brew)"
+run = """
+#!/usr/bin/env bash
+SCRIPT="{{ .chezmoi.sourceDir }}/tests/test-shell-precedence.sh"
 if [ -x "$SCRIPT" ]; then
     "$SCRIPT"
 else

--- a/tests/test-shell-precedence.sh
+++ b/tests/test-shell-precedence.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# Regression test for shell lookup order in an interactive zsh.
+#
+# Two invariants, both easy to break by accident and both silent when broken:
+#
+#   PATH:  mise > brew > system
+#          `mise activate` PREPENDS, so it establishes this order. Any later
+#          `PATH="x:$PATH"` in .zshrc jumps ahead of mise and shadows a managed
+#          tool. Nothing errors -- you just silently run a different binary than
+#          the one the dotfiles pin. This has happened twice: gcloud's
+#          path.zsh.inc (ships its own kubectl) and ~/.bun/bin (ten symlinks
+#          left behind by the #360 npm->mise migration).
+#
+#   fpath: ~/.zfunc > zsh's own functions > brew site-functions
+#          First match wins, so this decides which copy of a duplicated
+#          completer loads. ~/.zfunc is generated FROM THE BINARY THAT RUNS, so
+#          it goes first. zsh's own dir is deliberately ahead of brew because
+#          brew's _git is git's bash-completion wrapper, which would displace
+#          zsh's much richer native _git -- and dot_zfunc/__git_branch_names
+#          hooks that native _git, so it goes inert if brew's copy wins.
+#
+# Both are properties of a LIVE SHELL, not of the source tree, so this reads a
+# real `zsh -i`. On a machine without mise or brew (a CI runner) the affected
+# checks SKIP loudly rather than passing vacuously.
+#
+# The suite ends with a self-check that feeds the ordering assertions a
+# deliberately scrambled PATH and fails if they report it clean -- a green run
+# with a broken assertion is worth nothing.
+
+set -uo pipefail
+
+RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[0;33m'; NC=$'\033[0m'
+pass_count=0; fail_count=0; skip_count=0
+
+log_pass() { echo -e "  ${GREEN}✓${NC} $1"; pass_count=$((pass_count + 1)); }
+log_fail() { echo -e "  ${RED}✗${NC} $1"; fail_count=$((fail_count + 1)); }
+log_skip() { echo -e "  ${YELLOW}—${NC} SKIP: $1"; skip_count=$((skip_count + 1)); }
+
+# Commands allowed to lose to a non-mise copy. Each entry needs a reason; an
+# unexplained entry is a bug being hidden rather than an exception being made.
+#   kubectl -- google-cloud-sdk's path.zsh.inc prepends after `mise activate`
+#              and gcloud bundles its own kubectl. To drop this entry, move that
+#              source above `eval "$(mise activate zsh)"` in dot_zshrc.tmpl.
+#   jnv     -- installed via `cargo install`; ~/.cargo/bin is prepended in
+#              zshenv, before mise. Remove the cargo copy to drop this entry.
+SHADOW_ALLOWLIST=(kubectl jnv)
+
+# PATH directories exempt from the tier ordering, for the same reason: each one
+# prepends after `mise activate` and is tolerated rather than fixed. Listed by
+# directory so a NEW out-of-order entry still fails.
+#   google-cloud-sdk/bin      -- path.zsh.inc prepends; see dot_zshrc.tmpl
+#   android-commandlinetools  -- platform-tools prepend; collides with nothing
+TIER_ALLOWLIST_DIRS=(
+    "*/google-cloud-sdk/bin"
+    "*/android-commandlinetools/*"
+)
+
+tier_exempt() {
+    local d="$1" pat
+    for pat in "${TIER_ALLOWLIST_DIRS[@]}"; do
+        # shellcheck disable=SC2053
+        [[ "$d" == $pat ]] && return 0
+    done
+    return 1
+}
+
+if ! command -v zsh >/dev/null 2>&1; then
+    echo "zsh not installed; nothing to check" >&2
+    exit 0
+fi
+
+# One interactive shell, dumped once: re-running `zsh -i` per check is slow and
+# lets the two halves disagree.
+DUMP="$(zsh -i -c 'print -r -- "PATH_BEGIN"; print -l -- $path; print -r -- "FPATH_BEGIN"; print -l -- $fpath' 2>/dev/null)"
+
+if [[ -z "$DUMP" ]]; then
+    echo -e "${RED}✗ could not read PATH/fpath from an interactive zsh${NC}" >&2
+    exit 1
+fi
+
+mapfile -t PATH_ENTRIES < <(printf '%s\n' "$DUMP" | sed -n '/^PATH_BEGIN$/,/^FPATH_BEGIN$/p' | sed '1d;$d')
+mapfile -t FPATH_ENTRIES < <(printf '%s\n' "$DUMP" | sed -n '/^FPATH_BEGIN$/,$p' | sed '1d')
+
+classify() {
+    case "$1" in
+        */.local/share/mise/*|*/mise/shims*) echo MISE ;;
+        /opt/homebrew/*|/usr/local/Cellar/*|/home/linuxbrew/*) echo BREW ;;
+        /usr/bin|/bin|/usr/sbin|/sbin|/usr/local/bin|/usr/local/sbin|/System/*) echo SYSTEM ;;
+        *) echo OTHER ;;
+    esac
+}
+
+# Returns 0 when every MISE entry precedes every BREW entry, and every BREW
+# entry precedes every SYSTEM entry. OTHER/HOME entries are not ranked -- they
+# are caught by the shadowing check instead, which is the symptom that matters.
+check_path_tiers() {
+    local -a entries=("$@")
+    local i=0 last_mise=-1 first_brew=-1 last_brew=-1 first_system=-1 kind
+    for e in "${entries[@]}"; do
+        tier_exempt "$e" && { i=$((i + 1)); continue; }
+        kind="$(classify "$e")"
+        case "$kind" in
+            MISE)   last_mise=$i ;;
+            BREW)   [[ $first_brew -lt 0 ]] && first_brew=$i; last_brew=$i ;;
+            SYSTEM) [[ $first_system -lt 0 ]] && first_system=$i ;;
+        esac
+        i=$((i + 1))
+    done
+    PATH_TIER_DETAIL=""
+    local ok=0
+    if [[ $last_mise -ge 0 && $first_brew -ge 0 && $last_mise -gt $first_brew ]]; then
+        PATH_TIER_DETAIL="a mise entry (idx $last_mise) comes after a brew entry (idx $first_brew)"
+        ok=1
+    fi
+    if [[ $last_brew -ge 0 && $first_system -ge 0 && $last_brew -gt $first_system ]]; then
+        PATH_TIER_DETAIL="${PATH_TIER_DETAIL:+$PATH_TIER_DETAIL; }a brew entry (idx $last_brew) comes after a system entry (idx $first_system)"
+        ok=1
+    fi
+    return $ok
+}
+
+echo "=============================================="
+echo "Shell Lookup-Order Regression Suite"
+echo "=============================================="
+echo "PATH entries:  ${#PATH_ENTRIES[@]}"
+echo "fpath entries: ${#FPATH_ENTRIES[@]}"
+echo ""
+
+# ---------------------------------------------------------------- PATH tiers
+echo "PATH: mise > brew > system"
+have_mise=0; have_brew=0
+for e in "${PATH_ENTRIES[@]}"; do
+    [[ "$(classify "$e")" == MISE ]] && have_mise=1
+    [[ "$(classify "$e")" == BREW ]] && have_brew=1
+done
+
+# Print the exemptions before judging, so a tolerated violation is visible
+# rather than silently subtracted from the result.
+declare -A _exempt_seen=()
+for e in "${PATH_ENTRIES[@]}"; do
+    if tier_exempt "$e" && [[ -z "${_exempt_seen[$e]:-}" ]]; then
+        _exempt_seen[$e]=1
+        echo -e "  ${YELLOW}—${NC} tier-exempt (prepends after mise activate): $e"
+    fi
+done
+
+if [[ $have_mise -eq 0 ]]; then
+    log_skip "no mise entries on PATH (mise not activated here)"
+elif [[ $have_brew -eq 0 ]]; then
+    log_skip "no homebrew entries on PATH (not a brew machine)"
+elif check_path_tiers "${PATH_ENTRIES[@]}"; then
+    log_pass "tier order holds across ${#PATH_ENTRIES[@]} entries"
+else
+    log_fail "tier order violated: $PATH_TIER_DETAIL"
+fi
+
+# ----------------------------------------------------- shadowed mise commands
+echo ""
+echo "PATH: no mise-managed command shadowed by an earlier copy"
+if [[ $have_mise -eq 0 ]]; then
+    log_skip "no mise entries on PATH"
+else
+    declare -A first_owner=() seen_mise=()
+    for d in "${PATH_ENTRIES[@]}"; do
+        [[ -d "$d" ]] || continue
+        kind="$(classify "$d")"
+        while IFS= read -r f; do
+            b="${f##*/}"   # not basename(1): that forks per file, ~60s -> ~2s
+            [[ -n "${first_owner[$b]:-}" ]] || first_owner[$b]="$kind:$d"
+            [[ "$kind" == MISE ]] && seen_mise[$b]=1
+        # -L matters: mise install dirs are symlinks (`.../latest -> ./1.36.2`)
+        # and find will not descend a symlinked starting point without it. The
+        # first version of this test silently missed every such tool.
+        done < <(find -L "$d" -maxdepth 1 -type f -perm -u+x -print 2>/dev/null)
+    done
+
+    shadowed=0
+    for b in "${!seen_mise[@]}"; do
+        owner="${first_owner[$b]}"
+        [[ "${owner%%:*}" == MISE ]] && continue
+        allowed=0
+        for a in "${SHADOW_ALLOWLIST[@]}"; do [[ "$b" == "$a" ]] && allowed=1; done
+        if [[ $allowed -eq 1 ]]; then
+            echo -e "  ${YELLOW}—${NC} allowlisted: $b resolves to ${owner#*:}"
+        else
+            log_fail "$b is mise-managed but resolves to ${owner#*:}"
+            shadowed=$((shadowed + 1))
+        fi
+    done
+    [[ $shadowed -eq 0 ]] && log_pass "${#seen_mise[@]} mise-managed commands, none unexpectedly shadowed"
+fi
+
+# --------------------------------------------------------------- fpath order
+echo ""
+echo "fpath: ~/.zfunc > zsh's own > brew site-functions"
+idx_zfunc=-1; idx_sys=-1; idx_brew=-1; i=0
+for e in "${FPATH_ENTRIES[@]}"; do
+    case "$e" in
+        "$HOME"/.zfunc)                   [[ $idx_zfunc -lt 0 ]] && idx_zfunc=$i ;;
+        /usr/share/zsh/*/functions)       [[ $idx_sys   -lt 0 ]] && idx_sys=$i ;;
+        */share/zsh/site-functions)
+            case "$e" in
+                /opt/homebrew/*|/home/linuxbrew/*) [[ $idx_brew -lt 0 ]] && idx_brew=$i ;;
+            esac ;;
+    esac
+    i=$((i + 1))
+done
+
+if [[ $idx_zfunc -lt 0 ]]; then
+    # shellcheck disable=SC2088  # display string, not a path
+    log_fail "~/.zfunc is not on fpath at all"
+else
+    # shellcheck disable=SC2088  # display string, not a path
+    log_pass "~/.zfunc present (idx $idx_zfunc)"
+fi
+
+if [[ $idx_sys -lt 0 ]]; then
+    log_skip "zsh's own functions dir not found on fpath"
+elif [[ $idx_zfunc -ge 0 && $idx_zfunc -lt $idx_sys ]]; then
+    # shellcheck disable=SC2088  # display string, not a path
+    log_pass "~/.zfunc ($idx_zfunc) precedes zsh's own functions ($idx_sys)"
+else
+    log_fail "zsh's bundled completers ($idx_sys) shadow ~/.zfunc ($idx_zfunc)"
+fi
+
+if [[ $idx_brew -lt 0 ]]; then
+    if [[ -n "${HOMEBREW_PREFIX:-}" && -d "${HOMEBREW_PREFIX}/share/zsh/site-functions" ]]; then
+        log_fail "brew site-functions exists but is not on fpath"
+    else
+        log_skip "no brew site-functions dir on this machine"
+    fi
+elif [[ $idx_sys -ge 0 && $idx_brew -lt $idx_sys ]]; then
+    log_fail "brew site-functions ($idx_brew) precedes zsh's own ($idx_sys); brew's _git would displace zsh's native one"
+else
+    log_pass "brew site-functions last (idx $idx_brew)"
+fi
+
+# ---------------------------------------------- the specific _git landmine
+echo ""
+echo "fpath: nothing shadows zsh's native _git"
+if [[ -e "$HOME/.zfunc/_git" ]]; then
+    # shellcheck disable=SC2088  # display string, not a path
+    log_fail "~/.zfunc/_git exists — it is git's bash-completion wrapper and now outranks zsh's native _git, which dot_zfunc/__git_branch_names hooks"
+else
+    log_pass "no ~/.zfunc/_git"
+fi
+
+# ------------------------------------------------------------- self-check
+# Prove the tier assertion can actually fail. Without this, a refactor that
+# silently neuters check_path_tiers leaves a green suite asserting nothing.
+echo ""
+echo "self-check: assertions fire on known-bad input"
+if check_path_tiers /opt/homebrew/bin "$HOME/.local/share/mise/installs/node/latest/bin" /usr/bin; then
+    log_fail "scrambled PATH (brew before mise) was reported clean — the tier check is broken"
+else
+    log_pass "scrambled PATH correctly rejected ($PATH_TIER_DETAIL)"
+fi
+if check_path_tiers "$HOME/.local/share/mise/installs/node/latest/bin" /opt/homebrew/bin /usr/bin; then
+    log_pass "correctly ordered PATH accepted"
+else
+    log_fail "correctly ordered PATH rejected — the tier check has a false positive"
+fi
+
+echo ""
+echo "=============================================="
+echo -e "${GREEN}Passed:${NC} $pass_count   ${RED}Failed:${NC} $fail_count   ${YELLOW}Skipped:${NC} $skip_count"
+echo "=============================================="
+if [[ $fail_count -eq 0 ]]; then
+    echo -e "${GREEN}✓ Shell lookup order intact${NC}"
+    [[ $skip_count -gt 0 ]] && echo -e "${YELLOW}  (some checks skipped — not a mise/brew machine)${NC}"
+    exit 0
+fi
+echo -e "${RED}✗ Shell lookup-order regressions detected${NC}"
+exit 1


### PR DESCRIPTION
## What

Puts brew's zsh `site-functions` back on `fpath` — **appended**, never via `brew shellenv` — fixes a precedence skew that predates it, finishes the `~/.bun/bin` half of #360, and adds a regression test so none of it can be broken silently again.

Started as a comment recording *why* the directory was off `fpath`. The archaeology showed the omission was collateral rather than a decision, and that the real hazard is the **prepend**, not the directory — so the comment turned into a change.

## Why it was off fpath

`fpath+="$(brew --prefix)/share/zsh/site-functions"` was deleted in `1aae7e5` (2025-03-03), in the same hunk that deleted `eval "$(brew shellenv)"`. The surviving note — *"brew completions are messed up"* — was authored against the commented-out `shellenv` line in the **PATH** block. Nothing ever stated a reason for the `fpath` half; it went out because it lived inside the block being removed.

Re-derived against current brew, which emits `fpath[1,0]=…` plus `export FPATH`. Both halves bite, and both indict the prepend specifically:

- **Position 1** puts brew ahead of `~/.zfunc` *and* `/usr/share/zsh/*/functions`. First match wins, so brew's build-time snapshots would displace 20 of the completers `~/.zfunc` generates fresh, and brew's `_git` would displace zsh's native one.
- **`export FPATH`** propagates that order to child shells: after the eval, a bare `zsh -f` — which reads no config at all — resolves `_git` to the brew copy.

Appending has neither property.

## fpath order

Now `~/.zfunc` → zsh's own → brew, each position load-bearing:

| Position | Reason |
|---|---|
| `~/.zfunc` first | Generated from the binary that actually runs. It was **last**, so zsh's bundled `_npm`, `_pip`, `_luarocks` (5.9 = 2022) were shadowing the generated copies. Completion-side mirror of the PATH rule. |
| zsh's own next | The only names shared with brew are `_git` and `_luarocks`. Brew's `_git` is git's bash-completion wrapper; ahead of zsh's native one it would replace it wholesale and make `dot_zfunc/__git_branch_names` (#361) inert. |
| brew last | Reaches ~30 completers nothing else ships (`_bat`, `_delta`, `_k9s`, `_yq`, `_zoxide`, …) while displacing nothing. |

Verified after apply: `_git` → `/usr/share/zsh/5.9/functions/_git`, `_npm` → `~/.zfunc/_npm`, `_yq`/`_zoxide`/`_bat` → brew.

Also removes the stale unmanaged `~/.zfunc/_git`, a Feb-2025 copy of that same bash wrapper. Harmless while `~/.zfunc` sorted last; promoting the directory would have silently swapped git completion. Backed up first.

## PATH: mise > brew > system

Twelve commands violated it. `mise activate` prepends, so anything prepending *after* it wins:

- **Ten** were bin symlinks in `~/.bun/bin` pointing into `~/node_modules` — leftovers from #360, which moved the declarations into mise but left the old install behind (the same cleanup that PR did by hand for `ccr`). The duplicated deps and the ten now-dangling symlinks are gone; `happy-coder`, which mise does not manage, is untouched. All ten resolve to mise now.
- **Two remain and are allowlisted by name**, with the reason and the fix in the test: `kubectl` (gcloud's `path.zsh.inc` prepends after `mise activate` and bundles its own) and `jnv` (`cargo install`; `~/.cargo/bin` is prepended in zshenv).

## The test

`tests/test-shell-precedence.sh`, wired into `mise run test` as `test:shell-precedence`. It reads a live `zsh -i`, because both invariants are properties of a shell rather than of the source tree, and skips loudly on a machine without mise or brew.

What makes it trustworthy rather than decorative:

- **Verified in both directions.** It passes on this config and fails on the pre-change one — rendered from `origin/main`, not a hand-written bypass — with exactly the two expected failures.
- **Self-check.** It feeds the tier assertion a scrambled PATH and fails if that is reported clean, so the suite cannot go green with a neutered assertion.
- **Exceptions are printed, never silently subtracted.**
- Two bugs found in the test itself while validating it: `find` does not descend a symlinked starting point without `-L`, and mise's install dirs are symlinks (`latest -> ./1.36.2`) — the first version silently missed 20 tools, `kubectl` among them. And `basename(1)` forked per file: 58s → 1.6s with `${f##*/}`.

## Also recorded

A 2023-era comment (`7491c8c`) blamed brew completions for fzf-tab misbehaving on `kubectl`. That was a load-order bug, root-caused and repaired in `d4fb8c5` *"fix(zsh): load fzf-tab after compinit"*. The comment says so, so the next reader does not count an already-repaired bug as part of the rationale.

## Note

Builds on the same file as #361 but is independent of it; #361's completion override was re-verified working under the new fpath order.
