### PR TITLE
ci: add concurrency groups and pin smoke.yml permissions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,6 +7,10 @@ on:
     branches: [main]
   workflow_dispatch: # Allow manual triggering
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -10,6 +10,10 @@ on:
     - cron: '0 9 * * 1'
   workflow_dispatch: # Allow manual triggering
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
   issues: write

--- a/.github/workflows/organize-stars.yml
+++ b/.github/workflows/organize-stars.yml
@@ -12,6 +12,10 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.repository }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 

--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -9,6 +9,10 @@ on:
     types: [published]
   workflow_dispatch: # Allow manual triggering
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: write # Required for uploading SBOM artifacts
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
     branches: [ main ] # Or your default branch name
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+# Checkout and cache only; nothing here writes to the repo.
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Linters


### PR DESCRIPTION
## What

Adopts two conventions documented in `laurigates/.github`'s CLAUDE.md —
concurrency groups, and minimal workflow-level permissions — on the workflows
that lacked them. 36 lines added, nothing removed.

## Concurrency (8 workflows)

None of the PR checks had a concurrency group, so pushing twice to a PR ran
duplicate jobs to completion. PR-triggered workflows take the idiom already
established in `mcu-tinkering-lab`:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Cancelling is scoped to pull requests deliberately — a `main` push still runs to
completion, so the default branch keeps an unbroken run history.

`organize-stars.yml` gets the other shape: it is schedule-driven and mutates a
state file, so it **queues** rather than cancels (repository-scoped group,
`cancel-in-progress: false`), matching how the org repo treats `release-please`
and `terraform-sentry-sync`.

| workflow | idiom |
|---|---|
| benchmarks, coverage, labeler, link-checker, pr-size-labeler, sbom, smoke | PR — cancel superseded |
| organize-stars | schedule — queue, never cancel |

## Permissions (1 workflow)

`smoke.yml` gains `permissions: contents: read` — it only checks out and caches.

Correcting something I said while scoping this: the gap is **one** workflow, not
five. `claude.yml`, `claude-code-review.yml` and `claude-config-validation.yml`
declare permissions at *job* level, which is tighter than workflow level rather
than missing; my first audit grepped for `^permissions:` and only saw
workflow-scope. `renovate.yml` needs none — it is a caller, and the reusable
workflow declares its own.

## Pre-existing actionlint failure, not introduced here

`actionlint .github/workflows/*.yml` fails on `main` and on this branch, in
`auto-fix-ci-failures.yml`:

```
auto-fix-ci-failures.yml:193:50: property "changed" is not defined in object type
    if: steps.claude.outcome == 'success' && steps.claude.outputs.changed == 'true'
```

`claude-code-action` does not expose a `changed` output, so that condition has
always evaluated false — meaning the local auto-fix workflow's push and
PR-create steps have **never run**. This is what `mise run lint` has been
reporting as "⚠️ Warning: actionlint found issues" while still exiting 0. #370
replaces that file with the org reusable caller, which resolves it; no fix is
attempted here.

Every file touched by this PR is actionlint-clean, verified individually.

## Deliberately untouched

`claude.yml` (#371), `claude-code-review.yml` and `auto-fix-ci-failures.yml`
(#370) — all three are rewritten by in-flight PRs and editing them here would
conflict.
