### PR TITLE
ci(link-checker): confirm failures before reporting and close the issue when clean

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -28,7 +28,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check links in markdown files
-        uses: lycheeverse/lychee-action@v2.0.2
+        id: lychee
+        uses: lycheeverse/lychee-action@v2.9.0
         with:
           # Check all markdown files
           args: |
@@ -37,13 +38,18 @@ jobs:
             --accept 200,204,206,429
             --timeout 30
             --max-retries 3
-            --exclude-mail
             --exclude 'localhost'
             --exclude 'example.com'
             --exclude '127.0.0.1'
             '**/*.md'
-          # Fail on broken links in PRs, but only warn on main/scheduled runs
-          fail: ${{ github.event_name == 'pull_request' }}
+          # Never decide the job outcome here. A first-pass failure is only a
+          # candidate: the re-check step below confirms it before anything is
+          # reported, and the final step turns a confirmed failure into a red
+          # PR. `failIfEmpty` stays on (default) so a broken glob still fails.
+          fail: false
+          # Keep the plain report shape ('* [404] <url> …'); the checkbox mode
+          # added in v2.1.0 would change what the re-check step parses.
+          checkbox: false
           output: lychee-report.md
 
       - name: Create link check summary
@@ -58,8 +64,52 @@ jobs:
             echo "✅ All links are valid!" >> "$GITHUB_STEP_SUMMARY"
           fi
 
+      # Most historical findings were transient connection failures
+      # ("Network error: error sending request"), not broken links: the target
+      # was reachable again by the time anyone looked. Re-check just the failed
+      # URLs after a pause and only report what fails twice.
+      - name: Re-check failed links
+        id: recheck
+        if: always() && steps.lychee.outputs.exit_code != '0'
+        run: |
+          set -uo pipefail
+
+          # Error entries look like: '* [404] <https://example.org/x> (at 1:2) | …'
+          grep -E '^\s*\* \[' lychee-report.md \
+            | grep -oE 'https?://[^] )>|]+' \
+            | sort -u > failed-urls.txt || true
+
+          if [ ! -s failed-urls.txt ]; then
+            echo "Errors reported but no URLs could be extracted; reporting as-is."
+            echo "confirmed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Re-checking $(wc -l < failed-urls.txt) failed link(s) after a pause:"
+          cat failed-urls.txt
+          sleep 60
+
+          # The URL list is passed as an input *file* so lychee checks those
+          # URLs; passing them as arguments would make it crawl each page and
+          # check the links found inside instead.
+          if lychee \
+            --format markdown \
+            --output lychee-recheck.md \
+            --verbose \
+            --no-progress \
+            --accept 200,204,206,429 \
+            --timeout 30 \
+            --max-retries 5 \
+            --retry-wait-time 10 \
+            failed-urls.txt; then
+            echo "All failed links recovered on re-check; treating as transient."
+            echo "confirmed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "confirmed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Comment PR with broken links
-        if: failure() && github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request' && steps.recheck.outputs.confirmed == 'true'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -75,7 +125,7 @@ jobs:
             }
 
             report += '\n\n---\n';
-            report += '*Please fix the broken links before merging.*';
+            report += '*Confirmed by a second check; please fix the broken links before merging.*';
 
             github.rest.issues.createComment({
               issue_number: context.issue.number,
@@ -85,7 +135,7 @@ jobs:
             });
 
       - name: Create issue for broken links (scheduled run)
-        if: failure() && github.event_name == 'schedule'
+        if: always() && github.event_name == 'schedule' && steps.recheck.outputs.confirmed == 'true'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -99,18 +149,21 @@ jobs:
             }
 
             body += '\n\n---\n';
+            body += 'Every link above failed twice: once in the sweep, once in a re-check a minute later.\n\n';
             body += `Detected in scheduled run: ${context.runId}\n`;
             body += `Run URL: ${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
-            // Check if an issue already exists
+            // Check if an issue already exists. listForRepo also returns pull
+            // requests, which must not be commented on as if they were reports.
             const issues = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
               labels: 'documentation,broken-links'
             });
+            const open = issues.data.filter((i) => !i.pull_request);
 
-            if (issues.data.length === 0) {
+            if (open.length === 0) {
               // Create new issue
               await github.rest.issues.create({
                 owner: context.repo.owner,
@@ -124,8 +177,45 @@ jobs:
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: issues.data[0].number,
+                issue_number: open[0].number,
                 body: `### New broken links detected\n\n${body}`
+              });
+            }
+
+      # Without this the report is write-only: an issue opened for one bad week
+      # stays open after the links recover, and every later failure piles onto
+      # it. Close it once a sweep comes back clean.
+      - name: Close broken-link issue when the sweep is clean (scheduled run)
+        # steps.lychee.outcome guards the `failIfEmpty` case: a broken glob
+        # reports exit_code 0 while failing the step, and must not read as
+        # "no broken links".
+        if: always() && github.event_name == 'schedule' && steps.lychee.outcome == 'success' && (steps.lychee.outputs.exit_code == '0' || steps.recheck.outputs.confirmed == 'false')
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'documentation,broken-links'
+            });
+            const open = issues.data.filter((i) => !i.pull_request);
+
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            for (const issue of open) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `### ✅ All links healthy\n\nThe scheduled sweep found no broken links, so this report no longer has anything actionable.\n\nRun URL: ${runUrl}`
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'completed'
               });
             }
 
@@ -134,5 +224,16 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: link-check-report
-          path: lychee-report.md
+          path: |
+            lychee-report.md
+            lychee-recheck.md
+          if-no-files-found: ignore
           retention-days: 30
+
+      # The job's verdict, decided here rather than by the checker: broken links
+      # block a PR, while a scheduled sweep only files the issue above.
+      - name: Fail on confirmed broken links
+        if: always() && github.event_name == 'pull_request' && steps.recheck.outputs.confirmed == 'true'
+        run: |
+          echo "::error::Broken links confirmed by a second check. See the job summary."
+          exit 1


### PR DESCRIPTION
Closes #232.

## Why

#232 was open from 2026-06-08 to today with nothing actionable in it:

| Reported | Type | Status |
|---|---|---|
| `conventionalcommits.org` (issue body) | connection failure | transient; returns 200 |
| `docs.anthropic.com/claude-code/commands` | real 404 | fixed in #345 (`e3fb578`) |
| `chadd.org` | connection failure | transient; returns 200 |

Two of three findings were the network being briefly unavailable to a CI runner, and the one real finding was fixed six weeks before this review — but the workflow had no path back to closed, so the issue kept accumulating weekly comments.

## What changed

**Report only what fails twice.** A first-pass failure re-checks just the failing URLs after a 60s pause; links that recover are dropped. The URL list goes to lychee as an *input file*, not as arguments — passing a URL as an argument makes lychee crawl that page and check the links inside it instead of checking the URL itself.

**Close the issue when a sweep is clean.** Guarded on `steps.lychee.outcome` so a `failIfEmpty` glob break (exit_code 0, step failed) cannot be read as "links healthy".

**The workflow decides the job outcome, not the checker.** `fail: ${{ github.event_name == 'pull_request' }}` never took effect: lychee-action v2.0.2's `entrypoint.sh` set `INPUT_FAIL=true` unconditionally inside its `failIfEmpty` block, so scheduled runs failed the job against the comment's stated intent — and both reporting steps, gated on `if: failure()`, ran *only* because of that bug. Upstream fixed it (`should_fail_because_empty`), so the next version bump would have silently stopped the issue reporting. Reporting now gates on the action's `exit_code` output, and a final step fails PRs on confirmed breakage.

**Bump `lycheeverse/lychee-action` v2.0.2 → v2.9.0** (lychee v0.16.1 → v0.24.2). Required with it:
- drop `--exclude-mail`, removed in lychee 0.18 — mailto links are excluded by default now
- `checkbox: false`, so the report keeps the shape the re-check step parses

## Validation

- `actionlint` clean
- lychee v0.24.2 run locally with the new args: `--exclude-mail` rejected (`unexpected argument`), confirming the flag had to go; without it, `--dump '**/*.md'` yields 167 links and zero `mailto:` entries
- re-check logic simulated against a report holding one transient failure and one real 404: the 404 is confirmed, the transient one is dropped

## Not addressed here

Renovate runs every 6h and succeeds but has produced no `github-actions` PRs at all — `checkout@v4`, `github-script@v7`, `upload-artifact@v4` are all stale alongside the lychee pin this PR bumps by hand. The likely cause is the Renovate token lacking the `workflow` permission, which blocks pushes touching `.github/workflows/`. Worth checking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxC7y6uYt8iexj6Qv5ovhp

---
_Generated by [Claude Code](https://claude.ai/code/session_01BxC7y6uYt8iexj6Qv5ovhp)_