### PR TITLE
fix(chezmoi): install git-repo-agent and vault-agent from their standalone repos

### DIFF
--- a/.chezmoidata/uv_tools.toml
+++ b/.chezmoidata/uv_tools.toml
@@ -24,6 +24,11 @@
   # Each entry: { package = "<name in `uv tool list`>", url = "git+https://…", with = ["extra-dep", …] }
   # (`with` is optional). pal-mcp-server is installed globally so MCP configs can
   # invoke the bare `pal-mcp-server` command instead of re-resolving git via uvx on every launch.
+  # git-repo-agent and vault-agent were extracted out of laurigates/claude-plugins
+  # (claude-plugins@87f2b3e6, phase 3 of #1017/#1973) and are not published to PyPI,
+  # so they install from their standalone repos.
   git_tools = [
     { package = "pal-mcp-server", url = "git+https://github.com/laurigates/pal-mcp-server" },
+    { package = "git-repo-agent", url = "git+https://github.com/laurigates/git-repo-agent" },
+    { package = "vault-agent", url = "git+https://github.com/laurigates/vault-agent" },
   ]


### PR DESCRIPTION
## What

Adds `git-repo-agent` and `vault-agent` to `git_tools` in `.chezmoidata/uv_tools.toml`, installing both from their standalone GitHub repos.

## Why

`chezmoi apply` was failing:

```
error: Failed to upgrade git-repo-agent
  Caused by: /Users/lgates/repos/laurigates/claude-plugins/git-repo-agent does not appear to be a Python project, as neither `pyproject.toml` nor `setup.py` are present in the directory
chezmoi: 01-update-packages.sh: exit status 1
```

Both tools were installed as **editable** uv tools pointing into the plugins monorepo:

```toml
requirements = [{ name = "vault-agent", editable = "/Users/lgates/repos/laurigates/claude-plugins/vault-agent" }]
```

`claude-plugins@87f2b3e6` ("remove the extracted git-repo-agent and vault-agent CLIs", phase 3 of laurigates/claude-plugins#1017 and #1973) deleted both in-tree copies, leaving directories with no `pyproject.toml`. The `uv tool upgrade --all` at the end of `run_onchange_01-update-packages.sh` then aborted on them, and `set -euo pipefail` took the whole apply down with it.

Neither tool is published to PyPI (both return 404), so they install from `git+https://` against the standalone repos that now own them — `laurigates/git-repo-agent` and `laurigates/vault-agent`, both public and actively pushed.

Registering them also closes the gap that allowed this: neither was ever in this repo's registry, so nothing here reprovisioned them and the only record of how they were installed was a machine-local uv receipt.

## Verification

- Both reinstalled from `git+https://`; receipts now read `git = "https://github.com/laurigates/…"` rather than a local `editable` path.
- `uv tool upgrade --all` exits 0 (only the pre-existing, non-fatal `vectorcode` extras warning remains).
- `chezmoi execute-template` against this branch's source renders both install blocks into the script.
- The script's `uv tool list | grep -q "^<pkg> "` guards match both packages, so a provisioned machine skips reinstall; a control on an uninstalled name returns 0.
- `pre-commit` passed (TOML check, secret scan, conventional commit).

## Follow-up (not in this PR)

The gutted monorepo directories are still on disk and no longer referenced by anything: `claude-plugins/git-repo-agent` (240 MB, mostly a stale `.venv`) and `claude-plugins/vault-agent` (1 MB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HAajCdvwYdrjWYq7MRKMdJ
