### PR TITLE
fix(claude): stop apostrophes in claude --help from breaking the zsh completion

### DIFF
--- a/docs/claude-completion.md
+++ b/docs/claude-completion.md
@@ -12,10 +12,14 @@ The completion system automatically generates zsh completion functions for the C
 - **Location**: `scripts/generate-claude-completion-simple.sh`
 - **Purpose**: Parses `claude --help` and subcommand help outputs to generate zsh completion functions
 - **Features**:
-  - Extracts commands, options, and descriptions automatically
-  - Handles nested subcommands (config, mcp, install)
-  - Provides dynamic completion for models, config keys, and MCP servers
-  - Includes proper argument completion for complex commands
+  - Extracts commands, options, and descriptions automatically, joining
+    descriptions that `--help` wraps across several lines
+  - Handles nested subcommands (`mcp`, `install`, and `config` while the CLI
+    still has it), skipping any subcommand the CLI no longer defines
+  - Emits one candidate per alias, so `plugin|plugins` completes as both
+  - Quotes every extracted description, so an apostrophe in the help text
+    cannot break the generated zsh syntax
+  - Validates with `zsh -n` before replacing the committed completion
 
 ### 2. Chezmoi Integration
 - **Location**: `run_onchange_update-claude-completion.sh`
@@ -62,7 +66,6 @@ source ~/.zfunc/_claude
 
 # Test completion
 claude <TAB>
-claude config <TAB>
 claude mcp <TAB>
 ```
 
@@ -71,20 +74,25 @@ claude mcp <TAB>
 ### 1. Help Text Parsing
 The script runs these commands to gather information:
 - `claude --help` - Main command options and subcommands
-- `claude config --help` - Config subcommand structure
 - `claude mcp --help` - MCP subcommand structure
+- `claude config --help` - Config subcommand structure, **when it exists**. An
+  unknown subcommand makes the CLI print the top-level help instead of failing,
+  so the generator only harvests a subcommand whose usage line names it. As of
+  Claude Code 2.1.259 `config` is gone, and the generated completion omits the
+  `config` branch entirely.
 
 ### 2. Dynamic Completion
 For certain completions, the script attempts to get live data:
 - **Models**: Tries to detect available models, falls back to known ones
-- **Config Keys**: Attempts to list actual config keys via `claude config list`
+- **Config Keys**: Completed from a static list, emitted only when the CLI
+  still has a `config` subcommand
 - **MCP Servers**: Tries to get server list via `claude mcp list`
 
 ### 3. Completion Structure
 The generated completion supports:
 - Main command options (`--model`, `--debug`, etc.)
-- Subcommands (`config`, `mcp`, `install`)
-- Subcommand options (`config set --global`)
+- Subcommands (`mcp`, `install`, and `config` when present)
+- Subcommand options (`mcp add --scope`)
 - Context-aware argument completion
 - Help text for all options and commands
 
@@ -102,6 +110,11 @@ If completion doesn't work:
 2. Run the generator manually to see any error messages
 3. Verify Claude CLI is available: `which claude`
 4. Check the generated completion file for syntax errors: `zsh -n ~/.zfunc/_claude`
+
+If `chezmoi apply` fails with `Generated completion has syntax errors`, the
+generator refused to publish and named a temp file holding the rejected output;
+`zsh -n <that file>` prints the offending line. The committed
+`dot_zfunc/_claude` is left at its last good version.
 
 ### Customization
 To customize the completion:

--- a/dot_zfunc/_claude
+++ b/dot_zfunc/_claude
@@ -11,18 +11,26 @@ _claude() {
 
     commands=(
         'agents:Manage background agents'
+        'attach:Open a background session in this terminal. <id> is the short id that `claude --bg` prints and `claude agents` lists'
         'auth:Manage authentication'
-        'auto-mode:Inspect or reset auto mode classifier'
-        'doctor:Check the health of your Claude Code'
-        'gateway:Run the enterprise auth/telemetry'
-        'import:Import config from another AI coding'
-        'install:Install Claude Code native build. Use'
+        'auto-mode:Inspect or reset auto mode classifier configuration'
+        'doctor:Check the health of your Claude Code installation. Reads settings files in the current directory without a trust prompt. For a full checkup that can also fix issues, run /doctor in a session.'
+        'gateway:Run the enterprise auth/telemetry gateway'
+        'import:Import config from another AI coding agent into Claude Code'
+        'install:Install Claude Code native build. Use [target] to specify version (stable, latest, or specific version)'
+        'logs:Print a background session'\''s recent terminal output'
         'mcp:Configure and manage MCP servers'
-        'plugin|plugins:Manage Claude Code plugins'
+        'plugin:Manage Claude Code plugins'
+        'plugins:Manage Claude Code plugins'
         'project:Manage Claude Code project state'
-        'setup-token:Set up a long-lived authentication token'
-        'ultrareview:Run a cloud-hosted multi-agent code'
-        'update|upgrade:Check for updates and install if'
+        'respawn:Restart a background session, or all of them with --all, so it runs the current Claude Code version'
+        'rm:Delete a background session, and its worktree when that is safe. Works on sessions that have already exited'
+        'setup-token:Set up a long-lived authentication token (requires Claude subscription)'
+        'stop:Stop a background session. Its conversation is kept: `claude attach <id>` opens it again, `claude --resume` works once it is stopped'
+        'kill:Stop a background session. Its conversation is kept: `claude attach <id>` opens it again, `claude --resume` works once it is stopped'
+        'ultrareview:Run a cloud-hosted multi-agent code review of the current branch (or a PR number / base branch) and print the findings'
+        'update:Check for updates and install if available'
+        'upgrade:Check for updates and install if available'
     )
 
     _arguments -C \
@@ -83,9 +91,6 @@ _claude() {
             ;;
         args)
             case $words[1] in
-                config)
-                    _claude_config
-                    ;;
                 mcp)
                     _claude_mcp
                     ;;
@@ -100,80 +105,19 @@ _claude() {
     esac
 }
 
-_claude_config() {
-    local -a config_commands
-    config_commands=(
-        'agents:Manage background agents'
-        'auth:Manage authentication'
-        'auto-mode:Inspect or reset auto mode classifier'
-        'doctor:Check the health of your Claude Code'
-        'gateway:Run the enterprise auth/telemetry'
-        'import:Import config from another AI coding'
-        'install:Install Claude Code native build. Use'
-        'mcp:Configure and manage MCP servers'
-        'plugin|plugins:Manage Claude Code plugins'
-        'project:Manage Claude Code project state'
-        'setup-token:Set up a long-lived authentication token'
-        'ultrareview:Run a cloud-hosted multi-agent code'
-        'update|upgrade:Check for updates and install if'
-    )
-
-    _arguments -C \
-        '(-h --help)'{-h,--help}'[Display help for command]' \
-        '1: :->subcommand' \
-        '*: :->args' && return 0
-
-    case $state in
-        subcommand)
-            _describe -t config-commands 'config commands' config_commands
-            ;;
-        args)
-            case $words[2] in
-                get)
-                    _arguments \
-                        '(-g --global)'{-g,--global}'[Use global config]' \
-                        '1:key:_claude_config_keys'
-                    ;;
-                set)
-                    _arguments \
-                        '(-g --global)'{-g,--global}'[Use global config]' \
-                        '1:key:_claude_config_keys' \
-                        '2:value:'
-                    ;;
-                remove|rm)
-                    _arguments \
-                        '(-g --global)'{-g,--global}'[Use global config]' \
-                        '1:key:_claude_config_keys' \
-                        '*:values:'
-                    ;;
-                list|ls)
-                    _arguments \
-                        '(-g --global)'{-g,--global}'[Use global config]'
-                    ;;
-                add)
-                    _arguments \
-                        '(-g --global)'{-g,--global}'[Use global config]' \
-                        '1:key:_claude_config_keys' \
-                        '*:values:'
-                    ;;
-            esac
-            ;;
-    esac
-}
-
 _claude_mcp() {
     local -a mcp_commands
     mcp_commands=(
-        'add:<name> <commandOrUrl> Add an MCP server to Claude Code.'
-        'add-from-claude-desktop:Import MCP servers from Claude Desktop'
-        'add-json:<name> <json> Add an MCP server (stdio or SSE) with a'
-        'get:<name> Get details about an MCP server.'
+        'add:Add an MCP server to Claude Code.'
+        'add-from-claude-desktop:Import MCP servers from Claude Desktop (Mac and WSL only)'
+        'add-json:Add an MCP server (stdio, SSE, HTTP, or WebSocket) with a JSON string'
+        'get:Get details about an MCP server. Unapproved .mcp.json servers are shown as ⏸ Pending approval and not connected to; approved servers are health-checked unless disabled for this project.'
         'help:display help for command'
-        'list:List configured MCP servers. Unapproved'
-        'login:<name> Authenticate with an MCP server (HTTP,'
-        'logout:<name> Clear stored OAuth credentials for an'
-        'remove:<name> Remove an MCP server'
-        'reset-project-choices:Reset all approved and rejected'
+        'list:List configured MCP servers. Unapproved .mcp.json servers are shown as ⏸ Pending approval and not connected to; approved servers are health-checked unless disabled for this project.'
+        'login:Authenticate with an MCP server (HTTP, SSE, or claude.ai connector)'
+        'logout:Clear stored OAuth credentials for an MCP server'
+        'remove:Remove an MCP server'
+        'reset-project-choices:Reset all approved and rejected project-scoped (.mcp.json) servers within this project'
         'serve:Start the Claude Code MCP server'
     )
 
@@ -264,22 +208,6 @@ _claude_models() {
         'claude-haiku-4-5:Claude Haiku 4.5'
     )
     _describe -t models 'claude models' models
-}
-
-# Helper function to complete config keys
-_claude_config_keys() {
-    local -a config_keys
-    config_keys=(
-        'theme:UI theme setting'
-        'allowedTools:Allowed tool names'
-        'disallowedTools:Disallowed tool names'
-        'hasTrustDialogAccepted:Trust dialog acceptance status'
-        'hasCompletedProjectOnboarding:Project onboarding status'
-        'permissionMode:Default permission mode'
-        'model:Default model'
-        'fallbackModel:Fallback model'
-    )
-    _describe -t config-keys 'config keys' config_keys
 }
 
 # Helper function to complete MCP server names

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -6,8 +6,8 @@ Utility scripts for Claude Code infrastructure automation.
 
 | Script | Purpose |
 |--------|---------|
-| `generate-claude-completion.sh` | Generate zsh completions for Claude CLI from `--help` output → `dot_zfunc/_claude` |
-| `generate-claude-completion-simple.sh` | Simplified fallback completion generator with hardcoded lists |
+| `generate-claude-completion-simple.sh` | **The one in use.** Generates zsh completions for Claude CLI from `--help` output → `dot_zfunc/_claude`; run by `run_onchange_update-claude-completion.sh.tmpl` on every `chezmoi apply` |
+| `generate-claude-completion.sh` | Older, unwired alternative writing the same `dot_zfunc/_claude`. Nothing invokes it; running it by hand would overwrite the maintained file |
 | `migrate-command-namespaces.sh` | Migrate commands from flat structure to namespace hierarchy (supports `--dry-run`) |
 | `update-command-references.sh` | Update markdown references after namespace migration (supports `--dry-run`) |
 | `smoke-test-docker.sh` | Docker-based smoke tests for dotfiles |

--- a/scripts/generate-claude-completion-simple.sh
+++ b/scripts/generate-claude-completion-simple.sh
@@ -26,47 +26,98 @@ check_claude_cli() {
     log "Found claude CLI: $(claude --version 2>/dev/null | head -1 || echo 'unknown version')"
 }
 
-# Generate the complete zsh completion file using the current working version as a template
-# but with updated help text parsing
+# awk program that turns a `--help` "Commands:" block into TAB-separated
+# `name<TAB>description` records. Handles the three shapes the Claude CLI
+# emits: argument specs after the name (`attach <id>`, `import [options]
+# [source]`), descriptions wrapped across continuation lines, and alias
+# names (`plugin|plugins`) that must become one completion candidate each.
+# shellcheck disable=SC2016  # awk program text; $0/$1 are awk fields, not shell
+readonly AWK_PARSE_COMMANDS='
+function flush(   n, i, parts) {
+    if (cmd == "") return
+    gsub(/[ \t]+/, " ", desc)
+    sub(/^ +/, "", desc)
+    sub(/ +$/, "", desc)
+    n = split(cmd, parts, "|")
+    for (i = 1; i <= n; i++) printf "%s\t%s\n", parts[i], desc
+    cmd = ""
+    desc = ""
+    desccol = 0
+}
+/^Commands:/ && !inblock { inblock = 1; next }
+!inblock { next }
+# Any unindented line starts a new help section and ends the command block.
+/^[^ \t]/ { flush(); inblock = 0; next }
+/^[ \t]*$/ { next }
+{
+    # A command entry is indented exactly two spaces and separates its name
+    # from its description with a run of two or more spaces.
+    if ($0 ~ /^  [A-Za-z0-9]/) {
+        rest = substr($0, 3)
+        if (match(rest, /  +/)) {
+            flush()
+            cmd = substr(rest, 1, RSTART - 1)
+            sub(/ .*$/, "", cmd)          # drop `[options]` / `<id>` arg specs
+            desc = substr(rest, RSTART + RLENGTH)
+            desccol = 2 + RSTART + RLENGTH
+            next
+        }
+        next
+    }
+    # A continuation line is indented at least as far as the description
+    # column, which is what separates wrapped text from embedded examples.
+    if (cmd != "") {
+        match($0, /^ */)
+        if (RLENGTH >= desccol - 1) {
+            line = $0
+            sub(/^ +/, "", line)
+            desc = desc " " line
+        }
+    }
+}
+END { flush() }
+'
+
+# Read a "Commands:" block on stdin and emit zsh `_describe` array entries,
+# quoting each field so apostrophes in descriptions cannot terminate the
+# surrounding zsh single-quoted string.
+parse_commands() {
+    awk "$AWK_PARSE_COMMANDS" | while IFS=$'\t' read -r cmd desc; do
+        printf "        '%s:%s'\n" "${cmd//\'/\'\\\'\'}" "${desc//\'/\'\\\'\'}"
+    done
+}
+
+# Print a subcommand's help, or nothing when the subcommand does not exist.
+# An unknown subcommand makes the Claude CLI fall back to the top-level help,
+# which would otherwise be harvested as if it were the subcommand's own.
+subcommand_help() {
+    local sub="$1" out
+    out=$(claude "$sub" --help 2>/dev/null) || return 0
+    grep -q "^Usage: claude ${sub} " <<<"$out" || return 0
+    printf '%s\n' "$out"
+}
+
+# Generate the complete zsh completion file: a static skeleton with the
+# command lists extracted from the CLI's own `--help` output.
 generate_completion() {
     log "Generating updated Claude CLI completion..."
 
-    # Create directory if needed
     mkdir -p "$(dirname "$COMPLETION_FILE")"
 
-    # Get current help outputs
-    local main_help=$(claude --help 2>/dev/null)
-    local config_help=$(claude config --help 2>/dev/null)
-    local mcp_help=$(claude mcp --help 2>/dev/null)
+    local main_commands config_commands mcp_commands
+    main_commands=$(claude --help 2>/dev/null | parse_commands)
+    config_commands=$(subcommand_help config | parse_commands)
+    mcp_commands=$(subcommand_help mcp | parse_commands)
 
-    # Extract commands from main help
-    local main_commands=$(echo "$main_help" | sed -n '/^Commands:/,/^$/p' | grep -E '^  [a-z]' | sed 's/^  //' | while read -r line; do
-        cmd=$(echo "$line" | awk '{print $1}')
-        desc=$(echo "$line" | cut -d' ' -f2- | sed 's/^ *//')
-        # Clean up descriptions to remove extra formatting
-        desc=$(echo "$desc" | sed 's/\[[^]]*\]//g' | sed 's/  */ /g' | sed 's/^ *//' | sed 's/ *$//')
-        echo "        '$cmd:$desc'"
-    done)
+    [[ -n "$main_commands" ]] || error "No commands found in 'claude --help' output"
+    [[ -n "$mcp_commands" ]] || error "No commands found in 'claude mcp --help' output"
 
-    # Extract config commands
-    local config_commands=$(echo "$config_help" | sed -n '/^Commands:/,/^$/p' | grep -E '^  [a-z]' | sed 's/^  //' | while read -r line; do
-        cmd=$(echo "$line" | awk '{print $1}')
-        desc=$(echo "$line" | cut -d' ' -f2- | sed 's/^ *//')
-        # Clean up descriptions
-        desc=$(echo "$desc" | sed 's/\[[^]]*\]//g' | sed 's/  */ /g' | sed 's/^ *//' | sed 's/ *$//')
-        echo "        '$cmd:$desc'"
-    done)
+    # Build into a temporary file so a failed validation never leaves a
+    # broken completion behind in the source tree.
+    local tmp
+    tmp=$(mktemp "${TMPDIR:-/tmp}"/_claude.XXXXXX)
 
-    # Extract MCP commands
-    local mcp_commands=$(echo "$mcp_help" | sed -n '/^Commands:/,/^$/p' | grep -E '^  [a-z]' | sed 's/^  //' | while read -r line; do
-        cmd=$(echo "$line" | awk '{print $1}')
-        desc=$(echo "$line" | cut -d' ' -f2- | sed 's/^ *//')
-        # Clean up descriptions
-        desc=$(echo "$desc" | sed 's/\[[^]]*\]//g' | sed 's/  */ /g' | sed 's/^ *//' | sed 's/ *$//')
-        echo "        '$cmd:$desc'"
-    done)
-
-cat > "$COMPLETION_FILE" << 'COMPLETION_EOF'
+cat > "$tmp" << 'COMPLETION_EOF'
 #compdef claude
 
 # Zsh completion for Claude Code CLI
@@ -81,10 +132,9 @@ _claude() {
     commands=(
 COMPLETION_EOF
 
-    # Add the dynamically extracted commands
-    echo "$main_commands" >> "$COMPLETION_FILE"
+    printf '%s\n' "$main_commands" >> "$tmp"
 
-cat >> "$COMPLETION_FILE" << 'COMPLETION_EOF'
+cat >> "$tmp" << 'COMPLETION_EOF'
     )
 
     _arguments -C \
@@ -145,9 +195,17 @@ cat >> "$COMPLETION_FILE" << 'COMPLETION_EOF'
             ;;
         args)
             case $words[1] in
+COMPLETION_EOF
+
+    if [[ -n "$config_commands" ]]; then
+cat >> "$tmp" << 'COMPLETION_EOF'
                 config)
                     _claude_config
                     ;;
+COMPLETION_EOF
+    fi
+
+cat >> "$tmp" << 'COMPLETION_EOF'
                 mcp)
                     _claude_mcp
                     ;;
@@ -161,16 +219,19 @@ cat >> "$COMPLETION_FILE" << 'COMPLETION_EOF'
             ;;
     esac
 }
+COMPLETION_EOF
+
+    if [[ -n "$config_commands" ]]; then
+cat >> "$tmp" << 'COMPLETION_EOF'
 
 _claude_config() {
     local -a config_commands
     config_commands=(
 COMPLETION_EOF
 
-    # Add config commands
-    echo "$config_commands" >> "$COMPLETION_FILE"
+    printf '%s\n' "$config_commands" >> "$tmp"
 
-cat >> "$COMPLETION_FILE" << 'COMPLETION_EOF'
+cat >> "$tmp" << 'COMPLETION_EOF'
     )
 
     _arguments -C \
@@ -215,16 +276,19 @@ cat >> "$COMPLETION_FILE" << 'COMPLETION_EOF'
             ;;
     esac
 }
+COMPLETION_EOF
+    fi
+
+cat >> "$tmp" << 'COMPLETION_EOF'
 
 _claude_mcp() {
     local -a mcp_commands
     mcp_commands=(
 COMPLETION_EOF
 
-    # Add MCP commands
-    echo "$mcp_commands" >> "$COMPLETION_FILE"
+    printf '%s\n' "$mcp_commands" >> "$tmp"
 
-cat >> "$COMPLETION_FILE" << 'COMPLETION_EOF'
+cat >> "$tmp" << 'COMPLETION_EOF'
     )
 
     _arguments -C \
@@ -316,6 +380,10 @@ _claude_models() {
     _describe -t models 'claude models' models
 }
 
+COMPLETION_EOF
+
+    if [[ -n "$config_commands" ]]; then
+cat >> "$tmp" << 'COMPLETION_EOF'
 # Helper function to complete config keys
 _claude_config_keys() {
     local -a config_keys
@@ -332,6 +400,10 @@ _claude_config_keys() {
     _describe -t config-keys 'config keys' config_keys
 }
 
+COMPLETION_EOF
+    fi
+
+cat >> "$tmp" << 'COMPLETION_EOF'
 # Helper function to complete MCP server names
 _claude_mcp_servers() {
     local -a servers
@@ -359,11 +431,15 @@ _claude_mcp_servers() {
 _claude "$@"
 COMPLETION_EOF
 
-    # Validate the generated completion file
-    if ! zsh -n "$COMPLETION_FILE" 2>/dev/null; then
-        error "Generated completion file has syntax errors"
+    # Validate before publishing, so a syntax error never lands in the source
+    # tree. zsh's own diagnostic is the only thing that names the bad line.
+    # Keep the rejected output outside the chezmoi source tree: any file in
+    # dot_zfunc/ becomes a managed target on the next apply.
+    if ! zsh -n "$tmp"; then
+        error "Generated completion has syntax errors; kept for inspection at $tmp"
     fi
 
+    mv "$tmp" "$COMPLETION_FILE"
     success "Updated Claude CLI completion: $COMPLETION_FILE"
 }
 


### PR DESCRIPTION
## What

Rework how `scripts/generate-claude-completion-simple.sh` parses the `Commands:` block of `claude --help`, and validate the result before it replaces the committed completion.

## Why

`chezmoi apply` was failing:

```
[chezmoi] Updating Claude CLI zsh completion...
[ERROR] Generated completion file has syntax errors
[chezmoi] Failed to update Claude CLI completion
chezmoi: update-claude-completion.sh: exit status 1
```

The generator copied `--help` descriptions verbatim into single-quoted zsh `_describe` entries. The apostrophe in `Print a background session's recent terminal output` closed the quote, and the next `|` — from the `plugin|plugins` alias two lines down — reached the parser unquoted:

```
dot_zfunc/_claude:23: parse error near `|'
```

Because the file was written into the source tree *before* `zsh -n` ran, the failing apply also left a broken `dot_zfunc/_claude` in the working tree.

Three further defects were visible in the same output: descriptions were truncated at the first line (`'doctor:Check the health of your Claude Code'`), argument specs leaked into the description text (`'attach:<id> Open a background session in this'`), and the config array was being filled from the wrong help output.

## How

- **Quote both fields.** `parse_commands` escapes `'` as `'\''` in the command name and the description, so help text can no longer terminate the surrounding zsh string.
- **Join wrapped descriptions.** An awk pass tracks the column where each description starts and appends continuation lines indented to at least that column — which also keeps `claude mcp add`'s embedded example block out of the list, since those lines sit at a shallower indent.
- **Drop argument specs** (`<id>`, `[options] [source]`) from the command token.
- **Split alias names**, so `plugin|plugins` and `stop|kill` each yield one candidate per alias.
- **Skip subcommands the CLI no longer defines.** An unknown subcommand makes the CLI print the top-level help instead of failing, so `claude config --help` was silently filling the config array with the main command list. `config` is gone as of 2.1.259, so the generated file now omits the `config` branch, `_claude_config`, and `_claude_config_keys` entirely.
- **Validate before publishing.** The file is built in a temp file and moved into place only after `zsh -n` passes; the error surfaces zsh's own diagnostic rather than discarding it with `2>/dev/null`, and the last good completion is left untouched.

Docs updated: `docs/claude-completion.md` (config now conditional, plus a troubleshooting entry for the syntax-error path) and `scripts/CLAUDE.md`, whose table had the two generators' roles backwards — `-simple` is the one wired into `run_onchange_update-claude-completion.sh.tmpl`, and `generate-claude-completion.sh` is unwired.

## Verification

- `./scripts/generate-claude-completion-simple.sh` exits 0; `zsh -n dot_zfunc/_claude` and `zsh -n ~/.zfunc/_claude` are clean.
- `chezmoi apply` exits 0 and `chezmoi status` is empty afterwards.
- `_claude` autoloads in a zsh with `~/.zfunc` on `fpath`.
- The conditional config branch was exercised by standing `claude mcp --help` in for `config`, producing a valid file with the `config)` arm, `_claude_config`, and `_claude_config_keys` present.
- The validation-failure path was exercised with an executable `zsh` stub printing a sentinel: the generator refused to publish, named the rejected temp file, and left the existing completion byte-identical.
- `shellcheck` reports the same three codes as before the change (SC2034/SC2129/SC2155, all pre-existing); `pre-commit run --files` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjaJpyB2r1NCDmpXBsBK72
