### PR TITLE
chore(rules): raise the always-loaded context budget to 92,000

### DIFF
--- a/exact_dot_claude/CLAUDE.md
+++ b/exact_dot_claude/CLAUDE.md
@@ -17,7 +17,9 @@ When debugging issues, do not assume the root cause without evidence. Verify hyp
 
 ## PR Reviews
 
-When a PR review comment suggests a code change, verify the suggestion against official documentation or source code before applying it. Do not blindly accept review feedback as correct.
+Verify review feedback against docs or source before acting on it — its **blockers** as much as its suggestions. A wrong "do not merge" kills good work silently and nothing downstream contradicts it, so control-test each blocker against the repo before it changes a merge decision. This bites hardest with a review delegated to another model, whose wrong findings arrive as well-formed as its right ones; when one contradicts the PR's own recorded measurements, re-derive them rather than splitting the difference.
+
+> 2026-09 (R4C-Cesium-Viewer #959): a delegated review returned **DO NOT MERGE** on three blockers. Each died to one read — `tsconfig.json` sets `checkJs: true`, the "missing symbols" list was an exact match against `src/`, and the claimed "1–3% bundle gain" was a measured −13.95%.
 
 ## Tool Installation Priority
 

--- a/tests/test-claude-context-budget.sh
+++ b/tests/test-claude-context-budget.sh
@@ -83,13 +83,38 @@ GLOBAL_CLAUDE_MD="exact_dot_claude/CLAUDE.md"
 # still small enough that a second one triggers a cleanup pass. Ratchet again
 # when the next consolidation lands.
 #
-# Next cleanup candidates (largest unconditional, measured 2026-08-19, none yet
-# triaged). Note prefer-diy-over-heavy-dependency.md (651 B) and
-# pr-merge-hazards.md (2,163 B) have LEFT this list — both are now pointers:
-#   tool-use-patterns.md ~7.7 kB · communication.md ~5.8 kB
-#   offload-to-deterministic-substrate.md ~5.4 kB
-#   diagnose-at-the-failure-point.md ~4.9 kB · git-hazards.md ~4.7 kB
-TOTAL_BUDGET_BYTES=86000
+# 2026-09-08 → 92,000. The surface reached 85,979 of 86,000 (21 bytes free) on
+# origin/main at a0a3eb2, so the 5,537-byte margin the 2026-08-19 ratchet set
+# aside had been fully consumed and the gate was again a hard stop on any new
+# unconditional content rather than a cleanup trigger — the state #2324
+# describes, where the gate cannot distinguish "this addition is not worth its
+# bytes" from "nothing fits". Measured on disk in a clean worktree off
+# origin/main, before and after the addition that hit it:
+#
+#   unconditional_rule_bytes + CLAUDE.md = 85,979   (39 unconditional rules)
+#   after a 620-byte CLAUDE.md addition  = 86,599
+#   path_scoped_bytes                    = 55,459   (not counted; loads on match)
+#
+# 92,000 leaves 5,401 bytes (5.9%) free above the post-addition reading — the
+# same margin the last ratchet chose deliberately (5,537 / 6.4%) and for the
+# same reason: enough for one normal addition, small enough that a second
+# triggers a cleanup pass.
+#
+# NO cleanup is claimed here. This is a bump, not a ratchet, and per the
+# 2026-08-19 correction above it cites only bytes measured on disk. The surface
+# grew 80,463 → 85,979 (+5,516) since that ratchet with no consolidation in
+# between; that growth is untriaged and is the debt this bump defers. Ratchet
+# back toward 86,000 when the next consolidation lands.
+#
+# Next cleanup candidates (largest unconditional, re-measured 2026-09-08 in a
+# clean worktree). The previous list had drifted: tool-use-patterns.md was
+# recorded at ~7.7 kB and is 5,890 B since its split, and
+# never-fabricate-test-identifiers.md has entered the list.
+#   communication.md 6,284 B · git-hazards.md 6,081 B
+#   tool-use-patterns.md 5,890 B · offload-to-deterministic-substrate.md 5,378 B
+#   never-fabricate-test-identifiers.md 5,106 B
+#   diagnose-at-the-failure-point.md 4,901 B
+TOTAL_BUDGET_BYTES=92000
 # Largest unconditional rule at introduction: 8,758 bytes.
 PER_FILE_CAP_BYTES=10000
 


### PR DESCRIPTION
## What

`TOTAL_BUDGET_BYTES` 86,000 → 92,000 in `tests/test-claude-context-budget.sh`, plus the `CLAUDE.md` § PR Reviews addition that hit the old ceiling.

## Why

`origin/main` at `a0a3eb2` measured **85,979 of 86,000 — 21 bytes free**, with no edits applied. The 5,537-byte margin the 2026-08-19 ratchet set aside had been fully consumed.

At that margin the gate stops being a cleanup trigger and becomes a hard stop on any new unconditional content. It can no longer distinguish "this addition is not worth its bytes" from "nothing fits", and it forces whoever writes the next rule to adjudicate someone else's, mid-task, often against files another session has open. That is the failure mode [claude-plugins#2324](https://github.com/laurigates/claude-plugins/issues/2324) describes, and the same one that justified the 2026-07-28 bump.

92,000 leaves **5,401 bytes (5.9%)** above the post-addition reading — deliberately the same margin as the last ratchet (5,537 / 6.4%), for the reason recorded there: enough for one normal addition, small enough that a second triggers a cleanup pass. Not squeezed to the historical ~2 kB, which is what destroys the signal.

## Measurements

Per the 2026-08-19 correction in the script header — *a budget bump must cite MEASURED bytes on disk, never a cleanup believed to have landed* — all figures are from a clean worktree off `origin/main`:

| | bytes |
|---|---:|
| before (39 unconditional rules + CLAUDE.md) | 85,979 |
| after the 620-byte CLAUDE.md addition | 86,599 |
| new budget | 92,000 |
| headroom | 5,401 (5.9%) |
| `path_scoped_bytes` (not counted) | 55,459 |

**No cleanup is claimed.** This is a bump, not a ratchet. The surface grew 80,463 → 85,979 (+5,516) since the last ratchet with no consolidation in between; that growth is untriaged and is the debt this defers. The header says to ratchet back toward 86,000 when the next consolidation lands.

The cleanup-candidate list in the header had drifted and is re-measured here: `tool-use-patterns.md` was recorded at ~7.7 kB and is 5,890 B since its split; `never-fabricate-test-identifiers.md` (5,106 B) has entered the list.

## The addition

Extends § PR Reviews from "verify a review's suggestions" to cover its **blockers**. A wrong "do not merge" costs more than a wrong suggestion — it kills good work silently and nothing downstream contradicts it. Scoped explicitly at reviews delegated to another model, whose wrong findings arrive as well-formed as its right ones.

Evidence: on R4C-Cesium-Viewer #959 a delegated review returned **DO NOT MERGE** on three blockers, each refuted by a single file read (`tsconfig.json` sets `checkJs: true`; the "missing symbols" list was an exact match against `src/`; the claimed "1–3% gain" was a measured −13.95%). Acting on that verdict would have discarded a correct, measured PR.

## How it was verified

`tests/test-claude-context-budget.sh` → `PASS=4 FAIL=0 STATUS=PASS`. Full pre-commit run clean.

Teeth-checked, so the raised ceiling is not vacuous: padding `communication.md` by 5,510 bytes takes the total to 92,110 and the gate fails (`✗ FAIL: Always-loaded total 92110 exceeds budget 92000`), and the per-file cap fires alongside it. Restoring the file passes.

Sibling: #403 (the path-scoped half of the same session's distillation, which needed no budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqVnEb2MCenkKPa8mszFx3