### PR TITLE
docs(rules): check the mutation landed, not just that the run went green

### DIFF
--- a/exact_dot_claude/rules/validate-adversarial-constructions.md
+++ b/exact_dot_claude/rules/validate-adversarial-constructions.md
@@ -91,6 +91,20 @@ the bypass introduced a *different* failure which the test caught by accident.
   a total that matches expectation can still be the wrong tests.
 - **A pass during a teeth-check is a finding, not a relief.** Diagnose it
   before touching the test.
+- **A faithful bypass can still land in the wrong place.** When the mutation is
+  applied by a whole-file regex, it can hit an **earlier occurrence** than the
+  one under test: the edit succeeds, the run is green, and it reads as "no
+  teeth" though the assertion was never touched. `grep -c` the pattern before
+  substituting — more than one hit means the regex cannot express the edit —
+  then `grep -n` the inserted marker to confirm where it landed. The same check
+  applies to the restore afterwards.
+
+  > Observed 2026-09 (R4C-Cesium-Viewer #960). A `perl -0pi` teeth-check
+  > inserted a CDP `Network.clearBrowserCache` before the **first** of three
+  > `await page.reload()` in the file — inside an unrelated load-time test. The
+  > cache assertion still passed, which read as a weak assertion. Re-targeted to
+  > the real site it failed at once: `expected +0 to be 42`. The gate was fine;
+  > the mutation had missed.
 
 ## A comparison harness pinned to a moving baseline stops discriminating
 


### PR DESCRIPTION
## What

Adds one bullet (plus its evidence block) to the teeth-check material in `exact_dot_claude/rules/validate-adversarial-constructions.md`.

The file already covers a bypass that is **unfaithful** to the pre-fix behaviour. This is the sibling case: the bypass text is correct, but a whole-file regex applies it to an **earlier occurrence** than the one under test. The run goes green and reads as "the assertion has no teeth" — while the assertion was never touched.

## Why

Observed this session on R4C-Cesium-Viewer #960. Teeth-checking a cache assertion, a `perl -0pi` substitution inserted a CDP `Network.clearBrowserCache` before the **first** of three `await page.reload()` in the file, landing inside an unrelated load-time test. The cache test passed, which momentarily read as a weak assertion and nearly cost the test. Re-targeted to the real site, it failed immediately with `expected +0 to be 42`.

The prescription is two cheap checks: `grep -c` the pattern before substituting (>1 hit means the regex cannot express the edit), and `grep -n` the marker afterwards to confirm where it landed — plus the same check on the restore.

## Where it landed, and one thing worth knowing

This went into the rule file rather than `CLAUDE.md` because that file is **path-scoped**, so it carries no always-loaded context cost (`path_scoped_bytes` 55459 → 56392; `unconditional_rule_bytes+claude_md` unchanged at 85979).

That mattered, because **`origin/main` already sits at 85979 / 86000 on the global context budget — 21 bytes of headroom**, before any edit from this branch. Measured by running `tests/test-claude-context-budget.sh` on a clean checkout of `origin/main`. Any future addition to `CLAUDE.md` or an unconditional rule has to displace something first.

A second lesson from the same session — *verify a review's blockers, not just its suggestions* — was intended for `CLAUDE.md` § PR Reviews and is **not** in this PR for exactly that reason. It is described in the session report; landing it needs a decision about what to trim.

## How it was verified

`tests/test-claude-context-budget.sh` → `PASS=4 FAIL=0 STATUS=PASS`. Full pre-commit run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqVnEb2MCenkKPa8mszFx3