### PR TITLE
ci(smoke): add a macOS build job alongside Ubuntu

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -137,3 +137,64 @@ jobs:
               exit 1
             fi
           "
+
+  build-macos:
+    name: Build (macOS)
+    runs-on: macos-latest
+    needs: [lint] # Run after linters pass, same as the Ubuntu build
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # No setup-homebrew here: macOS runners ship Homebrew preinstalled.
+      # The Linux jobs need the action because linuxbrew is not.
+      - name: Cache Homebrew
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Caches/Homebrew
+          key: ${{ runner.os }}-brew-${{ hashFiles('**/Brewfile') }}
+          restore-keys: |
+            ${{ runner.os }}-brew-
+
+      - name: Install Dependencies
+        # Deliberately NOT installing zsh. macOS ships zsh 5.9 as /bin/zsh and
+        # that is the zsh this repo's config actually targets — see the
+        # dot_zfunc/__git_branch_names override, which hooks the completion
+        # system zsh 5.9 provides. Installing brew's zsh would smoke-test a
+        # different shell than the one on the daily driver.
+        run: brew install chezmoi neovim
+
+      - name: Setup mise
+        uses: jdx/mise-action@v4
+
+      - name: Cache mise tools
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.local/share/mise
+            ~/.local/state/mise
+          key: ${{ runner.os }}-mise-${{ hashFiles('**/.mise.toml', '**/mise.toml', '**/.config/mise/config.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-mise-
+
+      - name: Run chezmoi apply
+        # Same flags as the Ubuntu build: --source=. because chezmoi's default
+        # source dir does not exist on a fresh runner, and --exclude=scripts to
+        # skip the stateful run_once_/run_onchange_ installers.
+        run: chezmoi apply -v --source=. --exclude=scripts
+
+      - name: Test zsh shell initialization
+        # Uses the system zsh (/bin/zsh, 5.9) for the reason given above.
+        # Same hang-guard rationale as the Ubuntu job — a bound on a config
+        # change that blocks on input, not a performance budget.
+        run: |
+          timeout 60s /bin/zsh -c "
+            source ~/.zshrc
+            if [[ -n \"\$ZSH_VERSION\" ]]; then
+              echo \"✅ zsh \$ZSH_VERSION configuration loaded successfully\"
+            else
+              echo \"❌ zsh configuration failed to load\"
+              exit 1
+            fi
+          "

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ pre-commit run gitleaks --all-files      # via pre-commit
 
 ## CI Pipeline
 
-- **smoke.yml** — Multi-platform (Ubuntu/macOS) linting and build
+- **smoke.yml** — Linting on Ubuntu; build + zsh smoke test on Ubuntu and macOS (see [ADR-0017](docs/adrs/0017-ci-platform-coverage.md))
 - **claude.yml** — AI-assisted dev with auto plugin install from [laurigates/claude-plugins](https://github.com/laurigates/claude-plugins)
 
 ## Blueprint Documentation


### PR DESCRIPTION
## What

Adds `Build (macOS)` to `smoke.yml`, implementing ADR-0017 (#368). This is the
first CI coverage of the platform the repo exists to configure since
`a264a61` removed it on 2025-09-15.

## Why now

The two reasons recorded for removing it were measured and do not hold here:

- **Cost** — public repositories bill standard runners at zero, macOS included.
  `gh api .../timing` on a sibling public repo running macOS jobs reports
  `MACOS: jobs=3, total_ms=0`.
- **Runtime** — macOS queued 2–3 s and ran 25–33 s against Ubuntu's 2–4 s and
  22–27 s in that same run. ~20% slower, not 10×.

The third reason, complexity, was not disproved and the ADR says so.

## Three deliberate differences from Build (Ubuntu)

**No `setup-homebrew` action.** macOS runners ship Homebrew preinstalled; the
Linux jobs need the action only because linuxbrew is not.

**zsh is not installed from Homebrew, and the test runs `/bin/zsh`.** This is
the one that matters. macOS ships zsh 5.9, and that is the zsh this
configuration targets — `dot_zfunc/__git_branch_names` overrides a helper from
the completion system zsh 5.9 provides, and its own header comment names
*"zsh 5.9 — the one macOS ships as `/bin/zsh`"*. Installing brew's zsh would
smoke-test a different shell than the daily driver actually runs, which would
make the job green while the real thing was broken.

**Cache path** is `~/Library/Caches/Homebrew`.

Gated on `needs: [lint]` like the Ubuntu build, so a lint failure doesn't burn a
second runner.

## Also corrects a stale claim

`CLAUDE.md` has described `smoke.yml` as *"Multi-platform (Ubuntu/macOS) linting
and build"* for the eleven months it was Ubuntu-only. The line now says what is
actually true — linting on Ubuntu, build and zsh smoke test on both — and links
the ADR.

## What this PR can't tell you yet

The estimate in ADR-0017 was 2–4 min of added wall clock, dominated by
`brew install` on a cold runner. This PR's own CI run is the first real
measurement; if it lands well outside that range, the ADR's revisit condition
(move to a schedule rather than delete) is the thing to reach for.

`actionlint` clean.

## Conflict note

#372 also touches `smoke.yml`, adding `concurrency` and `permissions` above
`jobs:`. Different region of the file, so they should merge cleanly in either
order — but whichever lands second may want a rebase check.
