### PR TITLE
fix(zsh): drop the macOS BROWSER export

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -9,9 +9,9 @@ set -o vi
 # set terminal preference for i3
 export TERMINAL=kitty
 
-{{ if eq .chezmoi.os "darwin" }}
-	export BROWSER="open -a Google\ Chrome"
-{{ else if eq .chezmoi.os "linux" }}
+# No BROWSER on macOS: LaunchServices already routes http(s) to Chrome, and
+# tools that spawn $BROWSER as argv[0] (Claude Code) break on a multi-word value.
+{{ if eq .chezmoi.os "linux" }}
 	export BROWSER=google-chrome-stable
 {{ end }}
 


### PR DESCRIPTION
## What

Removes the macOS `BROWSER` export from `dot_zshrc.tmpl`. The Linux branch
(`google-chrome-stable`) is unchanged.

## Why

`BROWSER` was set to the multi-word string `open -a Google\ Chrome`. Consumers
of `$BROWSER` split on two incompatible conventions:

- Python's `webbrowser` runs `shlex.split` → `['open', '-a', 'Google Chrome']`, valid argv.
- Claude Code passes the whole string as **argv[0]** to an execFile-style spawn
  and never invokes a shell:

  ```js
  let r = attacherCaps()?.browser ?? env.BROWSER;
  return UWb(await Gn(r || "open", [url]));   // Gn -> Ro, `shell` never set
  ```

Reproduced with `execFile(process.env.BROWSER, [url])`:

```
argv0 = "open -a Google\\ Chrome"   ENOENT
argv0 = "open"                      exit 1 (usage) — resolves fine   <- control
```

Claude Code maps the ENOENT to `reason:"opener_missing"`, returns `false`, and
silently renders the "copy this URL manually" fallback. Every MCP OAuth flow
required pasting the URL by hand.

## How

macOS needs no `BROWSER` at all — LaunchServices already routes `http`/`https`
to `com.google.chrome`, so Claude Code's `open <url>` fallback lands in the same
browser. A comment records why, so the export does not get re-added.

Ruled out along the way: the XQuartz `DISPLAY` (the no-display guard is
`platform === "linux"`-only) and sandbox restrictions on `open` (the control run
above spawns fine).

If a single-token `BROWSER` is wanted back later, point it at a wrapper script
rather than a command line — that satisfies both the argv[0] consumers and the
`shlex.split` ones.
