### PR TITLE
docs(rules): uvx pins itself to a stale build, and a JSON round-trip is not a surgical edit

### DIFF
--- a/exact_dot_claude/rules/dependency-management.md
+++ b/exact_dot_claude/rules/dependency-management.md
@@ -31,6 +31,23 @@ Why `exec` over `use`:
 Reach for `mise use` only when you genuinely want to *change* the project's or
 shell's default version going forward — not for a one-off run.
 
+## `uvx` Pins Itself to a Stale Build — Request `@latest`
+
+`uvx <pkg>` does **not** consult the index on a normal run, and the cache never
+expires. Two rules hand you an old build: an installed tool wins if
+`uv tool install <pkg>` ever ran, and otherwise the first resolution sticks.
+
+The flags that look like the fix are not — `--refresh`, `--reinstall` and
+`--refresh-package` act on the wheel cache, which is not what selects the
+version. Only `@latest` and `--isolated` re-resolve (uv 0.12.6). To tell the
+two rules apart, point `UV_TOOL_DIR` at an empty dir and re-run: if the version
+jumps, an installed copy was shadowing the index.
+
+**Write `uvx <pkg>@latest` in any config that must track releases**, MCP server
+entries in `.mcp.json` above all: a bare `uvx <pkg>` pins each machine to
+whatever it cached and published fixes never arrive. Pin `<pkg>==1.2.3` instead
+when reproducibility outranks currency.
+
 ## Upgrade Patterns
 
 - Replace deprecated tools promptly — don't maintain compatibility shims

--- a/exact_dot_claude/rules/tool-use-patterns.md
+++ b/exact_dot_claude/rules/tool-use-patterns.md
@@ -97,6 +97,11 @@ Prefer `Edit` with the smallest unique `old_string` over `Write`-ing the
 whole file. A rewrite regenerates untouched lines from memory, so content
 silently drifts and the diff is unreviewable. `Write` is for new files.
 
+Programmatic rewrites count too: a `json.load` → `json.dumps` round-trip drifts
+no values and still reformats untouched siblings — rewriting one `.mcp.json`
+entry collapsed inline `args` across six unrelated servers, nearly shipping
+that churn in ten PRs. Splice the target span in the raw text instead.
+
 ## WebFetch — do not retry the same failing URL
 
 Promoted to a skill: invoke `documentation-plugin:docs-fetch-fallbacks` when a


### PR DESCRIPTION
## What

Two rule updates distilled from a PAL MCP config sweep across 13 repos.

**`dependency-management.md`** gains a `uvx` section. `uvx <pkg>` does not consult the index on a normal run and its cache never expires: an installed tool wins if `uv tool install` ever ran, and otherwise the first resolution sticks. `--refresh`, `--reinstall` and `--refresh-package` act on the wheel cache, which is not what selects the version, so none of them changes the result — only `@latest` and `--isolated` re-resolve.

**`tool-use-patterns.md`** — "Edit surgically" gains the programmatic case. The existing text covers rewrites that regenerate content from memory; a `json.load` → `json.dumps` round-trip drifts no values and still reformats untouched siblings.

## Why these earn always-loaded bytes

Both were live failures this session, not theory.

The `uvx` one is the expensive kind: a bare `uvx <pkg>` in a `.mcp.json` pins each machine to whatever it happened to cache, so a published fix never arrives and nothing surfaces the staleness. It cost a wrong mechanism in the first diagnosis (I attributed it to environment-cache matching; it was the installed-tool preference) and was only settled by pointing `UV_TOOL_DIR` at an empty directory.

The round-trip one nearly shipped: rewriting a single server entry collapsed inline `args` arrays across six unrelated servers, and would have made ten PRs unreviewable.

## Budget

`claude-context-budget` initially failed at 87 014 bytes against the 86 000 cap. Rather than raise the cap, both additions were cut roughly in half — the `uvx` measurement table came out (evidence, not something worth paying for on every turn) and the prose was tightened. Final total passes with the cap unchanged; net +22 lines.

## Deliberately not added

The `gh search issues` false-zero — multi-word queries returned nothing while `gh api search/issues` reported 95 hits for the identical string, exposed by a bare-token control. Its natural home is the control-test paragraph under "Results that lie", which is currently an **uncommitted edit in the main checkout**. Adding it here would race that work and land two adjacent appends; it should go on top of that text once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFdCCsngcpLhXmSNPacr2W
