### PR TITLE
ci(claude): call org reusable workflows for PR review and CI auto-fix

### DIFF
--- a/.github/workflows/auto-fix-ci-failures.yml
+++ b/.github/workflows/auto-fix-ci-failures.yml
@@ -1,253 +1,47 @@
 name: Auto Fix CI Failures
 
+# Thin caller for the org-wide reusable workflow in laurigates/.github.
+# The local copy this replaced predated that repo and reimplemented, less
+# thoroughly, what reusable-auto-fix.yml provides: it had a branch-name loop
+# guard but no flood guard and no already-attempted detection, and it drove the
+# branch/push/PR-create steps itself.
+
 on:
   workflow_run:
     workflows: ["Smoke Test CI"]
     types:
       - completed
 
-permissions:
-  contents: write
-  pull-requests: write
-  actions: read
-  id-token: write # Required for Claude Code Action OIDC authentication
-  # issues: write removed - not used in workflow
-
-concurrency:
-  # ✅ FIXED: Use workflow_run.id instead of unsafe array access
-  group: auto-fix-${{ github.event.workflow_run.id }}
-  cancel-in-progress: false
+# Concurrency is declared by the reusable workflow. The loop guard that used to
+# live in this file's `if:` (skip branches named claude-auto-fix-ci-*) is
+# superseded by the reusable workflow's own flood guard (max_auto_fix_prs) and
+# its "skip if already attempted" step.
 
 jobs:
   auto-fix:
-    # ✅ FIXED: Added timeout to prevent runaway jobs
-    timeout-minutes: 15
-    if: |
+    if: >
       github.event.workflow_run.conclusion == 'failure' &&
-      github.event.workflow_run.pull_requests[0] &&
-      !startsWith(github.event.workflow_run.head_branch, 'claude-auto-fix-ci-')
-    runs-on: ubuntu-latest
-
-    env:
-      BOT_NAME: "claude[bot]"
-      BOT_EMAIL: "claude[bot]@users.noreply.github.com"
-      MAX_LOG_SIZE: "10000"
-
-    steps:
-      # ✅ FIXED: Extract PR metadata with safety checks
-      - name: Extract PR metadata
-        id: pr_meta
-        run: |
-          # Safely extract PR number with fallback
-          PR_NUM="${{ github.event.workflow_run.pull_requests[0].number }}"
-          if [ -z "$PR_NUM" ]; then
-            echo "ERROR: No PR number found in workflow_run event"
-            exit 1
-          fi
-          echo "pr_number=$PR_NUM" >> "$GITHUB_OUTPUT"
-          echo "base_branch=${{ github.event.workflow_run.head_branch }}" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_branch }}
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Setup git identity
-        run: |
-          git config --global user.email "${{ env.BOT_EMAIL }}"
-          git config --global user.name "${{ env.BOT_NAME }}"
-
-      - name: Create fix branch
-        id: branch
-        run: |
-          # Sanitize branch name to handle slashes
-          SANITIZED_BRANCH="${{ github.event.workflow_run.head_branch }}"
-          SANITIZED_BRANCH="${SANITIZED_BRANCH//\//-}"
-          BRANCH_NAME="claude-auto-fix-ci-${SANITIZED_BRANCH}-${{ github.run_id }}"
-          git checkout -b "$BRANCH_NAME"
-          echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
-
-      - name: Get CI failure details
-        id: failure_details
-        continue-on-error: true
-        uses: actions/github-script@v7
-        with:
-          script: |
-            // ✅ FIXED: Proper log download with redirect following and sanitization
-            const MAX_LOG_SIZE = parseInt(process.env.MAX_LOG_SIZE || '10000');
-
-            // Sanitize logs: remove ANSI codes, control chars, and limit size
-            function sanitizeLogs(logs, maxSize = MAX_LOG_SIZE) {
-              if (!logs || typeof logs !== 'string') return '';
-
-              return logs
-                .replace(/\x1b\[[0-9;]*m/g, '') // Strip ANSI escape codes
-                .replace(/[\x00-\x08\x0B-\x0C\x0E-\x1F\x7F]/g, '') // Remove control chars
-                .slice(-maxSize) // Keep only last N chars (most recent errors)
-                .trim();
-            }
-
-            const run = await github.rest.actions.getWorkflowRun({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: ${{ github.event.workflow_run.id }}
-            });
-
-            const jobs = await github.rest.actions.listJobsForWorkflowRun({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: ${{ github.event.workflow_run.id }}
-            });
-
-            const failedJobs = jobs.data.jobs.filter(job => job.conclusion === 'failure');
-
-            // ✅ FIXED: Handle empty failed jobs array
-            if (failedJobs.length === 0) {
-              console.log('No failed jobs found - workflow may have timed out');
-              return {
-                runUrl: run.data.html_url,
-                failedJobs: ['Workflow failed with no specific job failures'],
-                errorLogs: [{
-                  jobName: 'Workflow Timeout',
-                  logs: 'The workflow failed but no individual jobs were marked as failed. This typically indicates a workflow-level timeout or cancellation.'
-                }]
-              };
-            }
-
-            let errorLogs = [];
-            for (const job of failedJobs) {
-              try {
-                // ✅ FIXED: Follow redirect to get actual log content
-                const logResponse = await github.rest.actions.downloadJobLogsForWorkflowRun({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  job_id: job.id
-                });
-
-                // The API returns a redirect URL - fetch the actual content
-                const logsText = await fetch(logResponse.url).then(r => r.text());
-
-                // ✅ FIXED: Sanitize and truncate logs
-                const sanitizedLogs = sanitizeLogs(logsText);
-
-                errorLogs.push({
-                  jobName: job.name,
-                  logs: sanitizedLogs || 'No log content available'
-                });
-              } catch (error) {
-                console.log(`Failed to download logs for job ${job.name}: ${error.message}`);
-                errorLogs.push({
-                  jobName: job.name,
-                  logs: `Error downloading logs: ${error.message}`
-                });
-              }
-            }
-
-            return {
-              runUrl: run.data.html_url,
-              failedJobs: failedJobs.map(j => j.name),
-              errorLogs: errorLogs
-            };
-
-      - name: Fix CI failures with Claude
-        id: claude
-        if: steps.failure_details.outcome == 'success'
-        uses: anthropics/claude-code-action@v1
-        with:
-          prompt: |
-            You are analyzing a CI failure in a dotfiles repository managed with chezmoi.
-
-            **Context:**
-            - Failed workflow: ${{ fromJSON(steps.failure_details.outputs.result).runUrl }}
-            - Failed jobs: ${{ join(fromJSON(steps.failure_details.outputs.result).failedJobs, ', ') }}
-            - Original PR: #${{ steps.pr_meta.outputs.pr_number }}
-            - Base branch: ${{ steps.pr_meta.outputs.base_branch }}
-            - Repository: ${{ github.repository }}
-
-            **Error Logs:**
-            ${{ toJSON(fromJSON(steps.failure_details.outputs.result).errorLogs) }}
-
-            **Your Task:**
-            1. Analyze the error logs to identify root causes
-            2. Fix ONLY the issues causing CI failures
-            3. Follow the project's code style and conventions (see CLAUDE.md)
-            4. Do NOT make unrelated changes
-            5. If the failure is NOT fixable via code changes (e.g., infrastructure issue), explain why in your output
-
-            **Constraints:**
-            - You can modify code files, configs, and tests
-            - You CANNOT modify GitHub Actions workflows
-            - You CANNOT modify CHANGELOG.md (managed by release-please)
-            - Use chezmoi conventions (private_ prefix for private files)
-
-            **Verification:**
-            After making changes, explain what you fixed and why.
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: |
-            --model ${{ vars.CLAUDE_MODEL || 'claude-opus-4-8' }}
-            --allowed-tools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(bun:*),Bash(npm:*),Bash(npx:*),Bash(gh:*)"
-
-      - name: Push fix branch
-        if: steps.claude.outcome == 'success' && steps.claude.outputs.changed == 'true'
-        run: |
-          git push -u origin ${{ steps.branch.outputs.branch_name }}
-
-      - name: Create PR
-        if: steps.claude.outcome == 'success' && steps.claude.outputs.changed == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr create \
-            --base ${{ steps.pr_meta.outputs.base_branch }} \
-            --head ${{ steps.branch.outputs.branch_name }} \
-            --title "🤖 Auto-fix CI failures for PR #${{ steps.pr_meta.outputs.pr_number }}" \
-            --body "Automated fixes for CI failures detected in ${{ fromJSON(steps.failure_details.outputs.result).runUrl }}
-
-            ## Summary
-            This PR was automatically created by the CI auto-fix workflow using Claude Code.
-
-            **Original PR:** #${{ steps.pr_meta.outputs.pr_number }}
-            **Failed workflow:** ${{ fromJSON(steps.failure_details.outputs.result).runUrl }}
-            **Failed jobs:** ${{ join(fromJSON(steps.failure_details.outputs.result).failedJobs, ', ') }}
-
-            ## Review Checklist
-            - [ ] Verify fixes address the root cause
-            - [ ] Check for unintended side effects
-            - [ ] Ensure coding standards are followed
-            - [ ] Validate tests pass locally
-
-            Please review carefully before merging."
-
-      # ✅ ADDED: Comment on original PR if no fixes made
-      - name: Comment on original PR if no fixes made
-        if: steps.claude.outcome == 'success' && steps.claude.outputs.changed != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr comment ${{ steps.pr_meta.outputs.pr_number }} \
-            --body "🤖 Claude analyzed the CI failures but determined no code changes are needed.
-
-            **Failed workflow:** ${{ fromJSON(steps.failure_details.outputs.result).runUrl }}
-
-            This may indicate:
-            - Flaky tests
-            - Infrastructure issues
-            - Transient failures
-            - Configuration problems outside the codebase
-
-            Please review the failure logs manually."
-
-      # ✅ ADDED: Notify on workflow failure
-      - name: Report auto-fix failure
-        if: failure()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr comment ${{ steps.pr_meta.outputs.pr_number }} \
-            --body "⚠️ Automated CI fix workflow encountered an error.
-
-            **Failed workflow:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-            Manual intervention may be required. Please review the auto-fix workflow logs."
+      github.event.workflow_run.pull_requests[0]
+    uses: laurigates/.github/.github/workflows/reusable-auto-fix.yml@main
+    with:
+      branch: ${{ github.event.workflow_run.head_branch }}
+      run_id: "${{ github.event.workflow_run.id }}"
+      workflow_name: ${{ github.event.workflow_run.name }}
+      head_sha: ${{ github.event.workflow_run.head_sha }}
+      claude_args: --model ${{ vars.CLAUDE_MODEL || 'opus' }} --max-turns 50
+      # Repo-specific grants on top of the reusable workflow's built-in set
+      # (Write/Edit/Grep/Glob/Task/TodoWrite, the git verbs, gh pr/issue/run).
+      # A dotfiles CI failure is almost always a lint failure, and fixing one
+      # means re-running the linter to confirm — hence the linters, and chezmoi
+      # for source-tree validation.
+      additional_permissions: |
+        Bash(pre-commit *)
+        Bash(actionlint *)
+        Bash(shellcheck *)
+        Bash(luacheck *)
+        Bash(gitleaks *)
+        Bash(chezmoi diff *)
+        Bash(chezmoi status *)
+        Bash(mise run lint*)
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,68 +1,35 @@
 name: Claude Code Review
 
+# Thin caller for the org-wide reusable workflow in laurigates/.github.
+# The local copy this replaced predated that repo. It also carried a step that
+# generated an --allowedTools list from .github/claude-tools-config.json
+# (preset: pr_review); that is dropped deliberately — see below.
+
 on:
   pull_request:
     types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
-# Prevent duplicate review runs for the same PR
-concurrency:
-  group: claude-review-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+# Concurrency is declared by the reusable workflow
+# (claude-review-${{ github.event.pull_request.number }}-${{ github.repository }},
+# cancel-in-progress: true), matching what the local copy declared here.
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    uses: laurigates/.github/.github/workflows/reusable-claude-review.yml@main
+    with:
+      claude_args: --model ${{ vars.CLAUDE_MODEL || 'opus' }} --max-turns 50
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-      id-token: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Generate allowed tools for PR review
-        id: tools-config
-        run: |
-          chmod +x .github/scripts/generate-allowed-tools.sh
-          ALLOWED_TOOLS=$(.github/scripts/generate-allowed-tools.sh .github/claude-tools-config.json pr_review)
-          echo "allowed_tools=$ALLOWED_TOOLS" >> "$GITHUB_OUTPUT"
-
-      - name: Run Claude Code Review
-        id: claude-review
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-
-          # Prompt for PR review
-          prompt: |
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
-
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
-
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
-
-          # Claude Code configuration via CLI arguments
-          claude_args: |
-            --model ${{ vars.CLAUDE_MODEL || 'claude-opus-4-8' }}
-            --allowedTools "${{ steps.tools-config.outputs.allowed_tools }}"
+# Why no --allowedTools here
+# -------------------------
+# claude-code-action's configuration docs state: "The base GitHub tools are
+# always included. Use --allowedTools to add additional tools." The flag is
+# ADDITIVE, so the pr_review preset was a grant list, not a sandbox — it added
+# Read/Glob/Grep and a handful of `gh` Bash commands on top of the base set.
+#
+# The reusable workflow's prompt tells Claude to use the built-in Read/Grep/Glob
+# for exploration and not to shell out for it, and it posts the review through
+# the action's own mechanism rather than `Bash(gh pr comment)`. Nothing the
+# preset granted is still needed, so the generation step goes away rather than
+# being reproduced as a literal.


### PR DESCRIPTION
## What

`claude-code-review.yml` and `auto-fix-ci-failures.yml` become thin callers for
their `laurigates/.github` counterparts. **299 lines out, 60 in.**

## claude-code-review.yml — preset dropped, not reproduced

The local copy generated `--allowedTools` from
`.github/claude-tools-config.json` (preset `pr_review`). That step is gone
rather than replaced, because the preset was never doing what its name suggests.

From claude-code-action's configuration docs:

> **Note**: The base GitHub tools are always included. Use `--allowedTools` to
> add additional tools (including specific Bash commands), and
> `--disallowedTools` to prevent specific tools from being used.

The flag is **additive**. `pr_review` was a grant list, not a sandbox — it added
`Read`/`Glob`/`Grep` and a few `gh` Bash commands on top of a base set that is
always present. The reusable workflow's prompt directs Claude to the built-in
`Read`/`Grep`/`Glob` (*"Do NOT use Bash for find/grep operations"*) and posts the
review through the action's own mechanism rather than `Bash(gh pr comment)`, so
nothing the preset granted is still load-bearing.

## auto-fix-ci-failures.yml — short literal instead

`reusable-auto-fix.yml` already grants `Write`, `Edit`, `Grep`, `Glob`, `Task`,
`TodoWrite`, the git verbs and `gh pr/issue/run`, then appends
`additional_permissions`. What this repo needs on top is the linters and
chezmoi — a dotfiles CI failure is almost always a lint failure, and fixing one
means re-running the linter to confirm. That's eight lines in the caller instead
of a script plus a JSON config.

It also picks up guards the local copy never had: a flood guard on open auto-fix
PRs (`max_auto_fix_prs`, default 2) and an already-attempted check. Those
supersede the local `claude-auto-fix-ci-*` branch-name loop guard, which is why
that condition is gone from the `if:`.

## Verification

There is no dry run for a `workflow_run`-triggered caller, and `actionlint`
validates syntax but not a *remote* workflow's interface — so the contract was
checked mechanically instead of by eye. A script parses each reusable workflow's
declared `workflow_call` inputs/secrets and asserts the caller supplies every
required one and no unknown ones:

```
claude-code-review.yml   -> reusable-claude-review.yml   ok
auto-fix-ci-failures.yml -> reusable-auto-fix.yml        ok
renovate.yml             -> reusable-renovate.yml        ok   (re-checks #369)
control: bogus input     -> FAIL unknown inputs: not-a-real-input
```

The control matters: without it a green result proves nothing about the check.
`actionlint` is clean on both files.

## Not in this PR

`.github/scripts/generate-allowed-tools.sh` and `.github/claude-tools-config.json`
survive — `claude.yml` (`full_access`) and `claude-config-validation.yml`
(`config_validation`) still consume them. They go when those two are dealt with.

## Worth a look while you're here

`vars.CLAUDE_MODEL` is `claude-opus-4-8`, set 2026-06-29, and both callers still
honour it (`${{ vars.CLAUDE_MODEL || 'opus' }}`) to preserve current behaviour.
If that model ID has since been retired, the action will fail on it — the org
workflows default to the floating `opus` alias instead. Unsetting the repo
variable is the one-click fix if so; I did not change it, since that is a
behaviour change beyond this migration.
