### PR TITLE
chore(claude): drop cclsp, superseded by the native LSP client

### DIFF
--- a/docs/justfile-architecture.md
+++ b/docs/justfile-architecture.md
@@ -19,7 +19,7 @@ justfile *and* the global justfile, so `just <recipe>` (inside this repo) and
 flowchart TD
     subgraph src["chezmoi source: private_dot_config/just/"]
         plugins["plugins.just<br/>group: plugins<br/>(marketplace install/enable/audit)"]
-        claude["claude.just<br/>group: claude<br/>(mcp-*, cclsp, settings-audit)"]
+        claude["claude.just<br/>group: claude<br/>(mcp-*, settings-audit)"]
         git["git.just<br/>group: git<br/>(branch-audit)"]
     end
 
@@ -67,7 +67,7 @@ the imported modules:
 | `maintain` | root | `update`, `bump`, `clean`, `secrets`, `update-claude-completion` |
 | `info` | root | `docs`, `dev`, `edit`, `info`, `doctor` |
 | `plugins` | `plugins.just` | `plugins-install/enable/disable/update/uninstall`, `plugins-audit`, `plugins-setup-repo` |
-| `claude` | `claude.just` | `mcp-*`, `cclsp`, `claude-setup`, `settings-audit` |
+| `claude` | `claude.just` | `mcp-*`, `claude-setup`, `settings-audit` |
 | `git` | `git.just` | `branch-audit` |
 | `nvim` | `nvim.just` | `nvim-plugins-audit` |
 

--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ set shell := ["bash", "-uc"]
 # the global ~/.user.justfile so `just -g plugins-*` works from any directory.
 import 'private_dot_config/just/plugins.just'
 
-# Claude Code setup recipes (mcp-*, cclsp, claude-setup, settings-audit) — single
+# Claude Code setup recipes (mcp-*, claude-setup, settings-audit) — single
 # source of truth, also imported by ~/.user.justfile so `just -g mcp-*` works
 # from any directory.
 import 'private_dot_config/just/claude.just'

--- a/private_dot_config/just/claude.just
+++ b/private_dot_config/just/claude.just
@@ -4,7 +4,7 @@
 #   • the dotfiles repo justfile (so `just mcp-*` / `just settings-audit` work here), and
 #   • the global ~/.config/just/justfile (so `just -g mcp-*` works from ANY directory).
 #
-# The mcp-* / cclsp / claude-setup recipes run `claude mcp add-json -s project`
+# The mcp-* / claude-setup recipes run `claude mcp add-json -s project`
 # against the CURRENT repo, so being globally invokable from inside any target
 # repo is exactly what you want. settings-audit sweeps the ~/repos portfolio
 # tree (consistent with plugins-audit in plugins.just, which also hardcodes it).
@@ -42,14 +42,9 @@ mcp-sequential-thinking:
 mcp-chrome-devtools:
     claude mcp add-json -s project chrome-devtools '{"type": "stdio", "command": "bunx", "args": ["chrome-devtools-mcp@latest"], "env": {}}'
 
-# Set up Claude Code Language Server Protocol
+# Add all MCP servers
 [group: "claude"]
-cclsp:
-    bunx cclsp@latest setup
-
-# Add all MCP servers and set up cclsp
-[group: "claude"]
-claude-setup: mcp-sentry mcp-github mcp-context7 mcp-playwright mcp-sequential-thinking mcp-chrome-devtools cclsp
+claude-setup: mcp-sentry mcp-github mcp-context7 mcp-playwright mcp-sequential-thinking mcp-chrome-devtools
 
 # Audit Claude Code settings files for hygiene issues
 [group: "claude"]

--- a/private_dot_config/just/justfile
+++ b/private_dot_config/just/justfile
@@ -8,7 +8,7 @@
 #
 # Source of truth for the recipes lives beside this file:
 #   • plugins.just  — Claude plugin management (plugins-*)
-#   • claude.just   — Claude Code setup (mcp-*, cclsp, claude-setup, settings-audit)
+#   • claude.just   — Claude Code setup (mcp-*, claude-setup, settings-audit)
 #   • git.just      — Git branch hygiene (branch-audit)
 #   • maint.just    — Local machine maintenance (home-audit)
 # Edit those, then `chezmoi apply`. Imports are relative to this file's directory.


### PR DESCRIPTION
## What

Removes the `cclsp` recipe from `claude.just`, drops it from `claude-setup`, and updates the justfile header comments and architecture docs.

## Why

`cclsp` was the stop-gap that gave Claude Code language intelligence over MCP. The native LSP client now covers it — once its plugins actually load (see #388).

| cclsp tool | native `LSP` equivalent |
|---|---|
| `find_definition` | `goToDefinition` ✅ |
| `find_references` | `findReferences` ✅ |
| `get_diagnostics` | passive — attached after edits, not callable on demand ⚠️ |
| `rename_symbol` | none ❌ |

Native additionally provides `hover`, `documentSymbol`, `workspaceSymbol`, `goToImplementation`, and call hierarchy (incoming/outgoing).

**`rename_symbol` is the one capability lost.** Everything else is a superset.

## Scope

The binary was never installed locally — the recipe fetched it per-run via `bunx cclsp@latest`, and the MCP registrations in `~/.claude.json` (loractl, comfyui-nodes) were no longer loading in any case.

Handled outside this PR:

- MCP registrations removed via `claude mcp remove cclsp -s local` (`~/.claude.json` is not chezmoi-managed).
- `cclsp.json` removed per repo — untracked copies deleted in `kicad-mcp` and `silverbucket-helper`; tracked ones get their own PRs in `loractl`, `comfyui-nodes`, `foundryvtt-mcp`, and `thelma`.

## Verification

`just --justfile private_dot_config/just/claude.just --list` parses, and the pre-commit justfile check passes. No `cclsp` references remain anywhere in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ciyCd7QKmbxMS6WNHvUmQ