### PR TITLE
fix(mise): install atuin from the musl asset on Linux

### DIFF
--- a/private_dot_config/mise/config.toml.tmpl
+++ b/private_dot_config/mise/config.toml.tmpl
@@ -112,7 +112,14 @@ rust = { version = "latest", components = "rust-analyzer" }
 
 # Terminal & Shell
 "aqua:ajeetdsouza/zoxide" = "latest"
+{{- if eq .chezmoi.os "darwin" }}
 "aqua:atuinsh/atuin" = "latest"
+{{- else }}
+# mise's aqua backend ignores the registry's linux -> unknown-linux-musl replacement and
+# installs the glibc asset, which needs GLIBC 2.38+ (Pop!_OS 22.04 ships 2.35). Pin the
+# musl asset explicitly via the github backend. Verified against mise 2026.9.3.
+"github:atuinsh/atuin" = { version = "latest", matching_regex = "^atuin-(x86_64|aarch64)-unknown-linux-musl", exe = "atuin" }
+{{- end }}
 "aqua:junegunn/fzf" = "latest"
 "github:starship/starship" = "latest"
 


### PR DESCRIPTION
## What

On Linux, install `atuin` via the `github:` backend pinned to the musl asset instead of `aqua:atuinsh/atuin`. macOS keeps the aqua entry.

## Why

Every `atuin` invocation on this Pop!_OS 22.04 box fails:

```
atuin: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by atuin)
atuin: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by atuin)
```

The aqua registry's current entry for atuin sets `replacements: linux: unknown-linux-musl`, but mise's aqua backend installs the glibc asset anyway. Control test on mise 2026.9.3:

```
$ mise x -y "aqua:atuinsh/atuin@18.22.0" -- atuin --version
mise ✓ aqua:atuinsh/atuin@18.22.0  2.6s  atuin-x86_64-unknown-linux-gnu.tar.gz
.../atuin: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found
```

`objdump -T` on the installed binary confirms `GLIBC_2.38` and `GLIBC_2.39` symbol requirements; `ldd --version` here reports 2.35. A fresh download reproduces it, so this is mise-side asset selection rather than a stale install.

## How

```toml
"github:atuinsh/atuin" = { version = "latest", matching_regex = "^atuin-(x86_64|aarch64)-unknown-linux-musl", exe = "atuin" }
```

The regex is needed rather than a plain `matching=musl`: that substring matches `atuin-server-x86_64-unknown-linux-musl.tar.gz` first and installs the server binary (verified — it printed `atuin-server 18.22.0`). The `ubi:` backend works identically but mise deprecates it in 2027.1.0, so this uses `github:`.

Verified from a scratch `mise.toml` carrying the exact line above:

```
$ mise ls github:atuinsh/atuin
github:atuinsh/atuin  18.22.0  .../mise.toml  latest
$ mise exec -- atuin --version
atuin 18.22.0 (f98361cf8d33326fb70e7a242ff37a58845f5173)
```

Follow-up worth filing upstream: mise ignoring the aqua registry's `linux -> unknown-linux-musl` replacement affects any package relying on that replacement, not just atuin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdpDcAQRQMDPz7Thmyqnvb
