### PR TITLE
docs(rules): the merge you did not notice, and the pipe that hides a failure

### DIFF
--- a/exact_dot_claude/rules/git-hazards.md
+++ b/exact_dot_claude/rules/git-hazards.md
@@ -11,9 +11,35 @@ nor the squash commit. A fresh branch off `origin/main` silently lacks that
 work; the first symptom is an ImportError far downstream.
 
 - **Check** before follow-up work: `git grep <symbol> origin/main -- <path>` —
-  don't trust "the PR merged".
+  don't trust "the PR merged". The symbol must be **unique to the change**: a
+  grep for `tier == "deliver"` reported a change as landed when the hit came
+  from a pre-existing line that merely contained the same text (2026-08-19).
+  Prefer `git cherry origin/main <branch>` — `+` means not upstream, and it
+  survives squash and SHA rewriting, which plain ancestry checks do not.
 - **Fix**: replay only the orphans: `git rebase --onto origin/main <squash-point> <branch>`,
   then verify `git log --oneline origin/main..HEAD` shows only the orphaned + new commits.
+  Confirm nothing was lost by comparing **trees**, not diffs:
+  `git rev-parse HEAD^{tree} <old-tip>^{tree}` must match.
+
+### The variant with no symptom at all: the PR merges WHILE you are still on the branch
+
+The framing above assumes you come back later and branch afresh. The quieter
+case is that you **never leave**: the PR is merged mid-session — by CI, by a
+teammate, by the user in another window — and you keep committing to the same
+branch. Every `git push` succeeds, `git status` is clean, and nothing says the
+branch's PR is closed. Observed 2026-08-19: two commits, and the source that
+produced an hour-long delivery render, sat on a branch whose PR had already
+merged. It surfaced only because an unrelated `git switch main` failed on local
+changes.
+
+- **The tell is on the remote, not locally.** `gh pr list --head <branch>`
+  returns nothing (and `--state all` shows MERGED) while you still have commits
+  in `origin/main..HEAD`.
+- **Do not reuse the merged branch for the new PR.** A merged PR cannot take new
+  commits; push the rebased work to a **new** branch name so the fresh PR is not
+  tangled with the closed one.
+- Cheap habit: before the *second* push to any branch in a long session, run
+  `gh pr list --head "$(git branch --show-current)" --json number,state`.
 
 ## 2. Unpushed commits on local `main` ride into new branches
 

--- a/exact_dot_claude/rules/shell-pipefail-grep-q.md
+++ b/exact_dot_claude/rules/shell-pipefail-grep-q.md
@@ -68,6 +68,36 @@ cleaner and conveys intent.
 trades a localized cosmetic bug for a class of *silent* ones. Fix the single
 pipeline, keep the option.
 
+## The mirror image: WITHOUT pipefail, a pipe hides a real failure
+
+Same law — *the pipeline's exit status is not the command's* — in the opposite
+and more dangerous direction. Without `pipefail`, `$?` is the **last** stage's
+status, so piping a gate into anything reports that pipe's success:
+
+```bash
+just test 2>&1 | tail -40 ; echo $?   # 0 — even when the suite exited 101
+```
+
+The false-failure case above is loud (you investigate a green thing that reads
+red). This one is **silent**: a failing build, test suite, or lint reads as
+green.
+
+What makes it bite is the reason the pipe is usually there. `| tail`, `| head`,
+`| grep` get added to **limit output** — so the same edit that discards the exit
+code also discards the failure message that would have contradicted it. Observed
+2026-08-09 running a Rust gate as `just test 2>&1 | tail -40`: exit 0 over a real
+`101`, with the failing assertion scrolled past the truncation window. It was
+caught only because a separate tally of `test result:` lines showed `failed=1`.
+
+**Never pipe a command whose exit status is the thing you care about.** Redirect
+and read instead — `cmd > out.log 2>&1; echo $?` — or, if the pipe is
+unavoidable, take `${PIPESTATUS[0]}` immediately (it is clobbered by the next
+command, including `echo`).
+
+This applies to any *gate*: test suites, `cargo`/`tsc`/`ruff`, deploy scripts,
+CI steps. A summarizing pipe belongs on output you are *reading*, never on
+output you are *judging*.
+
 ## Verify
 
 Reproduce the failure and confirm the fix by forcing a large writer so SIGPIPE
@@ -76,6 +106,13 @@ actually fires (a small input won't show it):
 ```bash
 bash -c 'set -o pipefail; seq 1 100000 | grep -q "^5$"; echo "pipe exit=$?"'   # 141 (false fail)
 bash -c 'set -o pipefail; grep -q "^5$" <<<"$(seq 1 100000)"; echo "hs exit=$?"' # 0   (correct)
+```
+
+And the mirror direction — a failing command laundered into success by a pipe:
+
+```bash
+bash -c '(exit 101) | tail -1; echo "piped exit=$?"'                  # 0   (hides it)
+bash -c '(exit 101) | tail -1; echo "real exit=${PIPESTATUS[0]}"'     # 101 (correct)
 ```
 
 ## When it bites


### PR DESCRIPTION
## What

Commits two rule additions that were sitting uncommitted in the working tree, authored in an earlier session. `chezmoi status` was clean for both targets — the live rules already carried this content — so only the source lagged, and the content had not reached any other machine.

## Why

### `git-hazards.md` — hazard 1 gains the variant with no symptom

The existing text covers the case where you come back later and branch afresh off a squash-merged branch. The quieter case is that you never leave: the PR is merged mid-session, by CI or by someone in another window, and you keep committing to the same branch. Every push succeeds, `git status` stays clean, and nothing locally says the PR is closed.

The tell is on the remote — `gh pr list --head <branch>` returns nothing while `origin/main..HEAD` still has commits. Adds the do-not-reuse-the-merged-branch rule (a merged PR cannot take new commits) and a cheap habit: check before the *second* push to any branch in a long session.

The same hazard's containment check picks up two corrections:

- The grepped symbol must be **unique to the change**. A grep for `tier == "deliver"` reported a change as landed when the hit came from a pre-existing line that merely contained the same text.
- `git cherry origin/main <branch>` is preferred — it survives squash and SHA rewriting, which plain ancestry checks do not.
- Confirm nothing was lost by comparing **trees**, not diffs.

### `shell-pipefail-grep-q.md` — the mirror image

The rule already covered `pipefail` + an early-closing reader producing a **false failure**. The opposite direction is more dangerous: *without* `pipefail`, `$?` is the last stage's status, so

```bash
just test 2>&1 | tail -40 ; echo $?   # 0 — even when the suite exited 101
```

reports success over a real failure. What makes it bite is that the pipe is usually there to limit output, so the same edit that discards the exit code also truncates away the failure message that would have contradicted it. Adds the `${PIPESTATUS[0]}` fix, the rule that a summarizing pipe belongs on output you are reading and never on output you are judging, and a two-line reproduction.

## Notes

Both files are always-loaded rules; the `check Claude global context budget` pre-commit hook passes at +64 lines. `shell-pipefail-grep-q.md` carries `paths:` frontmatter scoping it to shell files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdpDcAQRQMDPz7Thmyqnvb
