### PR TITLE
ci(renovate): call the org reusable workflow instead of a local copy

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,5 +1,11 @@
 name: Renovate
 
+# Thin caller for the org-wide reusable workflow in laurigates/.github.
+# The local copy this replaced predated that repo; it pinned
+# renovatebot/github-action itself and reimplemented the dry-run/log-level
+# plumbing. Keeping the schedule and the workflow_dispatch inputs here is
+# required — `workflow_call` cannot carry a `schedule` trigger.
+
 on:
   # Run on schedule (every 6 hours)
   schedule:
@@ -23,28 +29,16 @@ on:
           - warn
           - error
 
-# Limit concurrent runs to avoid conflicts
-concurrency:
-  group: renovate
-  cancel-in-progress: false
+# The reusable workflow declares its own concurrency group
+# (renovate-${{ github.repository }}, cancel-in-progress: false), which
+# supersedes the group the local copy declared here.
 
 jobs:
   renovate:
     name: Renovate
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Run Renovate
-        uses: renovatebot/github-action@v41.0.22
-        with:
-          configurationFile: renovate.json5
-          token: ${{ secrets.RENOVATE_TOKEN || secrets.GITHUB_TOKEN }}
-        env:
-          # Set dry run mode if requested
-          RENOVATE_DRY_RUN: ${{ inputs.dry_run == 'true' && 'full' || '' }}
-          # Set log level (default: info)
-          LOG_LEVEL: ${{ inputs.log_level || 'info' }}
-          # Timezone for scheduling
-          TZ: Europe/Helsinki
+    uses: laurigates/.github/.github/workflows/reusable-renovate.yml@main
+    with:
+      config-file: renovate.json5
+      # dry-run takes a string (false | full | lookup), not a boolean
+      dry-run: ${{ inputs.dry_run == true && 'full' || 'false' }}
+      log-level: ${{ inputs.log_level || 'info' }}


### PR DESCRIPTION
## What

Replaces the local `renovate.yml` with a thin caller for
`laurigates/.github/.github/workflows/reusable-renovate.yml@main`. 21 lines out,
15 lines in.

Part of the sweep to stop maintaining local forks of workflows the org repo now
owns — dotfiles predates `laurigates/.github`, which is the only reason these
copies exist.

## Why this one is a clean swap

Every knob the local copy used maps onto a reusable input:

| local | reusable |
|---|---|
| `configurationFile: renovate.json5` | `config-file: renovate.json5` |
| `RENOVATE_DRY_RUN` env | `dry-run` (string: `false` \| `full` \| `lookup`) |
| `LOG_LEVEL` env | `log-level` |
| `token: RENOVATE_TOKEN \|\| GITHUB_TOKEN` | GITHUB_TOKEN by default when `app-id` is unset |
| `concurrency: renovate` | `renovate-${{ github.repository }}`, `cancel-in-progress: false` |

The schedule and `workflow_dispatch` inputs stay in the caller — `workflow_call`
cannot carry a `schedule` trigger.

## Two behaviour notes

**Dropping `TZ: Europe/Helsinki` is a no-op.** `renovate.json5:123` already sets
`"timezone": "Europe/Helsinki"`, and that is the setting `schedule:weekly`
actually reads. The env var was duplicating config that already existed.

**The dry-run toggle was inert, and this fixes it.** `dry_run` is declared
`type: boolean`, and the local copy tested `inputs.dry_run == 'true'`. GitHub
Actions casts both operands to number when the types differ, so the boolean
became `1` and the string became `NaN` — never equal. Selecting "Dry run" in the
Actions UI ran a real Renovate pass that could open PRs. The caller compares
against `true` and passes the string values the reusable workflow expects.

Token behaviour is unchanged: this repo has no `RENOVATE_TOKEN` secret, so the
local copy was already falling through to `GITHUB_TOKEN`.

## Verification

`actionlint .github/workflows/renovate.yml` — clean.

Beyond that this is only really testable by running it: the schedule fires every
6 hours, and `workflow_dispatch` with dry-run now genuinely dry-runs, which is
the safe way to exercise it once merged.

## Not in this PR

The other three drifted workflows turned out not to be like-for-like swaps:

- **`claude.yml`** — 276 lines with six toolchain setup actions (node, bun, go,
  python, uv, homebrew) for the MCP servers in `.mcp.json`, plus plugin
  marketplace installation. `reusable-claude.yml` is checkout → action → failure
  handling and defaults to `ubuntu-slim`, which has no Go or Homebrew at all. A
  reusable workflow cannot accept caller-supplied steps, so this one cannot
  migrate without either an upstream input or moving the toolchain into a
  composite action.
- **`claude-code-review.yml`** and **`auto-fix-ci-failures.yml`** — both depend
  on `.github/scripts/generate-allowed-tools.sh` output, which a caller can only
  supply through a separate gate job feeding `needs.*.outputs` into `claude_args`.
  Migratable, but it is an adapter rather than a swap.
