### PR TITLE
chore(zsh): move the bun PATH prepend above `mise activate`

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -191,6 +191,26 @@ if type /home/linuxbrew/.linuxbrew/bin/brew &> /dev/null; then
 fi
 {{ end }}
 
+# bun global installs (`bun install -g`) land in $BUN_INSTALL/bin, and mise does
+# NOT know about them: mise provides the bun BINARY, but where bun links its
+# globals is bun's own business, controlled by BUN_INSTALL.
+#
+#   bun pm bin -g                    -> ~/.bun/bin
+#   env -u BUN_INSTALL bun pm bin -g -> ~/.cache/.bun/bin
+#
+# So this line is what makes a `bun install -g` binary reachable at all -- it is
+# not redundant with mise. It sits ABOVE `mise activate` on purpose: prepending
+# below would put ~/.bun/bin ahead of mise, which is exactly how ten stale
+# symlinks from the #360 npm->mise migration ended up shadowing their
+# replacements. Prefer a mise entry over `bun install -g` for anything mise can
+# manage (see ~/.claude/CLAUDE.md, Tool Installation Priority).
+#
+# ~/.bun also holds `bun link` registrations (install/global/node_modules) --
+# local repo checkouts linked for development. Those are not binaries and never
+# touch PATH, but they are why this directory is not disposable.
+export BUN_INSTALL="$HOME/.bun"
+export PATH="$BUN_INSTALL/bin:$PATH"
+
 # PATH precedence is mise > brew > system. mise activate PREPENDS its installs,
 # so it establishes that order -- which means any later `PATH="x:$PATH"` jumps
 # ahead of mise and silently shadows a managed tool. Add new PATH entries ABOVE
@@ -1353,18 +1373,6 @@ EOF
 export ANDROID_HOME="/opt/homebrew/share/android-commandlinetools"
 export NDK_HOME="$ANDROID_HOME/ndk/26.1.10909125"
 export PATH="$ANDROID_HOME/platform-tools:$PATH"
-
-# bun
-# NOTE: prepends AFTER `mise activate`, so anything in ~/.bun/bin outranks mise.
-# That directory is legacy: it holds bin symlinks into ~/node_modules from the
-# hand-maintained ~/package.json that #360 migrated into mise. Ten of those were
-# left behind by that migration and shadowed their mise-managed replacements;
-# they have been removed, leaving only packages mise does NOT manage. Do not
-# reintroduce a global install here for something mise can manage -- prefer a
-# mise entry, or this line silently wins. See the note at `mise activate`.
-export BUN_INSTALL="$HOME/.bun"
-export PATH="$BUN_INSTALL/bin:$PATH"
-
 
 #======================================================================
 # Tool Initializations (Starship, Zoxide, Atuin, etc.)


### PR DESCRIPTION
## What

Moves the `export PATH="$BUN_INSTALL/bin:$PATH"` line above `eval "$(mise activate zsh)"`, and documents why it exists at all. Comment-heavy; the functional change is two lines relocated.

Pairs with machine-side cleanup that needed no repo change: `~/package.json` and `~/node_modules` (1.8 GB) are gone, as are the two `~/.bun/bin` symlinks for `happy-coder`.

## Why the tree could go

`happy-coder` was the only thing still using it — last run 2026-01-31, three times ever (control: `git switch` returns 62 history hits, so the query discriminates). Everything else checked out clean:

| Checked | Result |
|---|---|
| `NODE_PATH` | unset |
| Hardcoded `~/node_modules` paths in configs | none |
| `yaml-language-server` | Mason ships its own; `yamlls` commented out in the nvim config |
| `axios` / `chalk` / `socket.io-client` | nothing references them |

Space was the smaller half. `~/node_modules` sat on Node's parent-directory resolution path for **every** project under `$HOME`, so an undeclared dependency resolved happily from 787 hoisted packages:

```
~/tmp/probe $ node -e "require.resolve('axios')"
RESOLVED -> /Users/lgates/node_modules/axios/dist/node/axios.cjs
```

A fresh directory, no `package.json`, no local deps. That is a works-here-fails-in-CI generator. It now reports not found, with a nonexistent package as the control so the probe is known to discriminate rather than merely being quiet.

## Why the PATH line moved instead of going away

The obvious follow-up — delete the line, since mise provides bun — is wrong. mise provides the bun **binary**; where bun links its **globals** is bun's own business, controlled by `BUN_INSTALL`:

```
bun pm bin -g                    -> ~/.bun/bin
env -u BUN_INSTALL bun pm bin -g -> ~/.cache/.bun/bin
which bun                        -> ~/.local/share/mise/installs/bun/latest/bin/bun
mise settings get npm.bun        -> false
```

So that line is what makes a `bun install -g` binary reachable at all. Verified end to end rather than argued: installing `cowsay` globally linked into `~/.bun/bin` and resolved from an interactive shell; removed again afterwards. Above `mise activate` it keeps working while mise still wins — `~/.bun/bin` now sits at PATH index 73, after every mise entry.

Incidentally this confirms the earlier diagnosis: the new symlinks point at `../install/global/node_modules/`, the proper bun global layout, whereas the ten stale ones pointed at `../../node_modules` — they were npm-style installs rooted at `$HOME`, never bun globals.

## Why ~/.bun survives

`~/.bun/install/global/node_modules` holds `bun link` registrations pointing at local repo checkouts (`@laurigates/comfy-modal-kit -> ~/repos/laurigates/comfyui-nodes/comfy-modal-kit`). They are not binaries and never touch PATH, which is exactly why an empty `~/.bun/bin` makes the directory look disposable when it isn't. The comment records that.

## Verification

- `tests/test-shell-precedence.sh` green: 8 passed, 0 failed, with `kubectl` and `jnv` still the two allowlisted exceptions.
- `chezmoi diff ~/.zshrc` showed only the relocation; template renders and `zsh -n` parses.
- The `bun link` registration survives; `~/.bun/bin` is empty.

## Note

`~/.bun/install/cache` is a further 3.7 GB. Left alone — it is a cache, it refills on demand, and clearing it is a separate call (`bun pm cache rm`, run from a directory containing a `package.json`).
