### PR TITLE
fix(chezmoi): drop leading slashes from ignore/remove patterns

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -3,10 +3,17 @@
 # e.g. dot_claude/private_CLAUDE.md.
 README.md
 # The repo-root justfile is the dotfiles repo's OWN project justfile (for working
-# in this repo). Without this, chezmoi applies it to ~/justfile, which shadows
-# ~/.user.justfile in `just -g`'s resolution order and breaks it (relative import
-# fails from $HOME). The global justfile is dot_user.justfile.tmpl → ~/.user.justfile.
-/justfile
+# in this repo). Without this, chezmoi applies it to ~/justfile, which `just -g`
+# then loads instead of the real global justfile — and it breaks, because its
+# relative imports don't resolve from $HOME. The global justfile is
+# private_dot_config/just/justfile → ~/.config/just/justfile.
+#
+# Slash-free ON PURPOSE — that IS the root anchor: a bare pattern matches only
+# the source-root copy, leaving ~/.config/just/justfile managed. Do NOT write
+# `/justfile` (leading slash = absolute = "invalid path", a fatal parse error
+# that kills every chezmoi command) nor `**/justfile` (would swallow the global
+# one too). Same for every other bare entry below.
+justfile
 Dockerfile
 docker-compose.yml
 setup/
@@ -16,17 +23,17 @@ images/
 lazy-lock.json
 # Claude Code runtime files are now handled via exact_dot_claude/.chezmoiignore
 CLAUDE.md
-/**/__pycache__/
+**/__pycache__/
 plugins/
 .mcp.json
 # Repo-meta that lives at the source root for working *in this repo* but must not
 # apply to $HOME (same rationale as README.md / Dockerfile / plugins/ above).
 # Root-anchored so only the source-root copy is ignored, never a managed nested
 # target of the same basename.
-/LICENSE
-/DOCKER.md
-/docs/
-/tests/
+LICENSE
+DOCKER.md
+docs/
+tests/
 # ~/tmp is a scratch dir, not dotfiles state — chezmoi shouldn't manage it or the
 # one-off notes previously committed under tmp/.
-/tmp/
+tmp/

--- a/.chezmoiremove
+++ b/.chezmoiremove
@@ -11,4 +11,8 @@
 ~/.claude/hooks/kitty-tab-processing.sh
 ~/.claude/setup_kitty_integration.sh
 ~/.claude/KITTY_INTEGRATION.md
-/tmp/claude_status_hub.log
+# NOTE: a `/tmp/claude_status_hub.log` entry lived here until chezmoi began
+# rejecting it as an invalid path. .chezmoiremove can only name targets under
+# the destination dir ($HOME); an absolute /tmp path is outside it. Do not
+# "fix" it to `tmp/claude_status_hub.log` — that resolves to ~/tmp, a scratch
+# dir chezmoi deliberately ignores, and would delete an unrelated file.

--- a/.claude/rules/chezmoi-conventions.md
+++ b/.claude/rules/chezmoi-conventions.md
@@ -253,14 +253,50 @@ usually broken: a repo justfile's **relative** `import`/`include` paths
 
 The fix is the same as the existing `README.md` / `Dockerfile` /
 `docker-compose.yml` entries already in `.chezmoiignore`: ignore the
-repo-meta file so it stays repo-local. **Root-anchor** the pattern so it
-only catches the source-root copy, not managed nested targets of the same
-basename:
+repo-meta file so it stays repo-local. The pattern must be **root-anchored**
+so it only catches the source-root copy, not managed nested targets of the
+same basename — and the way to write that is a **bare, slash-free** pattern:
 
 ```
 # .chezmoiignore — root-anchored, won't touch ~/.config/just/justfile etc.
-/justfile
+justfile
 ```
+
+### A leading `/` is NOT how you anchor — it's a hard error
+
+The obvious-looking `/justfile` is **invalid**. chezmoi matches patterns
+against the target path *relative* to the destination dir, so a leading
+slash makes the path absolute — outside the destination — and chezmoi
+aborts the whole run on it:
+
+```
+chezmoi: /path/to/source/.chezmoiignore:9: /justfile: invalid path
+```
+
+That error is **fatal and total**: `apply`, `ignored`, `managed` all refuse
+to run, and chezmoi reports only the *first* offending line, so a file with
+several absolute patterns looks like it has one problem. Older chezmoi
+tolerated the form silently; ≥2.72 rejects it. This broke the repo's CI for
+two weeks in 2026-08 — the `Build (Ubuntu)` job died at `chezmoi apply`
+while every other check stayed green, because CI installs chezmoi unpinned
+(`brew install chezmoi`) and a release changed the rule underneath it.
+
+The same applies to `.chezmoiremove`. There, a path genuinely outside `$HOME`
+(e.g. `/tmp/some.log`) is not expressible at all — `.chezmoiremove` can only
+name targets under the destination dir. Delete such an entry rather than
+"fixing" the slash: `tmp/some.log` silently re-points it at `~/tmp/some.log`,
+a different file.
+
+Anchoring semantics, verified against chezmoi v2.72.0:
+
+| Pattern | Matches | Use for |
+|---|---|---|
+| `justfile` | source-root `justfile` **only** — `.config/just/justfile` stays managed | root-anchored ignore ✅ |
+| `/justfile` | nothing — **fatal parse error** | never ❌ |
+| `**/justfile` | *every* `justfile` at any depth, including the managed global one | deliberate recursion only (e.g. `**/__pycache__/`) |
+
+Directory patterns follow the same rule: `docs/` ignores only the root
+`docs/`, leaving `~/.config/nvim/docs/` managed.
 
 Verify it's no longer a target, then remove the already-leaked copy:
 


### PR DESCRIPTION
## What

Unbreaks `Build (Ubuntu)`, which has failed on **`main`** since 2026-08-04 — every commit, not just PRs.

```
chezmoi: /home/runner/work/dotfiles/dotfiles/.chezmoiignore:9: /justfile: invalid path
```

## Why now, when nothing in the repo changed

chezmoi matches patterns against the target path **relative to the destination dir**, so a leading slash makes the path absolute — outside the destination. Newer chezmoi (≥2.72) rejects that; older releases tolerated it silently. CI installs chezmoi unpinned (`brew install chezmoi`), so a release changed the rule underneath us. `/justfile` itself has been in the file since #308 (2026-07-07) and was green for a month.

The failure is worth understanding because it is **fatal and total**: `apply`, `ignored` and `managed` all refuse to run, and chezmoi reports only the **first** offending line — so seven bad patterns presented as one. That is why the job dies at `chezmoi apply` while `Linters`, `Benchmarks`, `SBOM` and the rest stay green, and why it looks like an isolated `justfile` problem rather than a whole-file one.

## The fix, and why bare patterns are correct

A slash-free pattern **is** the root anchor — it was never the leading slash doing that work. Verified against a locally built chezmoi v2.72.0:

| Pattern | Matches | |
|---|---|---|
| `justfile` | source-root `justfile` only — `.config/just/justfile` stays managed | ✅ what we want |
| `/justfile` | nothing — fatal parse error | ❌ |
| `**/justfile` | every `justfile` at any depth, **including the managed global one** | ❌ would break `just -g` |

Directory patterns behave the same: `docs/` ignores only the root `docs/`, leaving `~/.config/nvim/docs/` managed. So all seven edits preserve the existing intent exactly — this is a syntax repair, not a semantics change.

Both invariants re-checked against the real source tree after the change:

- `chezmoi managed` still lists `.config/just/justfile` — the global justfile survives.
- `chezmoi managed` still does **not** list `justfile` — the repo-root copy stays out of `$HOME`.
- `chezmoi apply -v --dry-run --source=. --exclude=scripts` (CI's exact command) exits 0.

## `.chezmoiremove`

The second offender, surfaced only once line 9 stopped aborting the parse:

```
.chezmoiremove:14: /tmp/claude_status_hub.log: invalid path
```

Deleted rather than de-slashed. `.chezmoiremove` can only name targets under `$HOME`, so a genuine `/tmp` path is not expressible at all — and `tmp/claude_status_hub.log` would silently re-point it at `~/tmp`, a scratch dir `.chezmoiignore` deliberately ignores, deleting an unrelated file. Nothing else in the tree references that log; it is dead weight from a 2025-09-30 cleanup. A comment records the reasoning so the entry is not "repaired" back into existence.

## Docs

`.claude/rules/chezmoi-conventions.md` documented `/justfile` as *the* root-anchoring idiom — following the rule as written re-breaks CI. Corrected to the slash-free form, with the anchoring table above and a note that a leading slash is now a hard error.

The `.chezmoiignore` comment block also claimed the global justfile is `dot_user.justfile.tmpl` → `~/.user.justfile`, which the same rule file elsewhere explains is wrong (`~/.user.justfile` is not on `just`'s search path). Corrected to `private_dot_config/just/justfile` → `~/.config/just/justfile` while touching those lines.

## Note

Found while investigating the red check on #362. It is unrelated to that PR's diff — split out here so it unblocks every PR rather than riding inside a zsh change. #362 stays red until this merges.

## Follow-up worth considering (not in this PR)

CI installs chezmoi unpinned, which is what let an upstream release break `main` silently. Pinning it (mise already manages `chezmoi = "latest"`) would turn this class of breakage into a deliberate upgrade.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sa3o7Pia4UZ1zKH5NFRQ24)_