### PR TITLE
ci(smoke): replace `timeout` with a perl alarm so the macOS job can run

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -136,15 +136,26 @@ jobs:
           # near this limit is a genuine problem worth its own investigation;
           # note that the benchmarks workflow does NOT cover it, because it
           # times a minimal /tmp/test.zshrc rather than the applied ~/.zshrc.
-          timeout 60s zsh -c "
+          #
+          # `perl -e 'alarm ...; exec @ARGV'` rather than `timeout`: the SIGALRM
+          # timer set by alarm(2) survives the exec, so a hang still dies
+          # non-zero — identical semantics to `timeout 60s`, minus the GNU
+          # coreutils dependency that the macOS job cannot satisfy (#380). Both
+          # jobs use the same mechanism so the guard cannot drift per-platform.
+          #
+          # The `exit 127` tail is NOT optional. perl's exec() returns only on
+          # failure, so without it a missing zsh would fall off the end of the
+          # one-liner and exit 0 — a green smoke test that sourced nothing.
+          # `timeout` reported 127 for that case; this reproduces it.
+          perl -e 'alarm shift; exec @ARGV; warn qq(exec: $!\n); exit 127' 60 zsh -c '
             source ~/.zshrc
-            if [[ -n \"\$ZSH_VERSION\" ]]; then
-              echo \"✅ zsh configuration loaded successfully\"
+            if [[ -n "$ZSH_VERSION" ]]; then
+              echo "✅ zsh configuration loaded successfully"
             else
-              echo \"❌ zsh configuration failed to load\"
+              echo "❌ zsh configuration failed to load"
               exit 1
             fi
-          "
+          '
 
   build-macos:
     name: Build (macOS)
@@ -195,14 +206,17 @@ jobs:
       - name: Test zsh shell initialization
         # Uses the system zsh (/bin/zsh, 5.9) for the reason given above.
         # Same hang-guard rationale as the Ubuntu job — a bound on a config
-        # change that blocks on input, not a performance budget.
+        # change that blocks on input, not a performance budget. `timeout` is
+        # GNU coreutils and is absent from the macOS runner image (as is
+        # `gtimeout`, without `brew install coreutils`), so this uses the same
+        # perl alarm/exec form as the Ubuntu job — see #380.
         run: |
-          timeout 60s /bin/zsh -c "
+          perl -e 'alarm shift; exec @ARGV; warn qq(exec: $!\n); exit 127' 60 /bin/zsh -c '
             source ~/.zshrc
-            if [[ -n \"\$ZSH_VERSION\" ]]; then
-              echo \"✅ zsh \$ZSH_VERSION configuration loaded successfully\"
+            if [[ -n "$ZSH_VERSION" ]]; then
+              echo "✅ zsh $ZSH_VERSION configuration loaded successfully"
             else
-              echo \"❌ zsh configuration failed to load\"
+              echo "❌ zsh configuration failed to load"
               exit 1
             fi
-          "
+          '


### PR DESCRIPTION
Closes #380. Picks up @claude's patch from [the issue thread](https://github.com/laurigates/dotfiles/issues/380#issuecomment-5351098586) — it did the research and chose option B, but its push was rejected because the GitHub App lacks `workflows` permission on `.github/workflows/`. This session has it, so I'm landing the work.

**One substantive change to that patch** — see below; it had a hole that would have made the smoke test green while testing nothing.

## The fix

`timeout` is GNU coreutils. macOS runners ship neither `timeout` nor `gtimeout` without `brew install coreutils`, so `Build (macOS)` died at `command not found` before sourcing anything, and has never passed since #374 added it.

Replaced with `perl -e 'alarm shift; exec @ARGV; …' 60 …` in **both** jobs, not just macOS: perl is preinstalled on both runner images, the `alarm(2)` timer survives the `exec`, and using one mechanism on both platforms means the hang-guard can't drift per-platform. That drops the coreutils assumption rather than papering over it on one side.

## The correction to the proposed patch

The bot's form was `perl -e 'alarm shift; exec @ARGV' 60 zsh -c '…'`. perl's `exec()` **returns only on failure**, so with no tail after it the one-liner falls off the end and exits **0** when the target binary is missing:

```console
$ timeout 60s definitely-not-a-real-binary; echo $?
timeout: failed to run command 'definitely-not-a-real-binary': No such file or directory
127

$ perl -e 'alarm shift; exec @ARGV' 60 definitely-not-a-real-binary; echo $?
0          # <- silently green
```

That is not hypothetical here: the Ubuntu job invokes bare `zsh`, installed by an earlier setup step. Had that install ever broken, this smoke test would have gone green having sourced nothing — the failure mode `.claude/rules` calls a lying test. `timeout` reported 127; the added `warn` + `exit 127` reproduces it.

## Verification

Ran the final form directly — this container has no zsh and no macOS runner, so these exercise the wrapper's semantics, which is what changed:

| Case | Result | Want |
|---|---|---|
| success | `0` | 0 |
| `exit 1` | `1` | 1 — real failures must still fail |
| `exit 3` | `3` | exit code passed through, not flattened |
| hang (`sleep 60`, alarm 2) | `142` in 2s | non-zero, at the deadline — not the 6-hour job limit |
| blocked on stdin (`cat`) | `142` in 2s | the actual hazard the guard exists for |
| missing binary | `127` | 127 — **was `0`** before the correction |

YAML parses and both `run:` blocks render as intended. `actionlint` isn't installed in this container, so CI is the first real lint pass — the `Linters` job covers it.

The issue's acceptance criterion — *"a deliberately hanging `~/.zshrc` still fails the job rather than running to the 6-hour limit"* — is the hang and stdin rows above.

## Also

Inline scripts move from double- to single-quoted `zsh -c '…'`, dropping the `\"`/`\$` escaping so zsh expands `$ZSH_VERSION` itself. Same output, less quoting to get wrong.

Once this merges, #378 gets its base merged in so its `Build (macOS)` re-runs against a green base — that's its last red check and the only thing standing between it and mergeable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQV3do6dGoc7HABQm6v5ZQ)_