### PR TITLE
docs(rules): zsh colon-modifier and tied-path-variable traps; raise context budget to 104,000

### DIFF
--- a/exact_dot_claude/rules/never-fabricate-test-identifiers.md
+++ b/exact_dot_claude/rules/never-fabricate-test-identifiers.md
@@ -73,6 +73,37 @@ attributed to the code under test rather than to your transcription.
 An empty run and a broken harness produce the same output. Only the control
 tells them apart.
 
+## Don't fabricate the *environment* either — an inert stub means the real tool ran
+
+The third form. The subject is real and the inputs are real, but the harness
+never took effect: a stubbed CLI placed on `PATH` that is **not executable** is
+skipped by PATH lookup in silence, and the real binary runs instead. Nothing
+warns. The run completes, prints plausible output, and — if the real tool has
+side effects — performs them.
+
+> Observed 2026-08 (FVH `infrastructure`): testing a workflow step that posts a
+> PR comment, I wrote a fake `gh` onto `PATH` with the Write tool, which does
+> not set the executable bit. The real `gh` ran, and what was framed as a local
+> test **POSTed and then PATCHed a comment onto a live PR**. It surfaced only
+> because the output carried a real comment ID where the stub's canned `12345`
+> was expected. Re-running with `chmod +x` behaved correctly.
+
+- **Set the bit and check it.** `chmod +x <stub>` via Bash after any Write, then
+  `ls -l`. File-creation tools generally do not set the executable bit.
+- **Assert the stub is the one in effect before trusting any case.**
+  `command -v <tool>` at the top of the harness, or better, have the stub print
+  a sentinel the real tool never would and fail the run if it is absent.
+- **Make the stub's output impossible to mistake for the real thing** — a canned
+  `12345` beats a realistic-looking id, so a discrepancy is visible at a glance
+  rather than plausible.
+- **Treat "it's only a local test" as a reason for more isolation, not less.**
+  That framing is what suppresses the caution normally applied to a command that
+  writes to shared state, and whether the writing tool runs is precisely what is
+  in question.
+
+Same law as the two forms above, one layer out: the harness was green while
+measuring production.
+
 ## When it bites
 
 - Diagnosing whether an endpoint, credential, or permission works — exactly where a

--- a/exact_dot_claude/rules/zsh-colon-modifiers-after-variables.md
+++ b/exact_dot_claude/rules/zsh-colon-modifiers-after-variables.md
@@ -1,0 +1,53 @@
+# `$VAR:word` Is a Modifier in Zsh, Not a Colon After a Variable
+
+**Scope**: every zsh command, including one-liners run through the Bash tool
+— the same scope as `zsh-special-variables-path.md`.
+
+## The trap
+
+Zsh applies history-style **modifiers** directly to a bare parameter
+expansion: `$f:h` (dirname), `$f:t` (basename), `$f:r`, `$f:e`, `$f:s/a/b/`,
+`$f:g…`. So a URL that puts a variable straight before a colon is not the URL
+you wrote:
+
+```zsh
+# Wrong — `:g` is read as the start of a global-substitution modifier
+curl "https://…/v1beta/models/$MODEL:generateContent"
+```
+
+Observed 2026-09-05 (robocar-unified, probing a replacement Gemini model):
+three requests came back `HTTP 404` in **60 ms with an empty body**, and were
+nearly reported as "the new model does not support generateContent". The
+empty body and the sub-100 ms turnaround were the tell — a real API 404 carries
+a JSON error and takes a round trip. The same request with braces returned 200.
+
+## The fix
+
+Brace the expansion. Braces end the parameter name, so the colon is literal:
+
+```zsh
+curl "https://…/v1beta/models/${MODEL}:generateContent"
+```
+
+Double quotes do **not** protect you — modifiers apply inside them. Bash has no
+such modifier syntax, which is why a snippet lifted from a bash-tested doc
+breaks only here.
+
+## When it bites
+
+- Gemini-style `model:method` REST paths, `host:port`, `user:group`,
+  `file:line`, `scp`/`rsync` `host:path` targets — any `$var:` with a letter
+  after the colon.
+- A modifier letter that zsh does not recognise errors loudly
+  (`unrecognized modifier`); the recognised ones (`g`, `h`, `t`, `r`, `e`,
+  `s`, `a`, `A`, `l`, `u`, `q`, `Q`, `x`, `c`, `P`) fail silently by
+  rewriting the string.
+
+## Related
+
+- `zsh-special-variables-path.md` — the other bare-variable trap (`path` is
+  tied to `PATH`); same family, different mechanism
+- `zsh-pattern-expansion-extended-glob.md` — zsh-vs-POSIX assumptions that
+  fail silently
+- `tool-use-patterns.md` § *Results that lie* — a fast, empty negative is a
+  broken probe, not a clean answer; control-test it against a known-good call

--- a/exact_dot_claude/rules/zsh-special-variables-path.md
+++ b/exact_dot_claude/rules/zsh-special-variables-path.md
@@ -1,0 +1,74 @@
+# `path` Is Not a Free Variable Name in Zsh
+
+**Scope**: every zsh command, including one-liners run through the Bash
+tool. Unlike `zsh-pattern-expansion-extended-glob.md` (which is scoped to
+`.zsh` / `zshrc` files), this bites in ordinary interactive commands.
+
+## The trap
+
+Zsh **ties `path` to `PATH`**: `path` is the array view, `PATH` the
+scalar view, and writing either rewrites the other. Assigning a string to
+`path` therefore destroys the search path for the rest of the shell.
+
+The usual way in is a loop variable chosen for readability:
+
+```zsh
+# Wrong — `path` is special; PATH is destroyed on the FIRST iteration
+while IFS=$'\t' read -r key title labels path; do
+  gh issue create --title "$title" --body-file "$path" ...
+done < list.tsv
+```
+
+Observed 2026-09-02 (silverbucket-helper, filing eight issues): every
+iteration printed `command not found: tail`, and **nothing was created**
+— `gh` was already unreachable by the time the body ran.
+
+Zsh's tied variables are a small set, and the rest are just as ordinary
+looking: `path`, `cdpath`, `fpath`, `manpath`, `fignore`, `mailpath`,
+`module_path`, `prompt`, `psvar`, `status`, `argv`. `path` and `fpath`
+are the two a script is most likely to reach for by accident.
+
+## The fix
+
+Pick a name that is not tied. Any of `bodyfile`, `file`, `p`, `target`
+works; the rename is the whole fix.
+
+```zsh
+# Right
+while IFS=$'\t' read -r key title labels bodyfile; do
+  gh issue create --title "$title" --body-file "$bodyfile" ...
+done < list.tsv
+```
+
+`typeset` does not rescue you — `local path` inside a function still
+shadows the tied parameter and still breaks command lookup for that
+function's body.
+
+## Check whether anything actually ran
+
+The failure is loud but **misattributed**: zsh reports the missing
+command, not the cause, so the obvious next move is to fix the "missing"
+tool. Before retrying a loop that had side effects, establish whether the
+side effects happened — a partially-completed run retried from the top
+creates duplicates.
+
+```zsh
+gh issue list --state open --limit 30 --json number,createdAt   # did any land?
+```
+
+In the case above the answer was none, because `PATH` died on iteration
+one before `gh` was reached. Had it died later, some issues would exist
+and a blind retry would have double-filed them.
+
+## When it bites
+
+- `while read` loops over a TSV/CSV whose columns include a path.
+- `for path in ...` over filenames — the most natural name for the thing.
+- Any function taking a filesystem path as a positional it names `path`.
+
+## Related
+
+- `zsh-pattern-expansion-extended-glob.md` — the other zsh-vs-POSIX
+  assumption that fails silently; same family, different mechanism.
+- `tool-use-patterns.md` § *Results that lie* — the general law that a
+  command's failure message names its symptom, not its cause.

--- a/tests/test-claude-context-budget.sh
+++ b/tests/test-claude-context-budget.sh
@@ -106,15 +106,33 @@ GLOBAL_CLAUDE_MD="exact_dot_claude/CLAUDE.md"
 # between; that growth is untriaged and is the debt this bump defers. Ratchet
 # back toward 86,000 when the next consolidation lands.
 #
-# Next cleanup candidates (largest unconditional, re-measured 2026-09-08 in a
-# clean worktree). The previous list had drifted: tool-use-patterns.md was
-# recorded at ~7.7 kB and is 5,890 B since its split, and
-# never-fabricate-test-identifiers.md has entered the list.
-#   communication.md 6,284 B · git-hazards.md 6,081 B
-#   tool-use-patterns.md 5,890 B · offload-to-deterministic-substrate.md 5,378 B
-#   never-fabricate-test-identifiers.md 5,106 B
-#   diagnose-at-the-failure-point.md 4,901 B
-TOTAL_BUDGET_BYTES=92000
+# 2026-09-12 → 104,000. Two new always-loaded zsh gotchas (`$VAR:word` as a
+# history modifier; `path` tied to `PATH`) plus a third fabrication form added
+# to never-fabricate-test-identifiers.md brought the surface to 97,909 of
+# 92,000 — over budget, with the 5,401-byte margin from the last bump already
+# spent by untriaged growth in between. Measured on disk in a clean worktree
+# off origin/main:
+#
+#   unconditional_rule_bytes + CLAUDE.md = 91,156   (39 unconditional rules)
+#   after this addition (+6,753)         = 97,909
+#   path_scoped_bytes                    = 58,140   (not counted; loads on match)
+#
+# 104,000 leaves 6,091 bytes (6.2%) free above the post-addition reading — the
+# same margin range the last two ratchets chose deliberately (5,537 / 6.4% and
+# 5,401 / 5.9%), for the same reason: enough for one normal addition, small
+# enough that a second triggers a cleanup pass.
+#
+# NO cleanup is claimed here. This is a bump, not a ratchet. Ratchet back
+# toward 92,000 when the next consolidation lands.
+#
+# Next cleanup candidates (largest unconditional, re-measured 2026-09-12 in a
+# clean worktree). tool-use-patterns.md and git-hazards.md have grown
+# considerably since the 2026-09-08 reading (5,890 B / not listed →
+# 8,801 B / 7,727 B) with no consolidation in between.
+#   tool-use-patterns.md 8,801 B · git-hazards.md 7,727 B
+#   never-fabricate-test-identifiers.md 6,917 B · communication.md 6,284 B
+#   offload-to-deterministic-substrate.md 5,378 B
+TOTAL_BUDGET_BYTES=104000
 # Largest unconditional rule at introduction: 8,758 bytes.
 PER_FILE_CAP_BYTES=10000
 


### PR DESCRIPTION
## What

- Two new always-loaded zsh rules: `zsh-colon-modifiers-after-variables.md` (`$VAR:letter` read as a history modifier) and `zsh-special-variables-path.md` (`path` tied to `PATH`).
- Extends `never-fabricate-test-identifiers.md` with a third fabrication form: an inert (non-executable) test stub on `PATH` is skipped silently, and the real tool runs instead.
- Raises `TOTAL_BUDGET_BYTES` 92,000 → 104,000 in `tests/test-claude-context-budget.sh`.

## Why

The three content additions brought the always-loaded surface to 97,909 bytes against the 92,000 budget (91,156 before). Following the same bump pattern as the 2026-09-08 ratchet (a7cd16c), the new ceiling leaves 6,091 bytes (6.2%) of headroom above the post-addition reading — enough for one normal addition, small enough that a second triggers a cleanup pass. No cleanup is claimed; `tool-use-patterns.md` (8,801 B) and `git-hazards.md` (7,727 B) are the next consolidation candidates.

## How it was verified

`tests/test-claude-context-budget.sh` → `PASS=4 FAIL=0 STATUS=PASS`. Full pre-commit run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015X84c9pLgv4U34Jitd6F6T