### PR TITLE
fix(claude): make repo-activity see all 124 repos, not 1

### DIFF
--- a/exact_dot_claude/skills/repo-activity/SKILL.md
+++ b/exact_dot_claude/skills/repo-activity/SKILL.md
@@ -13,8 +13,21 @@ Scan all repositories in ~/repos/ and report recent activity.
 ### 1. Find All Git Repositories
 
 ```bash
-fd -t d -H '^\.git$' ~/repos --max-depth 3 -x dirname {} | sort -u
+fd -t d -H -I '^\.git$' ~/repos --max-depth 4 -x dirname {} | sort -u
 ```
+
+Both flags are load-bearing, and omitting either fails **silently** — you get a
+short repo list that reads as a quiet portfolio rather than a broken scan:
+
+- `-I` (`--no-ignore`): `~/repos` is itself a git repo whose `.gitignore` is
+  default-deny (`/*`, allowlisting only the portfolio config). Without `-I`,
+  `fd` honors it and finds **1** repo instead of 124.
+- `--max-depth 4`: nested packs live one level deeper than the
+  `owner/repo` layout — `laurigates/comfyui-nodes/comfyui-touch-resize`,
+  `ForumViriumHelsinki/simpl-open/user-manual`. Depth 3 finds 98, depth 4 finds 124.
+
+Sanity-check the count before reporting: fewer than ~50 repos means the scan is
+broken, not that the portfolio is small.
 
 ### 2. Get Activity for Each Repo
 


### PR DESCRIPTION
## What

`repo-activity`'s repository discovery returned **1 repo instead of 124**. Two independent causes, both fixed here:

```diff
-fd -t d -H '^\.git$' ~/repos --max-depth 3 -x dirname {} | sort -u
+fd -t d -H -I '^\.git$' ~/repos --max-depth 4 -x dirname {} | sort -u
```

| Cause | Effect |
|---|---|
| Missing `-I` | `~/repos` is itself a git repo with a default-deny `.gitignore` (`/*`, allowlisting only the portfolio config). `fd` honored it and skipped every nested project. |
| `--max-depth 3` | Nested packs sit one level deeper than `owner/repo` — `laurigates/comfyui-nodes/comfyui-touch-resize`, `ForumViriumHelsinki/simpl-open/user-manual`. |

Measured: default `1` → `-I` `98` → `-I` + depth 4 `124`.

## Why it matters

Both failures are **silent**. A short repo list reads as a quiet portfolio rather than a broken scan, so the skill has been reporting confidently on ~1% of the tree with nothing to signal it. This is the `tool-result-traps` shape — an empty-ish result that gates a conclusion.

The diff also documents why each flag is load-bearing and adds a count sanity check (`< ~50 repos means the scan is broken`), so the next regression is caught at the skill rather than downstream.

## How it was found

While building a weekly-digest gather script in LakuVault that reused this same discovery command — the script found 0 direct-commit repos in a week that definitely had them.

## Verification

- `chezmoi diff` reviewed, `chezmoi apply` clean
- Counts above measured directly against `~/repos`