### PR TITLE
fix(chezmoi): ignore Claude Code skill-usage and feedback runtime files

### DIFF
--- a/exact_dot_claude/.chezmoiignore
+++ b/exact_dot_claude/.chezmoiignore
@@ -3,6 +3,7 @@
 # MUST stay ignored: ~/.claude is an exact_ dir, so an unlisted top-level
 # entry is DELETED on chezmoi apply.
 friction-reports/
+skill-usage.jsonl
 
 # Vendored third-party skill, installed and updated by `notebooklm skill
 # install` (ships with the notebooklm-py package). Not chezmoi-managed so
@@ -39,6 +40,7 @@ daemon.status.json
 gh-pr-status-cache.json
 jobs/
 .last-update-result.json
+feedback/
 
 # Runtime files created by Claude Code
 .credentials.json


### PR DESCRIPTION
## What

Adds `skill-usage.jsonl` and `feedback/` to `exact_dot_claude/.chezmoiignore`.

## Why

Both are runtime state Claude Code writes at the top level of `~/.claude`. `exact_dot_claude/` is an `exact_` dir, so an unlisted top-level entry is deleted on `chezmoi apply` — these need to stay ignored the same way the other runtime files already listed here do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015X84c9pLgv4U34Jitd6F6T