### PR TITLE
ci(claude): scope MCP servers in CI and drop runtimes for servers never installed

### DIFF
--- a/.github/claude-mcp-ci.json
+++ b/.github/claude-mcp-ci.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "context7": {
+      "command": "bunx",
+      "args": ["-y", "@upstash/context7-mcp"]
+    },
+    "sequential-thinking": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+    }
+  }
+}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,5 +1,24 @@
 name: Claude Code
 
+# This workflow deliberately stays local rather than calling
+# laurigates/.github's reusable-claude.yml. That workflow is checkout ->
+# claude-code-action -> failure handling and defaults to ubuntu-slim, which
+# carries no Homebrew and no Go; a reusable workflow cannot accept
+# caller-supplied steps, so the toolchain below (node + bun for the MCP
+# servers, Homebrew + chezmoi + pre-commit for the repo's own checks) has
+# nowhere to go. Revisit if reusable-claude.yml ever grows a setup-action or
+# pre-steps input.
+#
+# MCP servers are scoped to .github/claude-mcp-ci.json via --strict-mcp-config.
+# The project .mcp.json declares five servers, but CI only ever installed the
+# runtimes -- never the server binaries: `pal-mcp-server` (no `uv tool install`)
+# and `github-mcp-server` (no `go install`) could not start, and `playwright`
+# would launch without browsers. Rather than install three more things the CI
+# job does not need, CI runs the two that work: context7 and
+# sequential-thinking, both fetched on demand by bunx/npx. The GitHub MCP
+# server is redundant here anyway -- the action's base GitHub tools and `gh`
+# cover it.
+
 on:
   issue_comment:
     types: [created]
@@ -47,19 +66,6 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-
-      - name: Setup Go for GitHub MCP server
-        uses: actions/setup-go@v5
-        with:
-          go-version: 'stable'
-
-      - name: Setup Python/uv for pal-mcp-server
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
 
       - name: Setup Homebrew
         uses: Homebrew/actions/setup-homebrew@master
@@ -111,8 +117,6 @@ jobs:
             echo "- testing-plugin"
             echo "- tools-plugin"
           } >> "$GITHUB_STEP_SUMMARY"
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
       - name: Generate allowed tools configuration
         id: tools-config
@@ -156,6 +160,8 @@ jobs:
             --model ${{ vars.CLAUDE_MODEL || 'claude-opus-4-8' }}
             --allowedTools ${{ steps.tools-config.outputs.allowed_tools }}
             --max-turns 100
+            --mcp-config .github/claude-mcp-ci.json
+            --strict-mcp-config
 
       - name: Collect workflow metrics
         if: always()


### PR DESCRIPTION
## What

Scopes the MCP servers Claude uses in CI to the two that actually work, and
removes the three runtimes installed for servers that were never installed.

## The audit

`.mcp.json` declares five servers. Cross-referencing them against what
`claude.yml` installs:

| server | command | runtime installed | server installed |
|---|---|---|---|
| `context7` | `bunx -y @upstash/context7-mcp` | bun ✅ | fetched on demand ✅ |
| `sequential-thinking` | `npx -y @modelcontextprotocol/...` | node ✅ | fetched on demand ✅ |
| `playwright` | `bunx -y @playwright/mcp@latest` | bun ✅ | fetched, but **no browsers** |
| `pal` | `pal-mcp-server` | python + uv ✅ | **never** — no `uv tool install` |
| `github` | `github-mcp-server stdio` | go ✅ | **never** — no `go install` |

`setup-go` was there to support a binary that is never built, and
`setup-python`/`setup-uv` one that is never installed. Both servers have been
failing to start for as long as this has been configured — silently, since a
server that fails to start just isn't available.

## The fix

Two options: install the three missing things, or stop pretending CI needs them.
This takes the second. `.github/claude-mcp-ci.json` declares `context7` and
`sequential-thinking`, and `claude_args` gains:

```
--mcp-config .github/claude-mcp-ci.json
--strict-mcp-config
```

`--strict-mcp-config` means *"only use MCP servers from `--mcp-config`"*, so the
project `.mcp.json` is ignored in CI rather than being partially attempted.
`.mcp.json` is untouched, so local development keeps all five.

The GitHub MCP server is the one that might look worth keeping — it isn't. The
action's base GitHub tools plus the `gh` CLI already cover that ground in CI.

## Also in here

- **Drops a dead secret reference.** The plugin-install step set
  `ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}`; this repo has no such
  secret — only `CLAUDE_CODE_OAUTH_TOKEN` — so it has always expanded to empty.
- **Documents why this workflow stays local.** A header note records that
  `reusable-claude.yml` is checkout → action → failure handling on `ubuntu-slim`
  (no Homebrew, no Go), and that a reusable workflow cannot accept
  caller-supplied steps, so the toolchain here has nowhere to go. With a
  revisit condition: if that workflow grows a `setup-action` or `pre-steps`
  input, this becomes migratable.

## What this does not do

It does not verify that `context7` and `sequential-thinking` *do* start in CI —
only that the other three cannot. That is checkable the next time an `@claude`
run happens on this repo; if either fails to start, the fix is a runtime
problem, not a config one.

Kept deliberately: `.github/scripts/generate-allowed-tools.sh` and the
`full_access` preset, which this workflow still uses.

`actionlint` clean.
