### PR TITLE
feat(zsh): complete PR numbers for `gh pr view`/`update-branch`

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -1458,6 +1458,69 @@ _chezmoi_edit_managed() {
 }
 compdef _chezmoi_edit_managed chezmoi
 
+# Custom completion for the PR argument of `gh pr <sub>`.
+# gh registers no completion for the [<number> | <url> | <branch>] positional:
+# `gh __complete pr view ""` returns zero candidates with directive 0
+# (ShellCompDirectiveDefault), which tells the shell to fall back to FILE
+# completion -- so `gh pr view <TAB>` offers the working directory. Supply the
+# open PR numbers here and defer to the cobra-generated _gh everywhere else,
+# the same wrap-and-delegate shape as _chezmoi_edit_managed above.
+#
+# Upstream has had this open as cli/cli#360 since 2020 (labelled `pitch`
+# 2026-03: pitched internally, no `help wanted`), gated on a caching
+# foundation for API-powered completions. Until that lands, this is local.
+#
+# `number:description` is _describe's pair form -- it splits at the FIRST
+# colon, so only the bare number is inserted while branch/title/author stay in
+# the description column and the fzf-tab preview. PR numbers contain no colon,
+# so the split is unambiguous. (The gh* wrapper completions above use a
+# `number[branch] title` form instead and strip the suffix in _gh_pick_arg;
+# that is not available here, since the real gh consumes the word verbatim.)
+
+# Subcommands whose first positional is [<number> | <url> | <branch>].
+typeset -ga _GH_PR_NUM_SUBS=(
+  view diff checkout checks merge comment edit close reopen ready
+  update-branch lock unlock
+)
+
+# gh flags that consume the FOLLOWING word, which is therefore not a
+# positional. `--flag=value` is self-contained and needs no entry.
+typeset -ga _GH_ARG_TAKING_FLAGS=(-R --repo -q --jq -t --template -b --body -F --body-file)
+
+# True only when the cursor sits at the FIRST positional of `gh pr <sub>`, so
+# `gh pr view 123 <TAB>` and `gh pr list <TAB>` fall through untouched.
+_gh_pr_at_number_arg() {
+  local w i skip=0
+  local -a positional
+  for (( i = 2; i < CURRENT; i++ )); do
+    w=$words[i]
+    if (( skip )); then skip=0; continue; fi
+    if (( ${_GH_ARG_TAKING_FLAGS[(Ie)$w]} )); then skip=1; continue; fi
+    [[ $w == -* ]] && continue
+    positional+=($w)
+  done
+  (( ${#positional} == 2 )) || return 1
+  [[ ${positional[1]} == pr ]] || return 1
+  (( ${_GH_PR_NUM_SUBS[(Ie)${positional[2]}]} ))
+}
+
+# Each TAB at that position costs one `gh pr list` (~0.5-1s), matching the
+# uncached gh* wrapper completions below. Outside a GitHub repo gh fails, the
+# candidate list is empty, and completion falls through to _gh.
+_gh_pr_numbers() {
+  if [[ ${words[CURRENT]} != -* ]] && _gh_pr_at_number_arg; then
+    local -a prs
+    prs=("${(@f)$(command gh pr list --limit 100 --json number,title,headRefName,author --jq '.[] | "\(.number):[\(.headRefName)] \(.title) (\(.author.login))"' 2>/dev/null)}")
+    if (( ${#prs} )); then
+      _describe -t prs 'pull request' prs
+      return
+    fi
+  fi
+  _gh "$@"
+}
+
+compdef _gh_pr_numbers gh
+
 # Custom completion for gh PR merge wrappers (ghsq, ghrb)
 # Lists open PRs with fzf-tab preview of PR details
 _gh_pr_merge_complete() {

--- a/private_dot_config/mise/config.toml.tmpl
+++ b/private_dot_config/mise/config.toml.tmpl
@@ -265,6 +265,19 @@ else
 fi
 """
 
+[tasks."test:gh-completion"]
+description = "Regression test: `gh pr <sub> <TAB>` completes PR numbers and still delegates to gh's own completion"
+run = """
+#!/usr/bin/env bash
+SCRIPT="{{ .chezmoi.sourceDir }}/tests/test-gh-completion.sh"
+if [ -x "$SCRIPT" ]; then
+    "$SCRIPT"
+else
+    echo "⚠️  Warning: $SCRIPT not found or not executable"
+    exit 1
+fi
+"""
+
 [tasks.lint]
 description = "Run all linters as used in CI"
 run = """

--- a/tests/test-gh-completion.sh
+++ b/tests/test-gh-completion.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# Regression test for `gh pr <sub> <TAB>` completing PR numbers.
+#
+# What is being protected
+# -----------------------
+# gh registers no completion for the [<number> | <url> | <branch>] positional
+# of `gh pr view` and friends: `gh __complete pr view ""` returns zero
+# candidates with directive 0 (ShellCompDirectiveDefault), which tells the
+# shell to fall back to FILE completion. dot_zshrc.tmpl installs
+# _gh_pr_numbers to fill that gap and delegate everything else to the real
+# _gh. Both halves are silent when broken -- a wrong `words` index makes the
+# hook simply never fire, and you are back to a directory listing without any
+# error to notice.
+#
+# Why the run is shaped this way
+# ------------------------------
+# Completion is a property of a LIVE SHELL, so the end-to-end checks drive a
+# real interactive zsh over a pty (zsh/zpty) and read back what TAB inserted.
+# The CONTROL run does the same thing with the hook NOT loaded and requires
+# the file-completion fallback to appear -- a green run whose control also
+# looked "fixed" would prove nothing about the hook.
+#
+# The candidate set comes from a repo with OPEN PRs, chosen at runtime. A
+# sweep over a repo with zero open PRs is green by construction and asserts
+# nothing, so that case SKIPS loudly instead of passing vacuously.
+
+set -uo pipefail
+
+RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[0;33m'; NC=$'\033[0m'
+pass_count=0; fail_count=0; skip_count=0
+
+log_pass() { echo -e "  ${GREEN}✓${NC} $1"; pass_count=$((pass_count + 1)); }
+log_fail() { echo -e "  ${RED}✗${NC} $1"; fail_count=$((fail_count + 1)); }
+log_skip() { echo -e "  ${YELLOW}—${NC} SKIP: $1"; skip_count=$((skip_count + 1)); }
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# ---------------------------------------------------------------------------
+# Extract the shipped functions from the rendered zshrc.
+#
+# Rendering through `chezmoi cat` rather than reading dot_zshrc.tmpl means the
+# test exercises the text that actually reaches ~/.zshrc. Retyping the logic
+# into the harness would test the copy, not the shipped code.
+# ---------------------------------------------------------------------------
+echo "Extracting completion functions from the rendered ~/.zshrc"
+if ! chezmoi cat ~/.zshrc > "$WORK/zshrc" 2>"$WORK/render.err"; then
+    log_fail "chezmoi cat ~/.zshrc failed: $(head -1 "$WORK/render.err")"
+    echo "1 failure"; exit 1
+fi
+sed -n '/^typeset -ga _GH_PR_NUM_SUBS=(/,/^compdef _gh_pr_numbers gh$/p' \
+    "$WORK/zshrc" > "$WORK/comp.zsh"
+if [ ! -s "$WORK/comp.zsh" ]; then
+    log_fail "could not extract _gh_pr_numbers block from the rendered zshrc"
+    echo "1 failure"; exit 1
+fi
+log_pass "extracted $(grep -c '' "$WORK/comp.zsh") lines of completion code"
+
+# ---------------------------------------------------------------------------
+# Unit: position detection
+#
+# _gh_pr_at_number_arg is pure zsh over $words/$CURRENT, so it can be driven
+# directly without a completion context.
+# ---------------------------------------------------------------------------
+echo
+echo "Position detection (_gh_pr_at_number_arg)"
+cat > "$WORK/unit.zsh" <<'ZSH'
+compdef() { : }          # stub: no completion system in this shell
+source "$1"
+fails=0
+check() {
+  local want=$1 desc=$2 got; shift 2
+  local -a words; words=("$@")
+  local CURRENT=$(( ${#words} + 1 ))
+  words+=('')
+  if _gh_pr_at_number_arg; then got=yes; else got=no; fi
+  if [[ $got == $want ]]; then print "PASS $desc"
+  else print "FAIL want=$want got=$got $desc"; (( fails++ )); fi
+}
+check yes 'gh pr view'                      gh pr view
+check yes 'gh pr update-branch'             gh pr update-branch
+check yes 'gh pr view --web (flag first)'   gh pr view --web
+check yes 'gh -R o/r pr view (-R eats arg)' gh -R o/r pr view
+check yes 'gh pr view --repo=o/r (=form)'   gh pr view --repo=o/r
+check no  'gh pr view 123 (arg supplied)'   gh pr view 123
+check no  'gh pr list (not a number sub)'   gh pr list
+check no  'gh pr (no subcommand yet)'       gh pr
+check no  'gh issue view (not pr)'          gh issue view
+check no  'gh pr create'                    gh pr create
+check no  'gh -R o/r pr list'               gh -R o/r pr list
+exit $(( fails > 0 ))
+ZSH
+while IFS= read -r line; do
+    case "$line" in
+        PASS\ *) log_pass "${line#PASS }" ;;
+        FAIL\ *) log_fail "${line#FAIL }" ;;
+    esac
+done < <(zsh "$WORK/unit.zsh" "$WORK/comp.zsh" 2>&1)
+
+# ---------------------------------------------------------------------------
+# Pick a control repo that actually has open PRs.
+# ---------------------------------------------------------------------------
+echo
+echo "Selecting a control repo with open PRs"
+CONTROL_REPO=""
+CONTROL_PREFIX=""
+if ! command -v gh >/dev/null 2>&1; then
+    log_skip "gh not installed — end-to-end checks need it"
+elif ! gh auth status >/dev/null 2>&1; then
+    log_skip "gh not authenticated — end-to-end checks need API access"
+else
+    for candidate in "$REPO_ROOT" "$HOME"/repos/*/*/; do
+        [ -d "$candidate/.git" ] || continue
+        nums="$(cd "$candidate" && gh pr list --limit 20 --json number \
+                --jq '[.[].number] | join(" ")' 2>/dev/null)" || continue
+        [ -n "$nums" ] || continue
+        # Longest common prefix of the numbers: what TAB inserts when several
+        # candidates share a leading run of digits (zsh completes the prefix).
+        prefix=""
+        first="${nums%% *}"
+        for (( i = 1; i <= ${#first}; i++ )); do
+            cand="${first:0:i}"; ok=1
+            for n in $nums; do case "$n" in "$cand"*) ;; *) ok=0; break;; esac; done
+            if [ "$ok" = 1 ]; then prefix="$cand"; else break; fi
+        done
+        [ -n "$prefix" ] || continue
+        CONTROL_REPO="$candidate"; CONTROL_PREFIX="$prefix"
+        break
+    done
+    if [ -z "$CONTROL_REPO" ]; then
+        log_skip "no reachable repo with open PRs — an empty sweep asserts nothing"
+    else
+        log_pass "control repo $(basename "${CONTROL_REPO%/}") — TAB should insert '$CONTROL_PREFIX'"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# End-to-end over a pty, plus the no-hook control.
+# ---------------------------------------------------------------------------
+run_pty() {  # run_pty <load-hook:0|1> <input-line>  -> prints what the shell showed
+    local load="$1" line="$2"
+    cat > "$WORK/rc.zsh" <<RC
+PS1='%% '
+fpath=(~/.zfunc \$fpath)
+autoload -Uz compinit
+compinit -u -d "$WORK/zcompdump"
+zstyle ':completion:*' menu no
+setopt NO_BEEP
+RC
+    [ "$load" = 1 ] && echo "source '$WORK/comp.zsh'" >> "$WORK/rc.zsh"
+    cat > "$WORK/pty.zsh" <<'ZSH'
+setopt EXTENDED_GLOB
+zmodload zsh/zpty
+cd $3
+zpty -b z zsh -f -i
+zpty -w z "source $1"
+sleep 4
+integer i
+for (( i=0; i<20; i++ )); do zpty -rt z junk 2>/dev/null; sleep 0.1; done
+zpty -w -n z "$2"$'\t'
+local out='' chunk
+for (( i=0; i<40; i++ )); do
+  if zpty -rt z chunk 2>/dev/null; then out+=$chunk; fi
+  sleep 0.25
+done
+zpty -d z 2>/dev/null
+print -r -- "${${out//$'\e'\[[0-9;?]#[a-zA-Z]/}//$'\r'/}"
+ZSH
+    zsh "$WORK/pty.zsh" "$WORK/rc.zsh" "$line" "$CONTROL_REPO" 2>/dev/null
+}
+
+if [ -n "$CONTROL_REPO" ]; then
+    echo
+    echo "End-to-end completion (pty, in $(basename "${CONTROL_REPO%/}"))"
+
+    # CONTROL: without the hook the same TAB must fall back to file completion.
+    # If this stops showing files, the assertions below have lost their meaning.
+    out="$(run_pty 0 'gh pr view ')"
+    if grep -qE '(\.md|\.toml|\.json|\.lock|/)' <<<"$out"; then
+        log_pass "CONTROL: without the hook, TAB falls back to file completion"
+    else
+        log_fail "CONTROL: expected a file listing without the hook; got: $(tr '\n' ' ' <<<"$out" | cut -c1-120)"
+    fi
+
+    for sub in view update-branch; do
+        out="$(run_pty 1 "gh pr $sub ")"
+        if grep -q "gh pr $sub $CONTROL_PREFIX" <<<"$out"; then
+            log_pass "gh pr $sub <TAB> inserts PR number(s) ('$CONTROL_PREFIX')"
+        else
+            log_fail "gh pr $sub <TAB> did not insert '$CONTROL_PREFIX'; got: $(tr '\n' ' ' <<<"$out" | cut -c1-120)"
+        fi
+    done
+
+    # Delegation: the hook must not swallow gh's own subcommand/flag completion.
+    out="$(run_pty 1 'gh pr vie')"
+    if grep -q 'gh pr view' <<<"$out"; then
+        log_pass "gh pr vie<TAB> still completes to 'view' (delegates to _gh)"
+    else
+        log_fail "subcommand completion broke; got: $(tr '\n' ' ' <<<"$out" | cut -c1-120)"
+    fi
+
+    out="$(run_pty 1 'gh pr view --w')"
+    if grep -q 'gh pr view --web' <<<"$out"; then
+        log_pass "gh pr view --w<TAB> still completes to '--web' (delegates to _gh)"
+    else
+        log_fail "flag completion broke; got: $(tr '\n' ' ' <<<"$out" | cut -c1-120)"
+    fi
+fi
+
+echo
+echo "Passed: $pass_count  Failed: $fail_count  Skipped: $skip_count"
+[ "$fail_count" -eq 0 ]


### PR DESCRIPTION
## What

Adds `_gh_pr_numbers`, a zsh completion wrapper that offers open PR numbers at
the first positional of `gh pr view`, `gh pr update-branch`, and the eleven
sibling subcommands that take `[<number> | <url> | <branch>]`. Everything else
— subcommands, flags, other command trees — is handed straight back to gh's
own cobra-generated `_gh`.

Ships with `tests/test-gh-completion.sh`.

## Why

gh registers no completion for that positional:

```
$ gh __complete pr view ""
:0
Completion ended with directive: ShellCompDirectiveDefault
```

Zero candidates with directive `0` tells the shell to fall back to **file**
completion, so `gh pr view <TAB>` currently offers the working directory.

Upstream tracks this as cli/cli#360, open since 2020-02-12 with 42 👍. A
working `ValidArgsFunction` patch for `pr/view` sits in that thread from 2022
and was never turned into a PR; maintainers have twice said the mechanism is
right but that they want a caching foundation for API-powered completions
first. The issue picked up the `pitch` label ("pitched internally for
prioritisation") on 2026-03-10 and lost `help wanted` on 2025-04-10 — so it is
alive, unbuilt, and not soliciting outside patches. Local workaround until it
lands. Related: cli/cli#360, cli/cli#11406.

## How

Same wrap-and-delegate shape as `_chezmoi_edit_managed` directly above it:

- `_gh_pr_at_number_arg` walks `$words`, skipping flags and the values of the
  ones that take an argument (`-R`, `--jq`, …), and fires only when exactly two
  positionals (`pr`, `<sub>`) precede the cursor. `gh pr view 123 <TAB>` and
  `gh pr list <TAB>` fall through.
- Candidates use `_describe`'s `number:description` pair form, which splits at
  the first colon — so only the bare number is inserted while branch, title and
  author stay in the description column and the fzf-tab preview. The `gh*`
  wrapper completions below use a `number[branch] title` form and strip the
  suffix in `_gh_pick_arg`; that is not available here, since the real `gh`
  consumes the word verbatim.

Uncached, matching the existing `gh*` wrapper completions: each TAB at that
position costs one `gh pr list` (~0.5–1 s). Outside a GitHub repo the candidate
list comes back empty and completion falls through to `_gh`.

## Testing

`tests/test-gh-completion.sh` — 18 assertions, all passing:

- 11 unit assertions on position detection, driving `_gh_pr_at_number_arg`
  directly over synthetic `$words`/`$CURRENT` (`gh -R o/r pr view` fires,
  `gh pr view 123` does not, `gh issue view` does not, …).
- 4 end-to-end checks over a real interactive zsh on a pty (`zsh/zpty`),
  reading back what TAB actually inserted: `gh pr view <TAB>` and
  `gh pr update-branch <TAB>` insert the PR numbers; `gh pr vie<TAB>` still
  completes to `view` and `gh pr view --w<TAB>` to `--web`, proving delegation
  survives.
- 1 **control** run with the hook not loaded, which requires the file-completion
  fallback to appear. Without it a green suite would prove nothing about the
  hook.

The completion code under test is extracted from `chezmoi cat ~/.zshrc` rather
than retyped into the harness, so the test exercises the text that reaches
`~/.zshrc`. The control repo is chosen at runtime from repos that actually have
open PRs, and the suite SKIPs loudly rather than passing vacuously when none is
reachable.
