### PR TITLE
fix(claude): restore LSP servers dropped by plugin install

### DIFF
--- a/exact_dot_claude/hooks/executable_lsp-manifest-heal.sh
+++ b/exact_dot_claude/hooks/executable_lsp-manifest-heal.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Re-inject lspServers into installed plugin manifests (SessionStart).
+#
+# WHY: the official *-lsp plugins declare their server ONLY in the marketplace's
+# marketplace.json, but Claude Code's LSP manager reads lspServers from the
+# INSTALLED plugin's own .claude-plugin/plugin.json. That file ships with just
+# name/description/version/author, so every LSP plugin arrives inert:
+#   [LSP SERVER MANAGER] getAllLspServers returned 0 server(s)
+# A `/plugin update` rewrites the cache and drops the fix again, hence this heal.
+#
+# Upstream marketplace.json stays the source of truth — nothing is hand-copied
+# here, so a changed command or a new server propagates on its own.
+set -uo pipefail
+
+plugins_dir="${HOME}/.claude/plugins"
+installed="${plugins_dir}/installed_plugins.json"
+[ -r "$installed" ] || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+healed=()
+while IFS=$'\t' read -r key install_path; do
+  [ -n "$install_path" ] || continue
+  name="${key%@*}"; marketplace="${key##*@}"
+  manifest="${install_path}/.claude-plugin/plugin.json"
+  market="${plugins_dir}/marketplaces/${marketplace}/.claude-plugin/marketplace.json"
+  [ -r "$manifest" ] && [ -r "$market" ] || continue
+  jq -e 'has("lspServers")' "$manifest" >/dev/null 2>&1 && continue
+
+  servers="$(jq -c --arg n "$name" \
+    '.plugins[]? | select(.name == $n) | .lspServers // empty' "$market" 2>/dev/null)"
+  [ -n "$servers" ] || continue
+
+  tmp="$(mktemp)" || continue
+  if jq --argjson s "$servers" '. + {lspServers: $s}' "$manifest" >"$tmp" 2>/dev/null && [ -s "$tmp" ]; then
+    cat "$tmp" >"$manifest" && healed+=("$name")
+  fi
+  rm -f "$tmp"
+done < <(jq -r '.plugins | to_entries[] | "\(.key)\t\(.value[0].installPath // "")"' "$installed" 2>/dev/null)
+
+[ ${#healed[@]} -gt 0 ] && printf 'lsp-manifest-heal: restored lspServers for %s (plugin update had dropped it)\n' "${healed[*]}"
+exit 0

--- a/exact_dot_claude/modify_settings.json
+++ b/exact_dot_claude/modify_settings.json
@@ -217,6 +217,11 @@ read -r -d '' overlay <<'OVERLAY' || true
             "type": "command",
             "command": "bash ~/.claude/hooks/claude-plugins-refresh.sh",
             "timeout": 20
+          },
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/lsp-manifest-heal.sh",
+            "timeout": 10
           }
         ]
       }
@@ -290,8 +295,8 @@ read -r -d '' overlay <<'OVERLAY' || true
     "prose-plugin@laurigates-claude-plugins": true,
     "pyright-lsp@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,
-    "rust-analyzer-lsp@claude-plugins-official": false,
-    "gopls-lsp@claude-plugins-official": true,
+    "rust-analyzer-lsp@claude-plugins-official": true,
+    "gopls-lsp@claude-plugins-official": false,
     "swift-lsp@claude-plugins-official": false,
     "clangd-lsp@claude-plugins-official": false,
     "codebase-attributes-plugin@laurigates-claude-plugins": false,


### PR DESCRIPTION
## What

Adds a `SessionStart` hook that re-injects `lspServers` into installed Claude Code plugin manifests, and reconciles the drifted LSP enable state.

## Why

The official `*-lsp` plugins declare `lspServers` **only** in the marketplace's `marketplace.json`, but Claude Code's LSP manager reads it from the **installed** plugin's `.claude-plugin/plugin.json` — which ships with just `name`/`description`/`version`/`author`. Every LSP plugin therefore installs inert:

```
[LSP SERVER MANAGER] getAllLspServers returned 0 server(s)
```

No server spawns, no `LSP` tool is registered, and nothing warns. The symptom is indistinguishable from a build without LSP support, which is how it went unnoticed.

Upstream: [anthropics/claude-code#15148](https://github.com/anthropics/claude-code/issues/15148) (open since 2025-12) and [anthropics/claude-plugins-official#379](https://github.com/anthropics/claude-plugins-official/issues/379), whose fix PR #378 was closed unmerged.

## How

`lsp-manifest-heal.sh` reads each missing block out of `marketplace.json` rather than carrying a copy, so a changed command or a newly added server propagates on its own — nothing here to drift. It runs every session rather than once because a `/plugin update` rewrites the cache and drops the block again.

The overlay change also fixes a pre-existing drift: it held `rust-analyzer-lsp: false` against a live `true`, so the next `chezmoi apply` would have switched the server back off.

## Verification

On Claude Code 2.1.246:

```
Loaded 1 LSP server(s) from plugin: pyright-lsp
Loaded 1 LSP server(s) from plugin: typescript-lsp
Loaded 1 LSP server(s) from plugin: rust-analyzer-lsp
[LSP SERVER MANAGER] getAllLspServers returned 3 server(s)
```

- `documentSymbol` on a Rust file returns 7 functions with real signatures; `hover` returns the doc comment; `findReferences` resolves across files.
- `documentSymbol` on a Python file in a different repo returns 108 symbols — cross-repo coverage confirmed (the plugins are user-scoped).
- Second run of the script is a silent no-op (idempotent, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ciyCd7QKmbxMS6WNHvUmQ