### PR TITLE
docs(rules): reach for the sharpest reference-finder, not the widest net

### DIFF
--- a/exact_dot_claude/rules/tool-use-patterns.md
+++ b/exact_dot_claude/rules/tool-use-patterns.md
@@ -102,6 +102,37 @@ no values and still reformats untouched siblings — rewriting one `.mcp.json`
 entry collapsed inline `args` across six unrelated servers, nearly shipping
 that churn in ten PRs. Splice the target span in the raw text instead.
 
+### Find references with the sharpest instrument
+
+`Edit` refuses on a file unread this session, so "read it first" is already a
+harness invariant — adding it as a rule buys nothing. The **uncovered** half is
+checking what *else* depends on what you're changing, and the reflex there is
+`grep`, which cannot tell a call from a comment, a definition from a mention,
+or `foo()` from `"foo"` in a string. Measured across 282 local sessions:
+~2,400 code-symbol searches went through `grep`/`rg`, against **6** `ast-grep`
+calls and **6** `LSP` calls.
+
+Ladder, sharpest first. Falling back down it is normal; starting at the bottom
+for a code symbol is the miss.
+
+| Reach for | When |
+|---|---|
+| `LSP` — `findReferences`, `incomingCalls`, `goToDefinition` | A language server is running for that filetype. Exact: no comment/string hits, and it follows imports and re-exports that no text pattern can. |
+| `ast-grep -p '$FN($$$ARGS)'` | No LSP, or the target is a *shape* rather than a name — a call with a given arity, a decorator, an un-awaited async call. Cross-language, bash included; see `code-quality-plugin:ast-grep-search`. |
+| `rg` | Non-code: markdown rules, chezmoi templates, config keys, justfile recipes, workflow YAML. The right tool there, not a fallback — most of a dotfiles or plugins repo is prose. |
+
+Two things that make the middle rung less automatic than it looks. A **bare
+identifier pattern matches the definition too** (`ast-grep --lang bash -p 'foo'`
+returns `foo() { … }` alongside every call), so an unshaped pattern is just
+`grep` with extra syntax. And a language server has to be **on `PATH`**, not
+merely installed — `bash-language-server` sitting in `~/.local/share/nvim/mason/bin`
+is invisible to the `LSP` tool, which silently drops shell to the middle rung.
+
+Structural tools carry their own empty-result trap: an `ast-grep` pattern that
+fails to parse returns no matches and exit 0, indistinguishable from a clean
+tree. The control test in *Results that lie* applies unchanged — and control it
+against a term you know is present, in the tool you are actually using.
+
 ## WebFetch — do not retry the same failing URL
 
 Promoted to a skill: invoke `documentation-plugin:docs-fetch-fallbacks` when a


### PR DESCRIPTION
## What

Adds a *Find references with the sharpest instrument* section to `exact_dot_claude/rules/tool-use-patterns.md`: the `LSP` → `ast-grep` → `rg` ladder for finding what depends on a symbol you're about to change.

## Why not the thing that was actually suggested

A codebase-analysis tool flagged a 1.5:1 read-to-edit ratio and prescribed adding to CLAUDE.md: *"Before editing any file, read it first. Before modifying a function, grep for all callers."*

The first sentence doesn't survive checking, for two independent reasons:

**It's already a harness invariant.** The `Edit` tool refuses on a file unread this session — "You must Read the file in this conversation before editing, or the call will fail." Adding it as a rule spends always-loaded context to restate something the harness enforces.

**The ratio counts one of two read channels.** Auto mode instructs reading through Bash (`cat`, `sed -n`, `grep`), which a Read-tool-only metric cannot see. Measured across 282 local sessions:

| Channel | Calls |
|---|---|
| `Read` tool | 1,045 |
| Bash reads (`grep`/`rg` 6,385, `sed -n` 2,156, `cat` 643, …) | 9,660 |
| `Edit`/`Write` tools | 2,423 |
| `sed -i` (Bash edits) | 64 |

Counting both channels: ~10,700 reads against ~2,490 edits ≈ **4.3:1**, which lands on the "healthy 4+" threshold the report prescribes. And the claimed cost — "editing without reading leads to retries" — is **39 of 2,423 edits (1.6%)**: 26 `not-read-yet`, 7 `modified-since-read`, 6 `old-string-not-found`.

## What the data does support

The second sentence — check the blast radius — is real and *not* harness-enforced. But the finding isn't that it's skipped; it's the instrument:

| Tool | Calls |
|---|---|
| `grep`/`rg` against code-ish files | ~2,400 |
| `ast-grep` | 6 |
| `LSP` (any operation) | 6 |

`grep` cannot tell a call from a comment, a definition from a mention, or `foo()` from `"foo"` in a string. So the rule documents the ladder rather than asking for more reading — more whole-file `Read`s would fight the neighbouring *Edit surgically* guidance and burn the resource that's actually scarce.

## Two gotchas that earned their lines

Both were hit while verifying the ladder rather than assumed:

- **A bare `ast-grep` identifier pattern matches the definition too.** `ast-grep --lang bash -p 'foo'` returns `foo() { … }` alongside every call site — an unshaped pattern is `grep` with extra syntax.
- **A language server must be on `PATH`, not merely installed.** `bash-language-server` sits in `~/.local/share/nvim/mason/bin` and is invisible to the `LSP` tool, which silently drops shell to the middle rung.

`rg` is named as *correct* for prose, not a fallback — most of a dotfiles or plugins repo is markdown, and a ladder that implied otherwise would be ignored as wrong.

## Budget

+2,113 bytes. Against the 92,000 limit from #404 the always-loaded total is **88,712 — PASS** with 3,288 bytes headroom. All four gates in `tests/test-claude-context-budget.sh` pass.

## Not applied to `~/.claude/`

Deliberately not run. A scoped `chezmoi diff` of the live target shows **11 deletion lines**: the working `~/.claude/rules/tool-use-patterns.md` carries a *"The control must exercise the part of the pattern that can fail"* paragraph that exists in neither `origin/main` nor this branch — an uncommitted source edit in the main checkout that was applied but never committed. Applying from this worktree would delete it. That paragraph should be committed from the main checkout first; then a normal apply from `main` picks up both.

## Sibling PR

laurigates/claude-plugins#2627 covers the other half of the same finding. In a repo that is 65% prose the blast radius isn't function callers at all — it's the skill-citation graph (244 citations, 2 of them dead), and that belongs in CI rather than in a rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LK8CtveSowcPhWHq5RbKrP
