### PR TITLE
docs(rules): control-test the part of the pattern that can fail

### DIFF
--- a/exact_dot_claude/rules/tool-use-patterns.md
+++ b/exact_dot_claude/rules/tool-use-patterns.md
@@ -146,6 +146,18 @@ there is no earlier moment to invoke a skill: **control-test any negative that
 gates an action** — re-run the same command shape against a term you know is
 present. If the control is also empty, the tool is broken, not the tree clean.
 
+The control must exercise the part of the pattern that can fail, not just
+the command name. Observed 2026-09-02: `git grep -nE 'parseFloat\([^)]*\)\s*\|\|'`
+returned nothing and was "confirmed" by a control counting bare `parseFloat`
+— which tests neither the `[^)]*` (it cannot span the nested parens in
+`parseFloat((e.target as HTMLInputElement).value)`) nor the `|| fallback`.
+The bug was live at four sites and was reported to the user as fixed. A
+second attempt returned empty *including its control*, which is what finally
+named the tool rather than the tree; `rg` with the same pattern found all four.
+Two lessons: negated character classes cannot span nested delimiters, and
+`git grep -E` and `rg` do not agree on every regex — when a negative matters,
+confirm it with the other tool.
+
 For mechanical work (parsing, counting, audits) prefer one inline
 `python3`/`rg` pass over an agent fan-out — see
 `offload-to-deterministic-substrate.md`.


### PR DESCRIPTION
## What

Commits a 12-line paragraph in `exact_dot_claude/rules/tool-use-patterns.md` that was written in an earlier session, applied to `~/.claude/`, and never committed.

## Why now

The paragraph exists **in the live target and in no branch**. It has been loading in every session while being one `chezmoi apply` from deletion — a scoped `chezmoi diff` of the target showed it as 11 deletion lines against `main`.

This surfaced while preparing #405, which edits the same file: applying that branch to `~/.claude/` would have destroyed this paragraph. Committing it first removes the hazard and lets both land normally.

## Content

It extends the existing control-test guidance in *Results that lie* — a control that exercises only the command name doesn't test the part of the pattern that can actually fail:

> `git grep -nE 'parseFloat\([^)]*\)\s*\|\|'` returned nothing and was "confirmed" by a control counting bare `parseFloat` — which tests neither the `[^)]*` (it cannot span the nested parens in `parseFloat((e.target as HTMLInputElement).value)`) nor the `|| fallback`. The bug was live at four sites and was reported to the user as fixed.

Authored in the earlier session; committed here unchanged, not rewritten.

## Budget

+798 bytes. Always-loaded total **87,397 / 92,000 — PASS**.

## Still uncommitted in the main checkout

This PR deliberately carries **only** the paragraph. The same hazard applies to three further items that are applied to `~/.claude/` and in no branch:

| Item | Cost |
|---|---|
| `never-fabricate-test-identifiers.md` — the "inert stub means the real tool ran" third form | +1,811 |
| `zsh-colon-modifiers-after-variables.md` (new) | +2,123 |
| `zsh-special-variables-path.md` (new) | +2,819 |
| `.chezmoiignore` — adds `skill-usage.jsonl` and `feedback/` | +2 lines |

Those are not free to land: with all of them plus #405, the always-loaded total reaches **96,263 against the 92,000 budget**. The `.chezmoiignore` entries are apply-safety (both name top-level entries in an `exact_` dir, so an unlisted one is deleted on apply) and are worth landing regardless of the budget question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LK8CtveSowcPhWHq5RbKrP
