### PR TITLE
feat(zsh): source the rustup env in .zshenv, guarded

### DIFF
--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -17,6 +17,13 @@ source ~/.api_tokens
 
 export OLLAMA_KEEP_ALIVE=30m
 
+# rustup toolchain. mise's rust install is a symlink to ~/.cargo/bin, so
+# `mise activate` (in .zshrc) already covers interactive shells. This covers
+# NON-interactive zsh, where only .zshenv is sourced and nothing else supplies
+# cargo/rustc/rustup/rust-analyzer — brew carries no rust. Guarded so a machine
+# without rustup doesn't error at startup.
+[ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
+
 {{- if and (eq .chezmoi.os "linux") (.chezmoi.kernel.osrelease | contains "truenas") }}
 # TrueNAS: /tmp is mounted noexec, breaking chezmoi's run_* scripts.
 # Redirect TMPDIR to an exec-allowed dataset.


### PR DESCRIPTION
## What

Capture rustup's `. "$HOME/.cargo/env"` line into `dot_zshenv.tmpl`, above the vim modeline and behind a `-f` guard.

## Why

`chezmoi status` reported `~/.zshenv` as target-modified. The drift was a single line rustup's installer had appended *below* the `# vim:ft=sh` modeline — never in the source, so the next full `chezmoi apply` would have silently dropped it.

Whether it is worth keeping came down to who else puts `~/.cargo/bin` on PATH.

**Interactive shells: redundant.** mise's rust install is a symlink to that directory:

```
~/.local/share/mise/installs/rust/1.98.1 -> /home/lgates/.cargo/bin
```

so `mise activate` in `.zshrc` prepends it. Control test — strip it from PATH, then activate:

```
$ env -u RUSTUP_TOOLCHAIN PATH="$PATH_without_cargo_bin" zsh -c 'eval "$(mise activate zsh)"; _mise_hook; command -v cargo'
/home/lgates/.cargo/bin/cargo
```

**Non-interactive zsh: not redundant.** Only `.zshenv` is sourced there, so `mise activate` never runs. With `~/.cargo/bin` *and* the mise directories stripped from PATH:

```
$ env -i HOME="$HOME" PATH="$PATH_stripped" zsh -c 'command -v cargo; command -v rg; command -v jq'
/home/lgates/.cargo/bin/cargo          <- from this .zshenv line
/home/linuxbrew/.linuxbrew/bin/rg      <- brew fallback
/home/linuxbrew/.linuxbrew/bin/jq      <- brew fallback
```

Brew supplies the other tools but carries no rust (`ls /home/linuxbrew/.linuxbrew/bin | grep -xE 'cargo|rustc|rustup|rust-analyzer'` is empty), so this line is the only supplier of `cargo`, `rustc`, `rustup` and `rust-analyzer` to scripts, git hooks and editor build tasks. It also covers the cargo-installed `loractl`, which exists nowhere else.

## How

```sh
[ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
```

Two changes from the raw installer append: it moves above the modeline, and the `-f` guard keeps a machine without rustup from erroring at shell startup (macOS included, where the same append may not exist).

Verified: `zsh -n` on the rendered file parses, and `chezmoi diff ~/.zshenv` after this change shows only the move-and-guard, with no other target content lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdpDcAQRQMDPz7Thmyqnvb
