### PR TITLE
fix(mise): declare rust-analyzer as a rustup component for the rust tool

### DIFF
--- a/private_dot_config/mise/config.toml.tmpl
+++ b/private_dot_config/mise/config.toml.tmpl
@@ -26,7 +26,10 @@ bun = "latest"
 
 # Systems programming
 go = "1.23"
-rust = "latest"
+# components: mise drives rustup, so rust-analyzer is a rustup component, not a
+# separate tool. Declaring it here reinstalls it whenever "latest" moves to a new
+# toolchain; `rustup component add` only covers the toolchain current at the time.
+rust = { version = "latest", components = "rust-analyzer" }
 
 # ============================================================================
 # Python Tools (via pipx backend, routed through uvx)


### PR DESCRIPTION
## What

Change the global mise `rust` entry from a bare version string to the table form with a `components` option:

```toml
rust = { version = "latest", components = "rust-analyzer" }
```

## Why

mise's `rust` core plugin is a thin wrapper over rustup — `~/.local/share/mise/installs/rust/1.97.0` is a symlink to `~/.cargo/bin`, and mise selects a toolchain by exporting `RUSTUP_TOOLCHAIN`. Every `rust*` binary on PATH is a rustup shim, so `rust-analyzer` is a rustup *component*, not a separately installable tool.

With `rust = "latest"`, the toolchain moves on every Rust release. An imperative `rustup component add rust-analyzer` covers only the toolchain current at the time; after the next bump the shim resolves to a toolchain that has no rust-analyzer and exits immediately:

```
error: Unknown binary 'rust-analyzer' in official toolchain '1.97.0-aarch64-apple-darwin'.
```

That failure mode is quiet in exactly the wrong way. An LSP client gets no response to `initialize`, times out after 30s, and leaves no rust-analyzer process behind to inspect — so it reads as "the language server is slow/hanging" rather than "the binary is missing". Found while diagnosing a dead cclsp MCP server in `laurigates/loractl`.

## How

mise's `components` tool option installs the listed components alongside each toolchain it installs, so the component follows `latest` forward instead of being stranded on one version.

Verified after the change: `mise install rust` resolved `latest` to 1.98.0 and reported "downloading 7 components", with `rust-analyzer-aarch64-apple-darwin` present in `rustup component list --toolchain 1.98.0-aarch64-apple-darwin --installed` and the binary on disk. cclsp then completed `initialize` and served `find_definition` / `find_references` / `find_workspace_symbols` against the loractl workspace.

Note: this does not retrofit already-installed toolchains — 1.97.0 still needed a one-off `rustup component add` to unblock the in-flight session, whose shell had `RUSTUP_TOOLCHAIN=1.97.0` frozen from startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DTPmZ913NUWXuCpRdVtBW
