### PR TITLE
feat(claude): keep the chezmoi config spine fresh and worktree-safe

### DIFF
--- a/.claude/scripts/post-sync.sh
+++ b/.claude/scripts/post-sync.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# post-sync.sh — make a freshly pulled chezmoi source tree actually EFFECTIVE.
+#
+# Run by .claude/scripts/repos-sync-nudge.sh (and by ~/repos/.routines/spine-sync.sh)
+# after a SUCCESSFUL fast-forward, never on its own schedule. A pulled rule that
+# is never applied is not in effect: `~/.claude/rules/*` is rendered from
+# `exact_dot_claude/rules/*`, so a `git pull` here changes nothing a session
+# reads until `chezmoi apply` runs.
+#
+# Scope is deliberately `~/.claude` only — the Claude Code config spine this
+# whole freshness chain exists for. Applying the rest of the dotfiles tree
+# unattended is a much larger blast radius and is not what a pull of a rule file
+# warrants.
+#
+# The pre-flight is this repo's own documented order (status → decide → apply),
+# from .claude/rules/chezmoi-apply-hazards.md:
+#
+#   * `chezmoi status` column 1 == M  →  the TARGET was edited since chezmoi last
+#     wrote it. Applying would silently overwrite that edit. Same discriminator
+#     exact_dot_claude/hooks/chezmoi-drift-guard.sh uses; column 2 alone is a
+#     pending SOURCE edit, which is the normal case this script exists to apply.
+#   * A `D` in either column  →  a deletion is in play (an `exact_` directory
+#     purging an unmanaged target, or a target already removed). Never resolve
+#     that unattended.
+#
+# Either case: REPORT ONLY, exit 0, and let a human look. `--force` must never
+# appear in this file — it only suppresses the prompt that is protecting
+# target-side edits, and adds no safety. `chezmoi update` must never be used
+# either: it defaults to `git pull --autostash --rebase`, which would autostash a
+# working tree this script has no business touching.
+set -uo pipefail
+
+TARGET="${HOME}/.claude"
+
+command -v chezmoi >/dev/null 2>&1 || exit 0
+[ -d "$TARGET" ] || exit 0
+
+status="$(chezmoi status "$TARGET" 2>/dev/null)" || {
+    echo "post-sync: 'chezmoi status ${TARGET}' failed — skipping apply."
+    exit 0
+}
+
+# Nothing pending and nothing drifted: the quiet, overwhelmingly common case.
+[ -z "$status" ] && exit 0
+
+# Column 1 is the target-vs-last-written state, column 2 the source-vs-target
+# delta. Both are single characters; the path starts at column 4.
+blockers="$(printf '%s\n' "$status" | awk '
+    { c1 = substr($0,1,1); c2 = substr($0,2,1); p = substr($0,4) }
+    c1 == "M" { printf "  %s  (target edited since chezmoi last wrote it)\n", p; next }
+    c1 == "D" { printf "  %s  (target deleted since chezmoi last wrote it)\n", p; next }
+    c2 == "D" { printf "  %s  (apply would DELETE this target)\n", p; next }
+')"
+
+if [ -n "$blockers" ]; then
+    echo "post-sync: NOT applying — ~/.claude has local drift or a pending deletion:"
+    printf '%s\n' "$blockers"
+    echo "  Review with: chezmoi diff ~/.claude   Capture edits with: just capture-drift"
+    exit 0
+fi
+
+pending="$(printf '%s\n' "$status" | awk 'substr($0,2,1) != " " { print substr($0,4) }')"
+[ -z "$pending" ] && exit 0
+count="$(printf '%s\n' "$pending" | grep -c .)"
+
+if ! out="$(chezmoi apply "$TARGET" 2>&1)"; then
+    echo "post-sync: 'chezmoi apply ${TARGET}' failed:"
+    printf '%s\n' "$out"
+    exit 1
+fi
+
+echo "post-sync: applied ${count} file(s) to ~/.claude (effective next session, not this one):"
+printf '%s\n' "$pending" | sed 's/^/  /'
+
+# The apply is only believable if the tree is clean afterwards — a non-force
+# apply SKIPS drifted files and still exits 0, so exit status alone proves
+# nothing about whether the tree synced.
+left="$(chezmoi status "$TARGET" 2>/dev/null | awk 'substr($0,2,1) != " " { print substr($0,4) }')"
+if [ -n "$left" ]; then
+    echo "post-sync: still out of sync after apply (chezmoi skipped these):"
+    printf '%s\n' "$left" | sed 's/^/  /'
+fi
+exit 0

--- a/.claude/scripts/repos-sync-nudge.sh
+++ b/.claude/scripts/repos-sync-nudge.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# repos-sync-nudge.sh — SessionStart freshness check for a shared-config repo.
+#
+# Installed in repos that hold CLAUDE.md guidance and .claude/ rules inherited
+# by every project underneath them (~/repos, laurigates/comfyui-nodes). A stale
+# checkout silently runs old rules, and unpushed edits silently never reach the
+# other sessions/machines, so the commit → PR → merge → pull cycle has to stay
+# prompt. This hook is the nudge that keeps it prompt.
+#
+# Repo-agnostic: it locates its own repo from BASH_SOURCE, so the same file is
+# dropped into each such repo (self-contained on purpose — these repos are
+# cloned to other hosts where a cross-repo path would not resolve).
+#
+# Behaviour:
+#   * Debounced `git fetch` (default 15 min) so most session starts cost nothing.
+#   * When the tree is CLEAN, on main, with no unpushed commits and no coworker
+#     markers, it fast-forwards automatically (`git merge --ff-only`, no network)
+#     and says so. This is the half that needs no judgment.
+#   * Every other state — dirty tree, unpushed commits, other branch, coworker
+#     marker present — is REPORTED ONLY. A dirty tree is exactly the "another
+#     agent is mid-work here" signal, and nothing is touched then.
+#   * After a SUCCESSFUL fast-forward only, an optional per-repo hook
+#     .claude/scripts/post-sync.sh is run and its output printed. A pull is not
+#     the same thing as the pulled content being in effect — the chezmoi source
+#     repo uses this to run `chezmoi apply`, since a rule that is pulled but
+#     never applied does nothing. Keeping the hook generic is what lets this
+#     script stay byte-identical across every repo it is dropped into.
+#
+# Pulled files land for the NEXT session; an already-running session does not
+# re-read them. Same model as claude-plugins-refresh.sh.
+#
+#   --force   ignore the debounce stamp (manual runs / verification)
+#
+# Env knobs:
+#   REPOS_SYNC_NUDGE_INTERVAL_MINUTES  fetch debounce window (default 15)
+#   REPOS_SYNC_NUDGE_NO_PULL=1         report only; never fast-forward
+set -uo pipefail
+
+INTERVAL_MIN="${REPOS_SYNC_NUDGE_INTERVAL_MINUTES:-15}"
+
+# Repo root = two levels up from .claude/scripts/. Never `cd`; use `git -C`.
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "${HERE}/../.." && pwd)"
+LABEL="$(basename "$REPO")"
+STAMP="${HOME}/.cache/repos-sync-nudge.${LABEL}.stamp"
+
+force=0
+[ "${1:-}" = "--force" ] && force=1
+
+git -C "$REPO" rev-parse --git-dir >/dev/null 2>&1 || exit 0
+
+# --- debounced fetch (network) ------------------------------------------------
+now=$(date +%s)
+interval_s=$(( INTERVAL_MIN * 60 ))
+do_fetch=1
+if [ "$force" -eq 0 ] && [ -f "$STAMP" ]; then
+  last="$(cat "$STAMP" 2>/dev/null || echo 0)"
+  case "$last" in ''|*[!0-9]*) last=0 ;; esac
+  [ $(( now - last )) -lt "$interval_s" ] && do_fetch=0
+fi
+if [ "$do_fetch" -eq 1 ]; then
+  mkdir -p "$(dirname "$STAMP")"
+  printf '%s\n' "$now" > "$STAMP"   # stamp first: concurrent starts don't all fetch
+  timeout 20 git -C "$REPO" fetch --quiet origin main >/dev/null 2>&1 || true
+fi
+
+# --- read state ---------------------------------------------------------------
+branch="$(git -C "$REPO" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')"
+dirty="$(git -C "$REPO" status --porcelain 2>/dev/null)"
+git -C "$REPO" rev-parse --verify --quiet origin/main >/dev/null 2>&1 || exit 0
+behind="$(git -C "$REPO" rev-list --count HEAD..origin/main 2>/dev/null || echo 0)"
+ahead="$(git -C "$REPO" rev-list --count origin/main..HEAD 2>/dev/null || echo 0)"
+
+# Coworker marker (the .git/.claude-session-* convention used by
+# git-plugin:git-coworker-check). Present = another agent claims this checkout.
+gitdir="$(git -C "$REPO" rev-parse --absolute-git-dir 2>/dev/null || echo '')"
+coworker=0
+if [ -n "$gitdir" ] && compgen -G "${gitdir}/.claude-session-*" >/dev/null 2>&1; then
+  coworker=1
+fi
+
+# --- act, or report -----------------------------------------------------------
+# Auto fast-forward only when nothing could be lost and nobody else is working.
+if [ "$branch" = "main" ] && [ -z "$dirty" ] && [ "$ahead" -eq 0 ] \
+   && [ "$behind" -gt 0 ] && [ "$coworker" -eq 0 ] \
+   && [ "${REPOS_SYNC_NUDGE_NO_PULL:-0}" != "1" ]; then
+  if git -C "$REPO" merge --ff-only origin/main >/dev/null 2>&1; then
+    echo "${LABEL}/: fast-forwarded ${behind} commit(s) from origin/main — inherited rules refreshed (effective next session)."
+    post="${REPO}/.claude/scripts/post-sync.sh"
+    if [ -x "$post" ]; then
+      if out="$(timeout 60 bash "$post" 2>&1)"; then
+        [ -n "$out" ] && printf '%s\n' "$out"
+      else
+        echo "${LABEL}/: post-sync.sh exited non-zero — the pull landed, but the repo's post-sync step did not complete."
+        [ -n "$out" ] && printf '%s\n' "$out"
+      fi
+    fi
+    exit 0
+  fi
+  echo "${LABEL}/: ${behind} commit(s) behind origin/main; auto fast-forward failed — run: git -C ${REPO} pull --ff-only"
+  exit 0
+fi
+
+msgs=()
+[ "$behind" -gt 0 ] && msgs+=("${behind} commit(s) behind origin/main — run: git -C ${REPO} pull --ff-only")
+[ "$ahead" -gt 0 ] && msgs+=("${ahead} unpushed commit(s) on ${branch} — push and open a PR so other projects inherit them")
+if [ -n "$dirty" ]; then
+  files="$(printf '%s\n' "$dirty" | awk '{print $NF}' | paste -sd' ' -)"
+  msgs+=("uncommitted changes (${files}) — commit → PR → merge → pull promptly; shared rules only take effect once merged")
+fi
+
+[ "${#msgs[@]}" -eq 0 ] && exit 0
+
+if [ "$coworker" -eq 1 ]; then
+  echo "${LABEL}/ (another Claude session has claimed this checkout — do not stash/reset; report only):"
+else
+  echo "${LABEL}/ shared-config repo:"
+fi
+for m in "${msgs[@]}"; do echo "  - ${m}"; done
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -39,6 +39,11 @@
             "type": "command",
             "command": "bash ~/.claude/hooks/claude-plugins-refresh.sh",
             "timeout": 20
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/scripts/repos-sync-nudge.sh\"",
+            "timeout": 25
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,12 @@ docs/blueprint/work-orders/
 *.key
 .api_tokens
 credentials*
+
+# Claude Code runtime state (managed by /configure:gitignore)
+#
+# .claude/worktrees/ is load-bearing beyond tidiness: .claude/scripts/repos-sync-nudge.sh
+# auto-fast-forwards ONLY when `git status --porcelain` is empty, so an untracked
+# worktree would silently disable this repo's freshness auto-pull.
+.claude/worktrees/
+/worktrees/
+.claude/scheduled_tasks.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,31 @@ Chezmoi dotfiles repository with cross-platform development environment configur
 
 This repo is **public** (`github.com/laurigates/dotfiles`). Never commit private information: secrets/API tokens (use `~/.api_tokens`, sourced by mise), personal hostnames/IPs, internal-only org facts, or machine-specific identifiers. Secret-adjacent files use the chezmoi `private_` prefix and stay out of templates that render to tracked output. When in doubt, leave it out — assume anything committed is world-readable and indexed.
 
+## Work in a Worktree
+
+Make changes to this repo in a Claude Code worktree, not in the main checkout —
+enter one before the first edit of a change task. Reading, answering questions,
+and running `chezmoi diff`/`status` do not need one.
+
+Two mechanical reasons:
+
+- `.claude/scripts/repos-sync-nudge.sh` auto-fast-forwards this checkout only
+  when `git status --porcelain` is empty. Uncommitted work in the main checkout
+  silently switches that freshness auto-pull off — the exact thing the nudge
+  exists to keep running.
+- `worktree.baseRef` is `fresh`, so a worktree branch starts from `origin/main`
+  rather than from wherever this checkout happens to be sitting.
+
+**Inside a worktree, chezmoi needs `--source`.** The source dir is pinned in
+`~/.config/chezmoi/chezmoi.toml` and nothing in the environment overrides it —
+`CHEZMOI_SOURCE_DIR` and `CHEZMOI_SOURCE` are both ignored, only the flag takes
+effect. So a bare `chezmoi apply` from a worktree exits 0 having applied
+**main's** content instead of the edits in front of you, with no error and no
+empty result to notice. Use `just apply` / `just diff` / `just status` (or
+`mise run apply`), which pass `--source "$(git rev-parse --show-toplevel)"` for
+you; `exact_dot_claude/hooks/executable_chezmoi-worktree-source-guard.sh` warns
+when a bare one slips through.
+
 ## Chezmoi Quick Reference
 
 - **Source directory**: `~/.local/share/chezmoi/` (always edit here)

--- a/exact_dot_claude/hooks/executable_chezmoi-worktree-source-guard.sh
+++ b/exact_dot_claude/hooks/executable_chezmoi-worktree-source-guard.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) — WARN (never block) when a bare `chezmoi apply|diff|status`
+# runs from inside a Claude Code worktree, where it will silently operate on the
+# MAIN checkout's content instead of the edits in front of you.
+#
+# Why this is invisible without a guard: chezmoi's source directory is pinned in
+# ~/.config/chezmoi/chezmoi.toml, and NOTHING in the environment overrides it —
+# CHEZMOI_SOURCE_DIR and CHEZMOI_SOURCE are both ignored (verified 2026-09);
+# only the --source flag takes effect. So a worktree under
+# <sourceDir>/.claude/worktrees/<name> is invisible to chezmoi: `chezmoi apply`
+# there exits 0, reports a normal diff, and applies main's version of every file
+# you just changed. There is no error and no empty result to notice.
+#
+# Warn, don't block: operating on main's content is occasionally what you want
+# (checking what the applied state currently is), and the repo's justfile and
+# mise tasks already pass --source for you. Same posture and command-position
+# regex as chezmoi-drift-guard.sh, which is the sibling guard for the *other*
+# silent-overwrite failure (apply clobbering un-captured target edits).
+#
+# Registered user-globally (modify_settings.json) so it fires regardless of cwd.
+set -euo pipefail
+
+input=$(cat)
+
+tool=$(jq -r '.tool_name // empty' <<<"$input" 2>/dev/null || echo "")
+[ "$tool" = "Bash" ] || exit 0
+
+cmd=$(jq -r '.tool_input.command // empty' <<<"$input" 2>/dev/null || echo "")
+[ -z "$cmd" ] && exit 0
+
+# Already explicit about its source tree — nothing to warn about.
+case "$cmd" in
+    *--source*) exit 0 ;;
+esac
+
+# Only fire when the session is actually standing in a Claude Code worktree.
+# `cwd` is the session's directory; a command that cd's elsewhere itself is out
+# of scope (and would have to name that path, which a reader can see).
+cwd=$(jq -r '.cwd // empty' <<<"$input" 2>/dev/null || echo "")
+case "$cwd" in
+    */.claude/worktrees/*) ;;
+    *) exit 0 ;;
+esac
+
+# `chezmoi` must start a command (line start, after ;|&&, inside $( ), or after
+# a shell-wrapper prefix itself at a command position), and the subcommand must
+# follow within the same segment. A bare substring match also fires on commit
+# messages and PR bodies that merely MENTION "chezmoi apply" — the false
+# positive chezmoi-drift-guard.sh was fixed for in 2026-07. Backtick is
+# deliberately not an anchor: markdown inline code in a message body would
+# false-positive.
+printf '%s\n' "$cmd" | grep -qE '(^|[;&|]|[$][(]|(^|[;&|(])[[:space:]]*(bash|sh|zsh|eval)[[:space:]]+(-[a-zA-Z]+[[:space:]]+)*["'"'"'])[[:space:]]*(command[[:space:]]+)?chezmoi[[:space:]][^;&|]*\b(apply|diff|status)\b' || exit 0
+
+msg="Heads-up: this 'chezmoi' command runs from a Claude Code worktree (${cwd}), but chezmoi's source dir is PINNED in ~/.config/chezmoi/chezmoi.toml and no environment variable overrides it — so without --source it will operate on the MAIN checkout's content, silently ignoring the edits in this worktree. It will still exit 0. Either use the repo's recipes ('just apply' / 'just diff' / 'just status', or 'mise run apply'), which pass --source for you, or add: --source \"\$(git rev-parse --show-toplevel)\". If you meant to inspect main's applied state, proceed."
+
+jq -nc --arg c "$msg" '{
+    hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "allow",
+        additionalContext: $c
+    }
+}'
+exit 0

--- a/exact_dot_claude/modify_settings.json
+++ b/exact_dot_claude/modify_settings.json
@@ -239,6 +239,10 @@ read -r -d '' overlay <<'OVERLAY' || true
           {
             "type": "command",
             "command": "bash ~/.claude/hooks/chezmoi-drift-guard.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/chezmoi-worktree-source-guard.sh"
           }
         ]
       },

--- a/justfile
+++ b/justfile
@@ -8,6 +8,17 @@
 
 set shell := ["bash", "-uc"]
 
+# Which chezmoi source tree these recipes operate on.
+#
+# chezmoi's sourceDir is PINNED in ~/.config/chezmoi/chezmoi.toml and NOTHING in
+# the environment overrides it — CHEZMOI_SOURCE_DIR and CHEZMOI_SOURCE are both
+# ignored; only the --source flag takes effect. So a bare `chezmoi apply` run
+# from a Claude Code worktree under .claude/worktrees/ silently applies MAIN's
+# content, not the edits you are looking at. `git rev-parse --show-toplevel`
+# resolves to the worktree root inside a worktree and to the checkout root
+# otherwise, so one expression is correct from both.
+chezmoi_src := `git rev-parse --show-toplevel 2>/dev/null || echo "$HOME/.local/share/chezmoi"`
+
 # Claude plugins recipes (plugins-*) — single source of truth, also imported by
 # the global ~/.user.justfile so `just -g plugins-*` works from any directory.
 import 'private_dot_config/just/plugins.just'
@@ -40,7 +51,7 @@ help:
 [group: "chezmoi"]
 apply target="":
     @echo "{{BLUE}}Applying dotfiles configuration...{{NORMAL}}"
-    chezmoi apply {{ if target != "" { target } else { "" } }} -v
+    chezmoi --source "{{ chezmoi_src }}" apply {{ if target != "" { target } else { "" } }} -v
 
 # Check what changes would be made (alias for status)
 [group: "chezmoi"]
@@ -50,19 +61,19 @@ check: status
 [group: "chezmoi"]
 diff:
     @echo "{{BLUE}}Showing configuration differences...{{NORMAL}}"
-    chezmoi diff
+    chezmoi --source "{{ chezmoi_src }}" diff
 
 # Show status of dotfiles vs current system state
 [group: "chezmoi"]
 status:
     @echo "{{BLUE}}Checking dotfiles status...{{NORMAL}}"
-    chezmoi status
+    chezmoi --source "{{ chezmoi_src }}" status
 
 # Verify dotfiles configuration integrity
 [group: "chezmoi"]
 verify:
     @echo "{{BLUE}}Verifying configuration integrity...{{NORMAL}}"
-    chezmoi verify .
+    chezmoi --source "{{ chezmoi_src }}" verify .
 
 # Drift = `chezmoi status` FIRST column M (target modified since chezmoi last
 # wrote it). A second-column-only change is a pending SOURCE edit, NOT drift —
@@ -74,12 +85,12 @@ verify:
 capture-drift *targets:
     #!/usr/bin/env bash
     set -uo pipefail
-    drift=$(chezmoi status {{targets}} 2>/dev/null | awk 'substr($0,1,1)=="M"{print substr($0,4)}')
+    drift=$(chezmoi --source "{{ chezmoi_src }}" status {{targets}} 2>/dev/null | awk 'substr($0,1,1)=="M"{print substr($0,4)}')
     if [ -z "$drift" ]; then echo "{{GREEN}}No target drift — nothing to capture.{{NORMAL}}"; exit 0; fi
     plain=""; tmpl=""
     while IFS= read -r t; do
         [ -z "$t" ] && continue
-        case "$(chezmoi source-path "$HOME/$t" 2>/dev/null || true)" in
+        case "$(chezmoi --source "{{ chezmoi_src }}" source-path "$HOME/$t" 2>/dev/null || true)" in
             *.tmpl) tmpl+="    chezmoi merge ~/$t"$'\n' ;;
             *)      plain+="    ~/$t"$'\n' ;;
         esac
@@ -95,18 +106,18 @@ capture-drift *targets:
 capture-drift-apply *targets:
     #!/usr/bin/env bash
     set -euo pipefail
-    drift=$(chezmoi status {{targets}} 2>/dev/null | awk 'substr($0,1,1)=="M"{print substr($0,4)}')
+    drift=$(chezmoi --source "{{ chezmoi_src }}" status {{targets}} 2>/dev/null | awk 'substr($0,1,1)=="M"{print substr($0,4)}')
     paths=()
     while IFS= read -r t; do
         [ -z "$t" ] && continue
-        case "$(chezmoi source-path "$HOME/$t" 2>/dev/null || true)" in
+        case "$(chezmoi --source "{{ chezmoi_src }}" source-path "$HOME/$t" 2>/dev/null || true)" in
             *.tmpl) ;;
             *) paths+=("$HOME/$t") ;;
         esac
     done <<< "$drift"
     if [ ${#paths[@]} -eq 0 ]; then echo "{{GREEN}}No non-template target drift to capture.{{NORMAL}}"; exit 0; fi
     echo "{{BLUE}}Capturing into source via re-add:{{NORMAL}}"; printf '  %s\n' "${paths[@]}"
-    chezmoi re-add "${paths[@]}"
+    chezmoi --source "{{ chezmoi_src }}" re-add "${paths[@]}"
     echo "{{GREEN}}Done.{{NORMAL}} Drifted templates still need {{BOLD}}chezmoi merge{{NORMAL}} — see {{BOLD}}just capture-drift{{NORMAL}}."
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/private_dot_config/mise/config.toml.tmpl
+++ b/private_dot_config/mise/config.toml.tmpl
@@ -189,21 +189,54 @@ _.file = "~/.api_tokens"
 # ----------------------------------------------------------------------------
 # Dotfiles Management
 # ----------------------------------------------------------------------------
+# These four tasks resolve the chezmoi SOURCE tree at run time instead of
+# letting chezmoi pick it up from the pinned `sourceDir` in
+# ~/.config/chezmoi/chezmoi.toml. Nothing in the environment overrides that pin
+# — CHEZMOI_SOURCE_DIR and CHEZMOI_SOURCE are both ignored; only --source takes
+# effect — so a bare `chezmoi apply` run from a Claude Code worktree under
+# .claude/worktrees/ silently applies MAIN's content rather than the edits in
+# front of you.
+#
+# This is a GLOBAL mise config, so a task runs from wherever it was invoked and
+# `git rev-parse --show-toplevel` can name any repo at all. The `case` guard is
+# what makes that safe: the git toplevel is used only when it IS the dotfiles
+# source dir or sits underneath it (which is exactly where worktrees live).
+# Everywhere else it falls back to the pinned $DOTFILES_DIR.
 [tasks.apply]
 description = "Apply dotfiles configuration to system"
-run = "chezmoi apply -v"
+run = """
+src="$DOTFILES_DIR"
+top=$(git rev-parse --show-toplevel 2>/dev/null || true)
+case "$top" in "$src"|"$src"/*) src="$top" ;; esac
+chezmoi --source "$src" apply -v
+"""
 
 [tasks.diff]
 description = "Show differences between current state and dotfiles"
-run = "chezmoi diff"
+run = """
+src="$DOTFILES_DIR"
+top=$(git rev-parse --show-toplevel 2>/dev/null || true)
+case "$top" in "$src"|"$src"/*) src="$top" ;; esac
+chezmoi --source "$src" diff
+"""
 
 [tasks.status]
 description = "Show status of dotfiles vs current system state"
-run = "chezmoi status"
+run = """
+src="$DOTFILES_DIR"
+top=$(git rev-parse --show-toplevel 2>/dev/null || true)
+case "$top" in "$src"|"$src"/*) src="$top" ;; esac
+chezmoi --source "$src" status
+"""
 
 [tasks.verify]
 description = "Verify dotfiles configuration integrity"
-run = "chezmoi verify ."
+run = """
+src="$DOTFILES_DIR"
+top=$(git rev-parse --show-toplevel 2>/dev/null || true)
+case "$top" in "$src"|"$src"/*) src="$top" ;; esac
+chezmoi --source "$src" verify .
+"""
 
 [tasks.check]
 alias = "status"

--- a/private_repos/CLAUDE.md
+++ b/private_repos/CLAUDE.md
@@ -11,6 +11,23 @@ This directory contains project repositories organized by owner/origin. Running 
 | `external/` | Third-party clones and forks (bevy, esp-idf, llama.cpp, moodle, etc.) |
 | `archive/` | Inactive/deprecated projects |
 
+## Work in a Worktree
+
+Make changes to **this** repo (its `CLAUDE.md`, `.claude/` rules, scripts and
+skills) in a Claude Code worktree, not in the main checkout — enter one before
+the first edit of a change task. Reading and answering questions do not need one.
+
+The reason is mechanical, not stylistic: `.claude/scripts/repos-sync-nudge.sh`
+auto-fast-forwards this checkout only when `git status --porcelain` is empty, so
+uncommitted work sitting in the main checkout silently switches that freshness
+auto-pull off — in the one repo whose whole job is to hand fresh rules to
+everything underneath it. `worktree.baseRef` is `fresh`, so the branch starts
+from `origin/main` rather than from wherever this checkout is sitting.
+
+This does **not** extend to the nested project repos underneath: those are
+separate checkouts with their own conventions, and `~/repos` deliberately
+ignores them.
+
 ## Key Workflows
 
 ### Repository Activity

--- a/private_repos/CLAUDE.md
+++ b/private_repos/CLAUDE.md
@@ -19,7 +19,9 @@ Run `/repo-activity` (user-global skill) to scan all repos and see recent activi
 
 ### Scheduled Routines
 
-Run `just routines` to list the portfolio's scheduled jobs (macOS LaunchAgents in `.routines/`) with live status — schedule, load state, run count, last exit, last run, and log path. The routines and how to choose a scheduler substrate (LaunchAgent vs cloud routine vs Desktop task) are documented in `.routines/README.md`. These are experimental/stop-gap; promote useful ones to a cloud routine or CI.
+Scheduled work runs on two substrates: **macOS LaunchAgents** defined in `.routines/`, and **Claude scheduled tasks** defined user-globally in `~/.claude/scheduled-tasks/`. `.routines/README.md` inventories both, and documents how to choose a substrate (LaunchAgent vs cloud routine vs Desktop task).
+
+`just routines` lists the LaunchAgents with live status — schedule, load state, run count, last exit, last run, log path. It does not cover the Claude scheduled tasks; their schedule and run history live at claude.ai/code/routines. These are experimental/stop-gap; promote useful ones to a cloud routine or CI.
 
 ### Podio Ticket Management
 


### PR DESCRIPTION
## What

Closes the two missing freshness axes for this repo, and makes it safe to work
in Claude Code worktrees.

Four axes exist. Two were already covered and are untouched here: the plugin
marketplace (`claude-plugins-refresh.sh`, SessionStart, 4 h debounce) and the
`~/repos` / `comfyui-nodes` checkouts (`repos-sync-nudge.sh`, SessionStart,
15 min debounce). The two gaps were this repo itself — it is not under `~/repos`,
so no nudge reached it — and the source→target apply, which nothing ran.

| File | Change |
|---|---|
| `.claude/scripts/repos-sync-nudge.sh` | New. Byte-identical to the copies in `~/repos` and `comfyui-nodes`; registered on `SessionStart` in `.claude/settings.json` |
| `.claude/scripts/post-sync.sh` | New. Runs `chezmoi apply ~/.claude` after a successful fast-forward, behind this repo's own status→apply pre-flight |
| `.gitignore` | Ignores `.claude/worktrees/` |
| `justfile`, `private_dot_config/mise/config.toml.tmpl` | chezmoi recipes/tasks pass `--source` |
| `exact_dot_claude/hooks/executable_chezmoi-worktree-source-guard.sh` | New warn-only PreToolUse guard, registered in `modify_settings.json` |
| `CLAUDE.md`, `private_repos/CLAUDE.md` | Worktree directive |

## Why

A pulled rule that is never applied is not in effect. `~/.claude/rules/*` is
rendered from `exact_dot_claude/rules/*`, so `git pull` here changes nothing a
session reads until `chezmoi apply` runs. `post-sync.sh` is the piece that makes
the pull half worth doing.

`repos-sync-nudge.sh` gains exactly one generic escape hatch — after a
**successful** fast-forward it runs `.claude/scripts/post-sync.sh` if present and
executable — so the three copies stay byte-identical and the repo-specific
behaviour lives in `post-sync.sh`, not in a diverged copy of the nudge.

Two things had to land before worktrees could be adopted at all.

**The auto fast-forward fires only when `git status --porcelain` is empty**, and
Claude Code puts worktrees at `.claude/worktrees/`, which this repo did not
ignore. The first worktree would have made the tree read dirty and silently
switched the freshness pull off — in the repo the whole change exists to keep
fresh, with no error to notice.

**chezmoi's `sourceDir` is pinned** in `~/.config/chezmoi/chezmoi.toml`, and
nothing in the environment overrides it: `CHEZMOI_SOURCE_DIR` and
`CHEZMOI_SOURCE` were both verified ignored, only `--source` takes effect. So a
bare `chezmoi apply` from a worktree exits 0 having applied **main's** content
instead of the edits in front of you.

## How

`post-sync.sh` follows `.claude/rules/chezmoi-apply-hazards.md`: read
`chezmoi status ~/.claude`, refuse on a column-1 `M` (target edited since chezmoi
last wrote it — the same discriminator `chezmoi-drift-guard.sh` uses) or a `D` in
either column, otherwise `chezmoi apply` **without `--force`** and re-check that
the tree actually synced, since a non-force apply skips drifted files and still
exits 0. `--force` only suppresses the prompt that is protecting target-side
edits; `chezmoi update` is not used at all, because it defaults to
`git pull --autostash --rebase`.

Source-awareness resolves from `git rev-parse --show-toplevel`, correct from
both the main checkout and a worktree. The mise tasks additionally guard that
path against `$DOTFILES_DIR` — this is a global mise config, so a task runs from
wherever it was invoked and could otherwise name any repo at all.

## Verification

Run in-session, not asserted:

- **gitignore** — `git check-ignore -v .claude/worktrees/probe` matches; with a
  throwaway worktree present, `git status --porcelain` line count is unchanged
  (9 → 9), which is the property the auto-ff gate actually depends on.
- **nudge** — `--force` against the (dirty) tree reported and did not pull.
- **post-sync** — quiet no-op when in sync; applied `.claude/rules/diagrams.md`
  after a source edit; and with a deliberate target-side edit present,
  `chezmoi status` showed `MM` and the script refused with the drift named. The
  `D` classifier was control-tested against ` D` / `D ` / ` M` / `MM` / ` A`.
- **worktree × chezmoi** — from a real worktree, `just apply` landed the
  **worktree's** content; a bare `chezmoi apply` from the same directory exited 0
  and silently reapplied **main's**, wiping the worktree edit. That is the
  failure the guard warns about.
- **guard hook** — 7 synthetic payloads: fires on bare `apply`/`status` and on
  `&&`-chained commands in a worktree cwd; silent with `--source`, outside a
  worktree, on a commit message that merely mentions `chezmoi apply`, and for
  non-Bash tools. `modify_settings.json` merges to the expected three-hook
  `PreToolUse` array with `worktree.baseRef: fresh` passing through untouched.
- shellcheck clean on all three scripts; `just --evaluate` parses.

The hook cannot be verified live this session — Claude Code reads hook
registration at session start, so it takes effect next session. Same for the
pulled-rules caveat the nudge already prints.

## Notes for review

- The first commit lands **pre-existing uncommitted work** found in the tree (the
  `private_CLAUDE.md` → `CLAUDE.md` rename plus a scheduled-substrates paragraph
  rewrite). It is not mine; it is separated into its own commit and included only
  because the worktree directive needs a committed file to sit in.
- `chezmoi verify .` keeps its `.` argument in both the recipe and the mise task.
  From an arbitrary cwd that argument is already meaningless — pre-existing, left
  alone rather than widening this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSM6A4bEzkywYizc5Z5i4b
